### PR TITLE
feat: nex pane list command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,13 +73,15 @@ make check
 - DB location: `~/Library/Application Support/Nex/nex.db`
 
 ### Agent monitoring & CLI
-- `SocketServer` — Unix domain socket at `/tmp/nex.sock` + optional TCP listener on `127.0.0.1:<port>`. Receives newline-delimited JSON from the `nex` CLI. Messages use `"command"` key. Commands: `start`, `stop`, `error`, `notification`, `session-start`, `pane-split`, `pane-create`, `pane-close`, `pane-name`, `pane-send`, `pane-move`, `pane-move-to-workspace`, `workspace-create`, `workspace-move`, `group-create`, `group-rename`, `group-delete`, `layout-cycle`, `layout-select`, `open`. Group icon management is deliberately UI-only (context menu); there is no `group-set-icon` wire command.
+- `SocketServer` — Unix domain socket at `/tmp/nex.sock` + optional TCP listener on `127.0.0.1:<port>`. Receives newline-delimited JSON from the `nex` CLI. Messages use `"command"` key. Commands: `start`, `stop`, `error`, `notification`, `session-start`, `pane-split`, `pane-create`, `pane-close`, `pane-name`, `pane-send`, `pane-move`, `pane-move-to-workspace`, `pane-list`, `workspace-create`, `workspace-move`, `group-create`, `group-rename`, `group-delete`, `layout-cycle`, `layout-select`, `open`. Group icon management is deliberately UI-only (context menu); there is no `group-set-icon` wire command.
+- **Request/response framing**: most commands are fire-and-forget (server reads, acts, drops the FD). `pane-list` is the first command that returns data — the server allocates a `SocketServer.ReplyHandle` for it, the reducer writes a single newline-terminated JSON line via `reply.send(...)`, then `reply.close()` cancels the client's dispatch source (EOF on the CLI side). The allowlist of reply-producing commands lives in `replyCommandAllowlist`; every other command is byte-identical on the wire.
 - **TCP transport**: enabled via `tcp-port = <port>` in `~/.config/nex/config`. Binds to `127.0.0.1` only (no auth needed — SSH tunnels handle remote security). Use cases: dev containers connect via `host.docker.internal:<port>`, remote agents connect via SSH reverse tunnel (`ssh -R <port>:localhost:<port> remote`).
 - `SocketMessage` — enum representing all wire messages (agent lifecycle + pane commands + workspace + group commands).
 - **Name-or-ID resolution** (`State.resolveGroup` / `State.resolveWorkspace`): commands like `workspace-move`, `group-rename`, `group-delete` accept either a UUID string or a case-sensitive name. UUID wins when it matches; names must be unique to resolve (ambiguous → no-op).
 - `nex` CLI — standalone Swift CLI in `Tools/nex-cli/`. Compiled as a post-build script and bundled into `Contents/Helpers/`. Subcommand structure:
   - `nex event stop|start|error|notification|session-start [--message ...] [--title ...] [--body ...]`
   - `nex pane split|create|close|name|send|move|move-to-workspace [options]`
+  - `nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]` — only command that returns data; prints a human-readable table by default, JSON array with `--json`
   - `nex workspace create [--name ...] [--path ...] [--color ...] [--group <name>]`
   - `nex workspace move <name-or-id> (--group <name> | --top-level) [--index N]`
   - `nex group create <name> [--color blue]`

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		089AA30B37857F3539BF81C3 /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D4EC6AC4CDFB5377057239 /* HelpView.swift */; };
 		0A3E7A2B0CB52F2FE791A2B5 /* GroupCustomEmojiSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD30BE0FDF3CC57813A5DB46 /* GroupCustomEmojiSheet.swift */; };
 		0CB9F718A5EF25AF73DED570 /* WorkspaceGroupRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2445F37BD230A19B4FA07CDC /* WorkspaceGroupRenderTests.swift */; };
+		0D7D8E5C230B6C98E7693D66 /* PaneListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */; };
 		0EAFF0FDB683293F95D8AB47 /* RenameWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */; };
 		0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B822ABF12B071E574E089BB4 /* GroupIconTests.swift */; };
 		14C1E964B19A8C277D5EA5E4 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE56BB11F5C7C34821411297 /* QuartzCore.framework */; };
@@ -231,6 +232,7 @@
 		F7F9C43CA9B19E7281082913 /* WorkspaceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceListView.swift; sourceTree = "<group>"; };
 		F90FF9C2E7F0BC50E51C47DE /* RepoRegistryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoRegistryView.swift; sourceTree = "<group>"; };
 		F9DA0C4B28F4E3DAF4CF1EB0 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneListTests.swift; sourceTree = "<group>"; };
 		FF88062F290789D98B545AC6 /* WorkspaceGroupCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupCRUDTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -328,6 +330,7 @@
 				5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */,
 				200EB2588E40ABB7C51E24E6 /* MarkdownHTMLRendererTests.swift */,
 				A11F5427AE75515696FB8295 /* PaneLayoutTests.swift */,
+				F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */,
 				CAA7FF54B539D06E39903C41 /* PaneShortcutMonitorTests.swift */,
 				4DA17E3004A004E6B4DDDBF6 /* PersistenceTests.swift */,
 				1C625959E287CE9896D5BA4D /* RepoRegistryTests.swift */,
@@ -651,6 +654,7 @@
 				B701F36FA68D43170D591F40 /* KeyBindingTests.swift in Sources */,
 				EA22F9720B68648A78D237E3 /* MarkdownHTMLRendererTests.swift in Sources */,
 				4D7F4ECDA338E826904B584E /* PaneLayoutTests.swift in Sources */,
+				0D7D8E5C230B6C98E7693D66 /* PaneListTests.swift in Sources */,
 				F6B537768D81B028C1B484B2 /* PaneShortcutMonitorTests.swift in Sources */,
 				B3FBC9276113E015DA08D41A /* PersistenceTests.swift in Sources */,
 				B5B3A5F0C2FA6509D37FA74A /* RepoRegistryTests.swift in Sources */,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -263,8 +263,12 @@ struct AppReducer {
         case workspaces(IdentifiedActionOf<WorkspaceFeature>)
         case settings(SettingsFeature.Action)
 
-        /// Socket messages (agent lifecycle + pane/workspace commands)
-        case socketMessage(SocketMessage)
+        /// Socket messages (agent lifecycle + pane/workspace commands).
+        /// `reply` is non-nil only for request-style commands (currently
+        /// only `pane-list`). The reducer writes a single JSON line via
+        /// `reply.send(...)` and closes the connection with
+        /// `reply.close()`.
+        case socketMessage(SocketMessage, reply: SocketServer.ReplyHandle?)
 
         // Cross-workspace surface notifications
         case surfaceTitleChanged(paneID: UUID, title: String)
@@ -527,6 +531,93 @@ struct AppReducer {
         state.groups.append(createdGroup)
         state.topLevelOrder.append(.group(newID))
         return .send(.persistState)
+    }
+
+    /// Build the `pane-list` response payload and write it to the
+    /// reply handle. Pure read of in-memory state — runs on the main
+    /// actor and returns before any effects would fire.
+    ///
+    /// Filter semantics:
+    /// - `workspace` and `scope == "current"` are mutually exclusive
+    ///   (server replies with an error if both are set).
+    /// - `scope == "current"` requires a valid `paneID`; the response
+    ///   contains the panes in the workspace that owns it.
+    /// - Unknown `workspace` → error response; unknown `scope` (other
+    ///   than `nil` / `"all"` / `"current"`) → error response.
+    func handlePaneList(
+        state: State,
+        paneID: UUID?,
+        workspaceFilter: String?,
+        scope: String?,
+        reply: SocketServer.ReplyHandle?
+    ) {
+        guard let reply else { return }
+
+        // Validate mutually exclusive filters.
+        if workspaceFilter != nil, scope == "current" {
+            reply.send(["ok": false, "error": "workspace and --current are mutually exclusive"])
+            reply.close()
+            return
+        }
+
+        // Resolve which workspaces to include.
+        let workspaces: [WorkspaceFeature.State]
+        switch scope {
+        case nil, "all":
+            if let filter = workspaceFilter {
+                guard let ws = state.resolveWorkspace(filter) else {
+                    reply.send(["ok": false, "error": "workspace not found: \(filter)"])
+                    reply.close()
+                    return
+                }
+                workspaces = [ws]
+            } else {
+                workspaces = Array(state.workspaces)
+            }
+        case "current":
+            guard let paneID,
+                  let ws = state.workspaces.first(where: { $0.panes[id: paneID] != nil }) else {
+                reply.send(["ok": false, "error": "no workspace contains the requesting pane"])
+                reply.close()
+                return
+            }
+            workspaces = [ws]
+        default:
+            reply.send(["ok": false, "error": "unknown scope: \(scope ?? "")"])
+            reply.close()
+            return
+        }
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+
+        var panes: [[String: Any]] = []
+        for workspace in workspaces {
+            for paneID in workspace.layout.allPaneIDs {
+                guard let pane = workspace.panes[id: paneID] else { continue }
+                var entry: [String: Any] = [
+                    "id": pane.id.uuidString,
+                    "type": pane.type.rawValue,
+                    "workspace_id": workspace.id.uuidString,
+                    "workspace_name": workspace.name,
+                    "working_directory": pane.workingDirectory,
+                    "status": pane.status.rawValue,
+                    "is_focused": workspace.focusedPaneID == pane.id,
+                    "is_active_workspace": state.activeWorkspaceID == workspace.id,
+                    "created_at": iso.string(from: pane.createdAt),
+                    "last_activity_at": iso.string(from: pane.lastActivityAt)
+                ]
+                if let label = pane.label { entry["label"] = label }
+                if let title = pane.title { entry["title"] = title }
+                if let branch = pane.gitBranch { entry["git_branch"] = branch }
+                if let sessionID = pane.claudeSessionID { entry["claude_session_id"] = sessionID }
+                if let filePath = pane.filePath { entry["file_path"] = filePath }
+                panes.append(entry)
+            }
+        }
+
+        reply.send(["ok": true, "panes": panes])
+        reply.close()
     }
 
     var body: some ReducerOf<Self> {
@@ -1533,7 +1624,7 @@ struct AppReducer {
 
             // MARK: - Socket Messages
 
-            case .socketMessage(let message):
+            case .socketMessage(let message, let reply):
                 switch message {
                 // MARK: Agent lifecycle
 
@@ -1832,6 +1923,18 @@ struct AppReducer {
                           let layout = PredefinedLayout(rawValue: name)
                     else { return .none }
                     return .send(.workspaces(.element(id: workspace.id, action: .selectLayout(layout))))
+
+                // MARK: Request / response
+
+                case .paneList(let paneID, let workspaceFilter, let scope):
+                    handlePaneList(
+                        state: state,
+                        paneID: paneID,
+                        workspaceFilter: workspaceFilter,
+                        scope: scope,
+                        reply: reply
+                    )
+                    return .none
                 }
 
             // MARK: - Cross-Workspace Surface Notifications

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -259,9 +259,9 @@ struct ContentView: View {
             }
             .onAppear {
                 // Start socket server and wire messages to AppReducer
-                socketServer.onMessage = { message in
+                socketServer.onMessage = { message, reply in
                     Task { @MainActor in
-                        store.send(.socketMessage(message))
+                        store.send(.socketMessage(message, reply: reply))
                     }
                 }
                 socketServer.start()

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -30,7 +30,16 @@ enum SocketMessage: Equatable {
     /// Layout commands
     case layoutCycle(paneID: UUID)
     case layoutSelect(paneID: UUID, name: String)
+    /// Request/response — first command that returns data.
+    /// `scope` may be `"current"` (require `paneID`) or `"all"` (default).
+    case paneList(paneID: UUID?, workspace: String?, scope: String?)
 }
+
+/// Commands that expect a single-line JSON reply followed by EOF. For any
+/// command outside this allowlist the server does not allocate a
+/// `ReplyHandle` and the wire behaviour is byte-identical to the
+/// pre-request/response protocol.
+private let replyCommandAllowlist: Set<String> = ["pane-list"]
 
 /// Unix domain socket server that listens for structured JSON messages
 /// from the `nex` CLI tool. Agent hooks (Claude Code, Codex)
@@ -55,9 +64,53 @@ final class SocketServer: Sendable {
     private nonisolated(unsafe) var tcpFD: Int32 = -1
     private nonisolated(unsafe) var tcpAcceptSource: DispatchSourceRead?
     private nonisolated(unsafe) var clientSources: [Int32: DispatchSourceRead] = [:]
+    /// Reply-handle id → client FD. Populated only for commands in
+    /// `replyCommandAllowlist`; other commands never allocate an entry.
+    private nonisolated(unsafe) var replyFDs: [UInt64: Int32] = [:]
+    private nonisolated(unsafe) var nextReplyID: UInt64 = 1
 
-    /// Called on the main queue when a valid message arrives.
-    nonisolated(unsafe) var onMessage: (@Sendable (SocketMessage) -> Void)?
+    /// Called on the main queue when a valid message arrives. The second
+    /// argument is non-nil only for request-style commands (see
+    /// `replyCommandAllowlist`); all existing fire-and-forget commands
+    /// receive `nil` and the server behaves identically to before.
+    nonisolated(unsafe) var onMessage: (@Sendable (SocketMessage, ReplyHandle?) -> Void)?
+
+    /// Opaque handle the reducer uses to write a single JSON response
+    /// line and close the client connection. Safe to drop on the floor —
+    /// the existing EOF path still closes orphaned FDs when the CLI
+    /// disconnects.
+    ///
+    /// Closure-based so tests can supply capture stubs without a live
+    /// `SocketServer`. Marked `@unchecked Sendable` because it only
+    /// needs to cross actors via the `socketServer.onMessage`
+    /// indirection, and both the server-backed and test-backed
+    /// implementations confine their state appropriately.
+    struct ReplyHandle: @unchecked Sendable, Equatable {
+        let id: UInt64
+        private let sendImpl: ([String: Any]) -> Void
+        private let closeImpl: () -> Void
+
+        init(id: UInt64, send: @escaping ([String: Any]) -> Void, close: @escaping () -> Void) {
+            self.id = id
+            sendImpl = send
+            closeImpl = close
+        }
+
+        func send(_ json: [String: Any]) {
+            sendImpl(json)
+        }
+
+        func close() {
+            closeImpl()
+        }
+
+        /// Identity compare on id only — the closures aren't comparable
+        /// but two handles from the same server slot always share an id.
+        /// Keeps the enclosing TCA Action Equatable-synthesized.
+        static func == (lhs: ReplyHandle, rhs: ReplyHandle) -> Bool {
+            lhs.id == rhs.id
+        }
+    }
 
     func start() {
         let alreadyRunning = lock.withLock {
@@ -225,6 +278,17 @@ final class SocketServer: Sendable {
         }
         guard clientFD >= 0 else { return }
 
+        // Suppress SIGPIPE on this FD so a `reply(id:json:)` write to a
+        // client that vanished between parse and reducer (e.g. the
+        // user ^C'd `nex pane list`) fails with EPIPE instead of
+        // terminating the whole app. macOS has no MSG_NOSIGNAL flag;
+        // SO_NOSIGPIPE on the socket is the equivalent.
+        var noSigPipe: Int32 = 1
+        setsockopt(
+            clientFD, SOL_SOCKET, SO_NOSIGPIPE,
+            &noSigPipe, socklen_t(MemoryLayout<Int32>.size)
+        )
+
         let clientSource = DispatchSource.makeReadSource(fileDescriptor: clientFD, queue: .global(qos: .utility))
         clientSource.setEventHandler { [weak self] in
             self?.readFromClient(fd: clientFD)
@@ -234,6 +298,11 @@ final class SocketServer: Sendable {
             guard let self else { return }
             lock.lock()
             clientSources.removeValue(forKey: clientFD)
+            // Drop any outstanding reply handles pointing at this FD.
+            // The handle's `send()` / `close()` become no-ops.
+            for (id, fd) in replyFDs where fd == clientFD {
+                replyFDs.removeValue(forKey: id)
+            }
             lock.unlock()
         }
         lock.withLock { clientSources[clientFD] = clientSource }
@@ -252,19 +321,81 @@ final class SocketServer: Sendable {
         }
 
         let data = Data(buffer[..<bytesRead])
-        processData(data)
+        processData(data, clientFD: fd)
     }
 
-    private func processData(_ data: Data) {
-        let messages = Self.parseMessages(data)
-        guard !messages.isEmpty else { return }
+    private func processData(_ data: Data, clientFD: Int32) {
+        let parsed = Self.parseMessagesWithCommands(data)
+        guard !parsed.isEmpty else { return }
 
         let callback = lock.withLock { onMessage }
-        DispatchQueue.main.async {
-            for message in messages {
-                callback?(message)
+        // Allocate reply handles on the read queue (before main async) so
+        // the id → FD mapping is guaranteed visible when the reducer
+        // runs. Non-reply commands carry a nil handle.
+        var dispatch: [(SocketMessage, ReplyHandle?)] = []
+        dispatch.reserveCapacity(parsed.count)
+        for (message, command) in parsed {
+            if replyCommandAllowlist.contains(command) {
+                let handle = allocateReplyHandle(for: clientFD)
+                dispatch.append((message, handle))
+            } else {
+                dispatch.append((message, nil))
             }
         }
+
+        DispatchQueue.main.async {
+            for (message, handle) in dispatch {
+                callback?(message, handle)
+            }
+        }
+    }
+
+    private func allocateReplyHandle(for clientFD: Int32) -> ReplyHandle {
+        let id: UInt64 = lock.withLock {
+            let next = nextReplyID
+            nextReplyID &+= 1
+            replyFDs[next] = clientFD
+            return next
+        }
+        return ReplyHandle(
+            id: id,
+            send: { [weak self] json in self?.reply(id: id, json: json) },
+            close: { [weak self] in self?.closeReply(id: id) }
+        )
+    }
+
+    /// Write a single JSON line to the reply-handle's FD. Silently
+    /// no-ops if the handle is stale (client disconnected, server
+    /// stopped). Called from the reducer on the main actor.
+    fileprivate func reply(id: UInt64, json: [String: Any]) {
+        let fd = lock.withLock { replyFDs[id] ?? -1 }
+        guard fd >= 0 else { return }
+        guard let data = try? JSONSerialization.data(withJSONObject: json),
+              var text = String(data: data, encoding: .utf8) else { return }
+        text += "\n"
+        text.withCString { ptr in
+            let len = strlen(ptr)
+            var remaining = len
+            var p = ptr
+            while remaining > 0 {
+                let n = send(fd, p, remaining, 0)
+                if n <= 0 { return }
+                remaining -= n
+                p = p.advanced(by: n)
+            }
+        }
+    }
+
+    /// Close the reply channel by cancelling the client's dispatch
+    /// source (which closes the FD). The cancel handler also removes
+    /// any lingering entries from `replyFDs`.
+    fileprivate func closeReply(id: UInt64) {
+        let (source, fd): (DispatchSourceRead?, Int32) = lock.withLock {
+            guard let fd = replyFDs.removeValue(forKey: id) else { return (nil, -1) }
+            return (clientSources[fd], fd)
+        }
+        guard fd >= 0 else { return }
+        source?.cancel()
     }
 
     // MARK: - Static Parsing (testable)
@@ -287,6 +418,9 @@ final class SocketServer: Sendable {
         var cascade: Bool?
         var index: Int?
         var group: String?
+        // Request/response — `pane-list` filters
+        var workspace: String?
+        var scope: String?
 
         enum CodingKeys: String, CodingKey {
             case command
@@ -296,6 +430,7 @@ final class SocketServer: Sendable {
             case direction, path, name, color, target, text
             case newName = "new_name"
             case cascade, index, group
+            case workspace, scope
         }
     }
 
@@ -347,6 +482,16 @@ final class SocketServer: Sendable {
             guard let path = wire.path, !path.isEmpty else { return nil }
             let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
             return (.openFile(path: path, paneID: paneID), wire)
+        }
+
+        if wire.command == "pane-list" {
+            // `pane_id` is optional — required only when `scope == "current"`,
+            // which the reducer validates. Invalid UUIDs fail the request
+            // downstream rather than silently dropping the message.
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+            let scope = (wire.scope?.isEmpty == true) ? nil : wire.scope
+            return (.paneList(paneID: paneID, workspace: workspace, scope: scope), wire)
         }
 
         guard let paneIDString = wire.paneID,
@@ -407,16 +552,25 @@ final class SocketServer: Sendable {
     /// Handles the session_id dual-fire logic: if a non-session-start command
     /// includes a session_id, a .sessionStarted message is also emitted.
     static func parseMessages(_ data: Data) -> [SocketMessage] {
+        parseMessagesWithCommands(data).map(\.0)
+    }
+
+    /// Like `parseMessages` but also returns the originating wire command
+    /// alongside each message, so callers (the server) can decide
+    /// whether to allocate a `ReplyHandle` for request-style commands.
+    /// The synthesized `.sessionStarted` dual-fires carry the original
+    /// command name so they never end up in the reply allowlist.
+    static func parseMessagesWithCommands(_ data: Data) -> [(SocketMessage, String)] {
         guard let text = String(data: data, encoding: .utf8) else { return [] }
 
-        var results: [SocketMessage] = []
+        var results: [(SocketMessage, String)] = []
         for line in text.split(separator: "\n") {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             guard !trimmed.isEmpty,
                   let jsonData = trimmed.data(using: .utf8) else { continue }
 
             guard let (message, wire) = parseWireMessage(jsonData) else { continue }
-            results.append(message)
+            results.append((message, wire.command))
 
             // session_id is a common field on all Claude Code hook stdin JSON.
             // Fire .sessionStarted whenever it's present (unless the command
@@ -425,7 +579,7 @@ final class SocketServer: Sendable {
                let paneIDString = wire.paneID,
                let paneID = UUID(uuidString: paneIDString),
                let sessionID = wire.sessionID, !sessionID.isEmpty {
-                results.append(.sessionStarted(paneID: paneID, sessionID: sessionID))
+                results.append((.sessionStarted(paneID: paneID, sessionID: sessionID), wire.command))
             }
         }
         return results

--- a/NexTests/AgentLifecycleTests.swift
+++ b/NexTests/AgentLifecycleTests.swift
@@ -50,7 +50,7 @@ struct AgentLifecycleTests {
         )
 
         // Send socket message for pane in WS2 (background workspace)
-        await store.send(.socketMessage(.agentStopped(paneID: paneID2)))
+        await store.send(.socketMessage(.agentStopped(paneID: paneID2), reply: nil))
 
         // The .send() effect routes to the child — wait for it
         await store.receive(
@@ -134,7 +134,7 @@ struct AgentLifecycleTests {
         )
 
         // Should produce no child effects — unknown pane
-        await store.send(.socketMessage(.agentStopped(paneID: unknownPaneID)))
+        await store.send(.socketMessage(.agentStopped(paneID: unknownPaneID), reply: nil))
     }
 
     // MARK: - Desktop Notifications
@@ -174,7 +174,7 @@ struct AgentLifecycleTests {
             activeWorkspaceID: wsID
         )
 
-        await store.send(.socketMessage(.sessionStarted(paneID: paneID, sessionID: "abc-123")))
+        await store.send(.socketMessage(.sessionStarted(paneID: paneID, sessionID: "abc-123"), reply: nil))
 
         await store.receive(
             .workspaces(.element(id: wsID, action: .sessionStarted(paneID: paneID, sessionID: "abc-123")))
@@ -199,7 +199,7 @@ struct AgentLifecycleTests {
         )
 
         // Error events always fire a notification (even if focused)
-        await store.send(.socketMessage(.agentError(paneID: paneID, message: "crash")))
+        await store.send(.socketMessage(.agentError(paneID: paneID, message: "crash"), reply: nil))
 
         await store.receive(
             .workspaces(.element(id: wsID, action: .agentError(paneID: paneID)))

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -554,7 +554,7 @@ struct AppReducerTests {
 
         await store.send(.socketMessage(.paneMoveToWorkspace(
             paneID: Self.paneID1, toWorkspace: "Target", create: false
-        ))) { state in
+        ), reply: nil)) { state in
             // Source workspace has no panes
             #expect(state.workspaces[id: Self.wsID1]?.panes.count == 0)
             #expect(state.workspaces[id: Self.wsID1]?.layout.isEmpty == true)
@@ -577,7 +577,7 @@ struct AppReducerTests {
 
         await store.send(.socketMessage(.paneMoveToWorkspace(
             paneID: Self.paneID1, toWorkspace: "NewWS", create: true
-        ))) { state in
+        ), reply: nil)) { state in
             // New workspace was created
             #expect(state.workspaces.count == 2)
             let newWS = state.workspaces.first(where: { $0.name == "NewWS" })
@@ -598,7 +598,7 @@ struct AppReducerTests {
 
         await store.send(.socketMessage(.paneMoveToWorkspace(
             paneID: Self.paneID1, toWorkspace: "NonExistent", create: false
-        )))
+        ), reply: nil))
         // No state change — pane stays in source
     }
 
@@ -609,7 +609,7 @@ struct AppReducerTests {
 
         await store.send(.socketMessage(.paneMoveToWorkspace(
             paneID: Self.paneID1, toWorkspace: "Source", create: false
-        )))
+        ), reply: nil))
         // No state change — same workspace
     }
 
@@ -621,7 +621,7 @@ struct AppReducerTests {
 
         await store.send(.socketMessage(.paneMoveToWorkspace(
             paneID: Self.paneID1, toWorkspace: "Target", create: false
-        ))) { state in
+        ), reply: nil)) { state in
             // Source workspace still exists but is empty
             #expect(state.workspaces[id: Self.wsID1] != nil)
             #expect(state.workspaces[id: Self.wsID1]?.panes.isEmpty == true)
@@ -641,7 +641,7 @@ struct AppReducerTests {
 
         await store.send(.socketMessage(.paneMoveToWorkspace(
             paneID: Self.paneID1, toWorkspace: "Empty", create: false
-        ))) { state in
+        ), reply: nil)) { state in
             // Pane becomes sole leaf in target
             #expect(state.workspaces[id: Self.wsID2]?.panes.count == 1)
             #expect(state.workspaces[id: Self.wsID2]?.layout == .leaf(Self.paneID1))

--- a/NexTests/PaneListTests.swift
+++ b/NexTests/PaneListTests.swift
@@ -1,0 +1,240 @@
+import Clocks
+import ComposableArchitecture
+import Foundation
+@testable import Nex
+import Testing
+
+/// Exercises the `pane-list` request/response path end-to-end through
+/// the reducer. Uses a capture-reply fake `SocketServer.ReplyHandle`
+/// (closure-backed) to observe the JSON payload the reducer writes,
+/// then close-notifies. No real socket or dispatch source is involved.
+@MainActor
+struct PaneListTests {
+    private static let ws1ID = UUID(uuidString: "70000000-0000-0000-0000-000000000001")!
+    private static let ws2ID = UUID(uuidString: "70000000-0000-0000-0000-000000000002")!
+    private static let pane1 = UUID(uuidString: "00000000-0000-0000-0000-00000000A001")!
+    private static let pane2 = UUID(uuidString: "00000000-0000-0000-0000-00000000A002")!
+    private static let pane3 = UUID(uuidString: "00000000-0000-0000-0000-00000000A003")!
+
+    /// Capture sink that collects every `send` and `close` call. Safe
+    /// to share across the handle + test body because calls happen on
+    /// the main actor via the TestStore.
+    private final class CaptureSink: @unchecked Sendable {
+        var payloads: [[String: Any]] = []
+        var closedCount = 0
+    }
+
+    private func makeCaptureHandle(_ sink: CaptureSink) -> SocketServer.ReplyHandle {
+        SocketServer.ReplyHandle(
+            id: 1,
+            send: { json in sink.payloads.append(json) },
+            close: { sink.closedCount += 1 }
+        )
+    }
+
+    private func makeStore(
+        workspaces: IdentifiedArrayOf<WorkspaceFeature.State>,
+        activeWorkspaceID: UUID?
+    ) -> TestStoreOf<AppReducer> {
+        var appState = AppReducer.State()
+        appState.workspaces = workspaces
+        appState.activeWorkspaceID = activeWorkspaceID
+        appState.topLevelOrder = workspaces.map { .workspace($0.id) }
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+        return store
+    }
+
+    private func makeWorkspace(
+        id: UUID,
+        name: String,
+        panes: [Pane],
+        focusedPaneID: UUID? = nil
+    ) -> WorkspaceFeature.State {
+        let paneIDs = panes.map(\.id)
+        let layout: PaneLayout = paneIDs.isEmpty ? .empty : .leaf(paneIDs[0])
+        // Naive nested split for test cases with >1 pane — good
+        // enough for the layout.allPaneIDs walk the reducer uses.
+        var finalLayout = layout
+        for id in paneIDs.dropFirst() {
+            finalLayout = finalLayout.splitting(
+                paneID: paneIDs[0], direction: .horizontal, newPaneID: id
+            ).layout
+        }
+        return WorkspaceFeature.State(
+            id: id,
+            name: name,
+            slug: name.lowercased(),
+            color: .blue,
+            panes: IdentifiedArrayOf(uniqueElements: panes),
+            layout: finalLayout,
+            focusedPaneID: focusedPaneID ?? paneIDs.first,
+            createdAt: Date(timeIntervalSince1970: 1000),
+            lastAccessedAt: Date(timeIntervalSince1970: 1000)
+        )
+    }
+
+    // MARK: - Success paths
+
+    @Test func paneListAcrossAllWorkspacesIncludesEveryPane() async {
+        let ws1 = makeWorkspace(
+            id: Self.ws1ID, name: "alpha",
+            panes: [
+                Pane(id: Self.pane1, label: "worker-1", workingDirectory: "/tmp/a", status: .running),
+                Pane(id: Self.pane2, workingDirectory: "/tmp/b")
+            ],
+            focusedPaneID: Self.pane1
+        )
+        let ws2 = makeWorkspace(
+            id: Self.ws2ID, name: "beta",
+            panes: [Pane(id: Self.pane3, workingDirectory: "/tmp/c")]
+        )
+        let store = makeStore(workspaces: [ws1, ws2], activeWorkspaceID: Self.ws1ID)
+
+        let sink = CaptureSink()
+        let handle = makeCaptureHandle(sink)
+
+        await store.send(.socketMessage(
+            .paneList(paneID: nil, workspace: nil, scope: nil),
+            reply: handle
+        ))
+
+        #expect(sink.payloads.count == 1)
+        #expect(sink.closedCount == 1)
+
+        let payload = sink.payloads[0]
+        #expect(payload["ok"] as? Bool == true)
+
+        let panes = payload["panes"] as? [[String: Any]] ?? []
+        #expect(panes.count == 3)
+        let ids = panes.compactMap { $0["id"] as? String }
+        #expect(ids.contains(Self.pane1.uuidString))
+        #expect(ids.contains(Self.pane2.uuidString))
+        #expect(ids.contains(Self.pane3.uuidString))
+
+        // Focus + active workspace flags should reflect the input state.
+        let pane1Entry = panes.first(where: { ($0["id"] as? String) == Self.pane1.uuidString })
+        #expect(pane1Entry?["is_focused"] as? Bool == true)
+        #expect(pane1Entry?["is_active_workspace"] as? Bool == true)
+
+        let pane3Entry = panes.first(where: { ($0["id"] as? String) == Self.pane3.uuidString })
+        #expect(pane3Entry?["is_active_workspace"] as? Bool == false)
+    }
+
+    @Test func paneListWorkspaceFilterByNameNarrowsResults() async {
+        let ws1 = makeWorkspace(
+            id: Self.ws1ID, name: "alpha",
+            panes: [Pane(id: Self.pane1)]
+        )
+        let ws2 = makeWorkspace(
+            id: Self.ws2ID, name: "beta",
+            panes: [Pane(id: Self.pane2)]
+        )
+        let store = makeStore(workspaces: [ws1, ws2], activeWorkspaceID: Self.ws1ID)
+
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .paneList(paneID: nil, workspace: "beta", scope: nil),
+            reply: makeCaptureHandle(sink)
+        ))
+
+        let panes = sink.payloads[0]["panes"] as? [[String: Any]] ?? []
+        #expect(panes.count == 1)
+        #expect((panes[0]["id"] as? String) == Self.pane2.uuidString)
+        #expect((panes[0]["workspace_name"] as? String) == "beta")
+    }
+
+    @Test func paneListScopeCurrentReturnsOwningWorkspace() async {
+        let ws1 = makeWorkspace(
+            id: Self.ws1ID, name: "alpha",
+            panes: [Pane(id: Self.pane1), Pane(id: Self.pane2)]
+        )
+        let ws2 = makeWorkspace(
+            id: Self.ws2ID, name: "beta",
+            panes: [Pane(id: Self.pane3)]
+        )
+        let store = makeStore(workspaces: [ws1, ws2], activeWorkspaceID: Self.ws2ID)
+
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .paneList(paneID: Self.pane1, workspace: nil, scope: "current"),
+            reply: makeCaptureHandle(sink)
+        ))
+
+        let panes = sink.payloads[0]["panes"] as? [[String: Any]] ?? []
+        // alpha has pane1 + pane2, beta is excluded.
+        #expect(panes.count == 2)
+        let ids = Set(panes.compactMap { $0["id"] as? String })
+        #expect(ids == [Self.pane1.uuidString, Self.pane2.uuidString])
+    }
+
+    // MARK: - Error paths
+
+    @Test func paneListWorkspaceNotFoundRepliesError() async {
+        let ws1 = makeWorkspace(id: Self.ws1ID, name: "alpha", panes: [Pane(id: Self.pane1)])
+        let store = makeStore(workspaces: [ws1], activeWorkspaceID: Self.ws1ID)
+
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .paneList(paneID: nil, workspace: "missing", scope: nil),
+            reply: makeCaptureHandle(sink)
+        ))
+
+        #expect(sink.payloads[0]["ok"] as? Bool == false)
+        #expect((sink.payloads[0]["error"] as? String)?.contains("missing") == true)
+        #expect(sink.closedCount == 1)
+    }
+
+    @Test func paneListMutuallyExclusiveFiltersError() async {
+        let ws1 = makeWorkspace(id: Self.ws1ID, name: "alpha", panes: [Pane(id: Self.pane1)])
+        let store = makeStore(workspaces: [ws1], activeWorkspaceID: Self.ws1ID)
+
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .paneList(paneID: Self.pane1, workspace: "alpha", scope: "current"),
+            reply: makeCaptureHandle(sink)
+        ))
+
+        #expect(sink.payloads[0]["ok"] as? Bool == false)
+        #expect(sink.closedCount == 1)
+    }
+
+    @Test func paneListScopeCurrentWithUnknownPaneError() async {
+        let ws1 = makeWorkspace(id: Self.ws1ID, name: "alpha", panes: [Pane(id: Self.pane1)])
+        let store = makeStore(workspaces: [ws1], activeWorkspaceID: Self.ws1ID)
+
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .paneList(paneID: Self.pane2, workspace: nil, scope: "current"),
+            reply: makeCaptureHandle(sink)
+        ))
+
+        #expect(sink.payloads[0]["ok"] as? Bool == false)
+        #expect(sink.closedCount == 1)
+    }
+
+    // MARK: - Nil handle is a no-op
+
+    @Test func paneListWithoutReplyIsNoOp() async {
+        let ws1 = makeWorkspace(id: Self.ws1ID, name: "alpha", panes: [Pane(id: Self.pane1)])
+        let store = makeStore(workspaces: [ws1], activeWorkspaceID: Self.ws1ID)
+
+        // A well-formed .paneList without a reply handle should parse and
+        // dispatch without crashing — the reducer silently drops it since
+        // there's no one to answer.
+        await store.send(.socketMessage(
+            .paneList(paneID: nil, workspace: nil, scope: nil),
+            reply: nil
+        ))
+    }
+}

--- a/NexTests/SocketParsingTests.swift
+++ b/NexTests/SocketParsingTests.swift
@@ -555,4 +555,58 @@ struct SocketParsingTests {
         let result = SocketServer.parseWireMessage(data)
         #expect(result == nil)
     }
+
+    // MARK: - pane-list (request/response)
+
+    @Test func parsePaneListNoFilter() {
+        let data = jsonData("""
+        {"command":"pane-list"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .paneList(paneID: nil, workspace: nil, scope: nil))
+    }
+
+    @Test func parsePaneListWithWorkspaceFilter() {
+        let data = jsonData("""
+        {"command":"pane-list","workspace":"nex"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .paneList(paneID: nil, workspace: "nex", scope: nil))
+    }
+
+    @Test func parsePaneListWithScopeCurrent() {
+        let data = jsonData("""
+        {"command":"pane-list","pane_id":"\(Self.paneIDString)","scope":"current"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .paneList(paneID: Self.paneUUID, workspace: nil, scope: "current"))
+    }
+
+    @Test func parsePaneListEmptyWorkspaceNormalisedToNil() {
+        // Defensive — an empty-string workspace field should not be
+        // treated as a name-or-ID to resolve.
+        let data = jsonData("""
+        {"command":"pane-list","workspace":""}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .paneList(paneID: nil, workspace: nil, scope: nil))
+    }
+
+    @Test func parsePaneListEmptyScopeNormalisedToNil() {
+        let data = jsonData("""
+        {"command":"pane-list","scope":""}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .paneList(paneID: nil, workspace: nil, scope: nil))
+    }
+
+    @Test func parsePaneListIgnoresUnknownPaneID() {
+        // A malformed pane_id collapses to nil — the reducer will
+        // surface the error when scope=current requires a valid id.
+        let data = jsonData("""
+        {"command":"pane-list","pane_id":"not-a-uuid"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .paneList(paneID: nil, workspace: nil, scope: nil))
+    }
 }

--- a/NexTests/WorkspaceGroupSocketTests.swift
+++ b/NexTests/WorkspaceGroupSocketTests.swift
@@ -99,7 +99,7 @@ struct WorkspaceGroupSocketTests {
         await store.send(.socketMessage(.groupCreate(
             name: "Monitors",
             color: .blue
-        ))) { state in
+        ), reply: nil)) { state in
             #expect(state.groups.count == 1)
             let group = state.groups.first
             #expect(group?.name == "Monitors")
@@ -118,7 +118,7 @@ struct WorkspaceGroupSocketTests {
         let group = WorkspaceGroup(id: Self.groupAID, name: "Old", childOrder: [])
         let store = makeStore(groups: [group], topLevelOrder: [.group(Self.groupAID)])
 
-        await store.send(.socketMessage(.groupRename(nameOrID: "Old", newName: "New")))
+        await store.send(.socketMessage(.groupRename(nameOrID: "Old", newName: "New"), reply: nil))
         await store.receive(\.renameGroup) { state in
             #expect(state.groups[id: Self.groupAID]?.name == "New")
         }
@@ -126,7 +126,7 @@ struct WorkspaceGroupSocketTests {
 
     @Test func socketGroupRenameUnknownIsNoOp() async {
         let store = makeStore()
-        await store.send(.socketMessage(.groupRename(nameOrID: "Missing", newName: "Ignored")))
+        await store.send(.socketMessage(.groupRename(nameOrID: "Missing", newName: "Ignored"), reply: nil))
     }
 
     @Test func socketGroupDeletePromoteChildren() async {
@@ -145,7 +145,7 @@ struct WorkspaceGroupSocketTests {
             activeWorkspaceID: Self.ws1ID
         )
 
-        await store.send(.socketMessage(.groupDelete(nameOrID: "G", cascade: false)))
+        await store.send(.socketMessage(.groupDelete(nameOrID: "G", cascade: false), reply: nil))
         await store.receive(\.deleteGroup) { state in
             // Children promoted; group removed. Dialog is never
             // shown — the CLI path skips the confirmation.
@@ -171,7 +171,7 @@ struct WorkspaceGroupSocketTests {
             activeWorkspaceID: Self.ws1ID
         )
 
-        await store.send(.socketMessage(.groupDelete(nameOrID: "G", cascade: true)))
+        await store.send(.socketMessage(.groupDelete(nameOrID: "G", cascade: true), reply: nil))
         await store.receive(\.deleteGroup) { state in
             #expect(state.groups[id: Self.groupAID] == nil)
             #expect(state.workspaces[id: Self.ws1ID] == nil)
@@ -190,7 +190,7 @@ struct WorkspaceGroupSocketTests {
             path: "/tmp",
             color: .blue,
             group: "Monitors"
-        )))
+        ), reply: nil))
         // The socket handler seeds state inline, then dispatches
         // `.moveWorkspaceToGroup` which is the action we receive.
         await store.receive(\.moveWorkspaceToGroup) { state in
@@ -208,7 +208,7 @@ struct WorkspaceGroupSocketTests {
             path: nil,
             color: nil,
             group: "Fresh"
-        )))
+        ), reply: nil))
         await store.receive(\.moveWorkspaceToGroup) { state in
             #expect(state.workspaces.count == 1)
             #expect(state.groups.count == 1)
@@ -227,7 +227,7 @@ struct WorkspaceGroupSocketTests {
             path: nil,
             color: nil,
             group: nil
-        )))
+        ), reply: nil))
         // With no group, the handler just dispatches the existing
         // `createWorkspace` action — no move-to-group follow-up.
         await store.receive(\.createWorkspace) { state in
@@ -251,7 +251,7 @@ struct WorkspaceGroupSocketTests {
             nameOrID: "Alpha",
             group: "Monitors",
             index: nil
-        )))
+        ), reply: nil))
         await store.receive(\.moveWorkspaceToGroup) { state in
             #expect(state.groups[id: Self.groupAID]?.childOrder == [Self.ws1ID])
         }
@@ -274,7 +274,7 @@ struct WorkspaceGroupSocketTests {
             nameOrID: "Alpha",
             group: nil,
             index: nil
-        )))
+        ), reply: nil))
         await store.receive(\.moveWorkspaceToGroup) { state in
             #expect(state.groups[id: Self.groupAID]?.childOrder.isEmpty == true)
             #expect(state.topLevelOrder.contains(.workspace(Self.ws1ID)))
@@ -292,7 +292,7 @@ struct WorkspaceGroupSocketTests {
             nameOrID: "Missing",
             group: "Monitors",
             index: nil
-        )))
+        ), reply: nil))
         // No follow-up action expected — store stays idle.
     }
 
@@ -307,7 +307,7 @@ struct WorkspaceGroupSocketTests {
             nameOrID: "Alpha",
             group: "Missing",
             index: nil
-        )))
+        ), reply: nil))
     }
 
     // MARK: - Findings fixes
@@ -328,7 +328,7 @@ struct WorkspaceGroupSocketTests {
             path: nil,
             color: nil,
             group: "Dupes"
-        )))
+        ), reply: nil))
         // No effects expected. Workspace count stays zero, group
         // count stays at two.
         #expect(store.state.workspaces.isEmpty)
@@ -345,7 +345,7 @@ struct WorkspaceGroupSocketTests {
             path: nil,
             color: nil,
             group: "   "
-        )))
+        ), reply: nil))
         await store.receive(\.createWorkspace) { state in
             #expect(state.workspaces.count == 1)
             #expect(state.groups.isEmpty)
@@ -357,7 +357,7 @@ struct WorkspaceGroupSocketTests {
         await store.send(.socketMessage(.groupCreate(
             name: "   ",
             color: nil
-        )))
+        ), reply: nil))
         // No group appended, no persist.
         #expect(store.state.groups.isEmpty)
     }
@@ -367,7 +367,7 @@ struct WorkspaceGroupSocketTests {
         await store.send(.socketMessage(.groupCreate(
             name: "  Monitors  ",
             color: nil
-        ))) { state in
+        ), reply: nil)) { state in
             #expect(state.groups.first?.name == "Monitors")
         }
     }

--- a/Resources/skills/nex-agentic/SKILL.md
+++ b/Resources/skills/nex-agentic/SKILL.md
@@ -48,6 +48,62 @@ nex pane name <label>
 
 # Send text to another pane (typed into its PTY + Enter)
 nex pane send --to <label-or-uuid> <command...>
+
+# List panes (only command that returns data — use for reconciliation)
+nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]
+```
+
+### `pane list` — reconcile with live state
+
+`pane list` is the only Nex command that returns data. Use it whenever a
+coordinator needs to know what panes actually exist right now — panes can
+be closed by the user, crash, or be moved between workspaces, and
+`pane send` silently no-ops against a missing target. Always check the
+list before assuming a worker is still alive.
+
+```bash
+# Human-readable (default)
+nex pane list
+
+# JSON for scripts — stable shape, exit code encodes success
+nex pane list --json
+
+# Only panes in the current pane's workspace (requires NEX_PANE_ID)
+nex pane list --current
+
+# Only panes in a named workspace
+nex pane list --workspace nex
+```
+
+Each JSON entry includes: `id`, `label`, `type` (`shell`/`markdown`/
+`scratchpad`), `title`, `workspace_id`, `workspace_name`,
+`working_directory`, `git_branch`, `status` (`idle`/`running`/
+`waitingForInput`), `claude_session_id`, `is_focused`,
+`is_active_workspace`, `created_at`, `last_activity_at`.
+
+Exit codes: `0` on success (including empty list), `1` on usage error,
+transport failure, or `ok: false` from the server. Empty output with
+exit `1` and `"upgrade required"` on stderr means the running Nex is
+older than v0.20 and doesn't support `pane list`.
+
+Common recipes:
+
+```bash
+# All labels of your workers
+nex pane list --json | jq -r '.[].label | select(startswith("worker-"))'
+
+# Which workers are still alive?
+alive=$(nex pane list --json | jq -r '.[].label')
+for w in worker-1 worker-2 worker-3; do
+  echo "$alive" | grep -qx "$w" && echo "$w: alive" || echo "$w: gone"
+done
+
+# Agent status across a fan-out
+nex pane list --json | jq -r '.[] | select(.label | startswith("worker-"))
+  | "\(.label)\t\(.status)"'
+
+# Find a specific pane's UUID before a `pane send`
+uuid=$(nex pane list --json | jq -r '.[] | select(.label == "build") | .id')
 ```
 
 ### Event Commands (Agent Lifecycle)
@@ -142,8 +198,25 @@ nex pane send --to worker-3 claude -p "Read .nex-tasks/worker-3.md and complete 
 #### Step 5: Poll for results
 
 ```bash
-# Wait for result files to appear
-while [ ! -f .nex-results/worker-1.md ] || [ ! -f .nex-results/worker-2.md ] || [ ! -f .nex-results/worker-3.md ]; do
+# Wait for result files to appear. Between polls, use `pane list` to
+# detect workers that died (user-closed, crashed) so the loop exits
+# instead of hanging forever.
+WORKERS=(worker-1 worker-2 worker-3)
+while true; do
+  all_done=true
+  for w in "${WORKERS[@]}"; do
+    [ -f ".nex-results/$w.md" ] || { all_done=false; break; }
+  done
+  $all_done && break
+
+  # Abort if any worker pane has vanished.
+  alive=$(nex pane list --json | jq -r '.[].label')
+  for w in "${WORKERS[@]}"; do
+    if ! echo "$alive" | grep -qx "$w" && [ ! -f ".nex-results/$w.md" ]; then
+      echo "worker $w disappeared before producing output" >&2
+      exit 1
+    fi
+  done
   sleep 5
 done
 ```
@@ -306,15 +379,21 @@ for worker in "${WORKERS[@]}"; do
   sleep 1
 done
 
-# Wait for all results
+# Wait for all results. Reconcile against live pane state so a worker
+# that died (user-closed, crashed) stops the loop instead of hanging.
 echo "Waiting for workers to complete..."
-all_done=false
-while [ "$all_done" = false ]; do
+while true; do
   all_done=true
   for worker in "${WORKERS[@]}"; do
-    if [ ! -f "$RESULT_DIR/$worker.md" ]; then
-      all_done=false
-      break
+    [ -f "$RESULT_DIR/$worker.md" ] || { all_done=false; break; }
+  done
+  $all_done && break
+
+  alive=$(nex pane list --json | jq -r '.[].label')
+  for worker in "${WORKERS[@]}"; do
+    if ! echo "$alive" | grep -qx "$worker" && [ ! -f "$RESULT_DIR/$worker.md" ]; then
+      echo "worker $worker disappeared before producing output" >&2
+      exit 1
     fi
   done
   sleep 5
@@ -328,6 +407,10 @@ echo "All workers complete. Results in $RESULT_DIR/"
 - If a worker fails, its result file won't appear. The coordinator should
   implement a timeout (e.g., 5 minutes) and report which workers didn't
   complete.
+- **Use `nex pane list` to detect dead workers** before timeout. If a
+  worker's label no longer appears in the list, the pane was closed
+  externally and its result file will never arrive — bail out instead of
+  polling forever.
 - Workers can signal errors via `nex event error --message "description"`.
 - Workers can send desktop notifications via
   `nex event notification --title "Done" --body "Task complete"`.

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -12,6 +12,7 @@
 //   nex pane send --to <name-or-uuid> <command...>
 //   nex pane move [left|right|up|down]
 //   nex pane move-to-workspace --to-workspace <name-or-uuid> [--create]
+//   nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]
 //   nex workspace create [--name "..."] [--path /dir] [--color blue] [--group <name>]
 //   nex workspace move <name-or-id> (--group <name> | --top-level) [--index N]
 //   nex group create <name> [--color blue]
@@ -80,6 +81,7 @@ func printUsage() {
       nex pane send --to <name-or-uuid> <command...>
       nex pane move [left|right|up|down]
       nex pane move-to-workspace --to-workspace <name-or-uuid> [--create]
+      nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]
       nex workspace create [--name "..."] [--path /dir] [--color blue] [--group <name>]
       nex workspace move <name-or-id> (--group <name> | --top-level) [--index N]
       nex group create <name> [--color blue]
@@ -131,13 +133,78 @@ func sendJSON(_ payload: [String: String]) {
 func sendJSONAny(_ payload: [String: Any]) {
     switch transport {
     case .unix(let path):
-        sendViaUnix(path: path, payload: payload)
+        sendViaUnix(path: path, payload: payload, expectsReply: false)
     case .tcp(let host, let port):
-        sendViaTCP(host: host, port: port, payload: payload)
+        sendViaTCP(host: host, port: port, payload: payload, expectsReply: false)
     }
 }
 
-func sendViaUnix(path: String, payload: [String: Any]) {
+/// Round-trip variant: send the payload, read until EOF, return the
+/// accumulated response bytes. Returns `nil` if the transport fails;
+/// callers must treat that differently from "empty reply" (which is
+/// data.isEmpty but non-nil, signalling an older server that silently
+/// dropped the request).
+func sendJSONAndReadReply(_ payload: [String: Any]) -> Data? {
+    switch transport {
+    case .unix(let path):
+        sendViaUnix(path: path, payload: payload, expectsReply: true)
+    case .tcp(let host, let port):
+        sendViaTCP(host: host, port: port, payload: payload, expectsReply: true)
+    }
+}
+
+/// Default read timeout (seconds) for request/response commands.
+/// Protects against mixed-version setups where an older Nex accepts
+/// the connection but silently drops `pane-list` and never closes —
+/// without this timeout the CLI would hang indefinitely. Override via
+/// `NEX_REPLY_TIMEOUT` (seconds, integer) for slow TCP tunnels.
+let replyTimeoutSeconds: Int = {
+    if let env = ProcessInfo.processInfo.environment["NEX_REPLY_TIMEOUT"],
+       let n = Int(env), n > 0 {
+        return n
+    }
+    return 5
+}()
+
+/// Apply the reply timeout to `fd` as a receive-side socket option.
+/// After this, `read()` returns -1 with `errno == EAGAIN` if nothing
+/// arrives within the window.
+func setReadTimeout(fd: Int32, seconds: Int) {
+    var tv = timeval(tv_sec: seconds, tv_usec: 0)
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+}
+
+/// Read everything the peer sends until it closes its end. Returns
+/// nil if `read()` errors before any bytes arrive; otherwise returns
+/// the accumulated buffer (possibly empty when the server accepts
+/// and immediately closes, or times out waiting on an older server
+/// that doesn't recognise the request).
+func readUntilEOF(fd: Int32) -> Data? {
+    var accumulated = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while true {
+        let n = read(fd, &buffer, buffer.count)
+        if n > 0 {
+            accumulated.append(buffer, count: n)
+            continue
+        }
+        if n == 0 {
+            return accumulated
+        }
+        // n < 0 — EINTR retry; EAGAIN/EWOULDBLOCK means the
+        // SO_RCVTIMEO elapsed, which we treat the same as "no
+        // reply" (empty Data) so the caller can surface a friendly
+        // upgrade-required message.
+        if errno == EINTR { continue }
+        if errno == EAGAIN || errno == EWOULDBLOCK {
+            return accumulated
+        }
+        return accumulated.isEmpty ? nil : accumulated
+    }
+}
+
+@discardableResult
+func sendViaUnix(path: String, payload: [String: Any], expectsReply: Bool) -> Data? {
     guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
           var jsonString = String(data: jsonData, encoding: .utf8)
     else {
@@ -147,7 +214,10 @@ func sendViaUnix(path: String, payload: [String: Any]) {
     jsonString += "\n"
 
     let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-    guard fd >= 0 else { exit(0) }
+    guard fd >= 0 else {
+        if expectsReply { return nil }
+        exit(0)
+    }
 
     var addr = sockaddr_un()
     addr.sun_family = sa_family_t(AF_UNIX)
@@ -166,6 +236,7 @@ func sendViaUnix(path: String, payload: [String: Any]) {
 
     guard connectResult == 0 else {
         close(fd)
+        if expectsReply { return nil }
         exit(0)
     }
 
@@ -174,10 +245,16 @@ func sendViaUnix(path: String, payload: [String: Any]) {
         _ = send(fd, ptr, len, 0)
     }
 
+    if expectsReply {
+        setReadTimeout(fd: fd, seconds: replyTimeoutSeconds)
+    }
+    let reply: Data? = expectsReply ? readUntilEOF(fd: fd) : nil
     close(fd)
+    return reply
 }
 
-func sendViaTCP(host: String, port: UInt16, payload: [String: Any]) {
+@discardableResult
+func sendViaTCP(host: String, port: UInt16, payload: [String: Any], expectsReply: Bool) -> Data? {
     guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
           var jsonString = String(data: jsonData, encoding: .utf8)
     else {
@@ -192,16 +269,24 @@ func sendViaTCP(host: String, port: UInt16, payload: [String: Any]) {
     hints.ai_socktype = SOCK_STREAM
     var result: UnsafeMutablePointer<addrinfo>?
     guard getaddrinfo(host, String(port), &hints, &result) == 0,
-          let addrInfo = result else { exit(0) }
+          let addrInfo = result
+    else {
+        if expectsReply { return nil }
+        exit(0)
+    }
     defer { freeaddrinfo(result) }
 
     let fd = socket(addrInfo.pointee.ai_family, addrInfo.pointee.ai_socktype, addrInfo.pointee.ai_protocol)
-    guard fd >= 0 else { exit(0) }
+    guard fd >= 0 else {
+        if expectsReply { return nil }
+        exit(0)
+    }
 
     let connectResult = connect(fd, addrInfo.pointee.ai_addr, addrInfo.pointee.ai_addrlen)
 
     guard connectResult == 0 else {
         close(fd)
+        if expectsReply { return nil }
         exit(0)
     }
 
@@ -210,7 +295,12 @@ func sendViaTCP(host: String, port: UInt16, payload: [String: Any]) {
         _ = send(fd, ptr, len, 0)
     }
 
+    if expectsReply {
+        setReadTimeout(fd: fd, seconds: replyTimeoutSeconds)
+    }
+    let reply: Data? = expectsReply ? readUntilEOF(fd: fd) : nil
     close(fd)
+    return reply
 }
 
 // MARK: - Subcommands
@@ -282,14 +372,13 @@ func handleEvent(_ args: inout ArraySlice<String>) {
 
 func handlePane(_ args: inout ArraySlice<String>) {
     guard let action = args.popFirst() else {
-        fputs("Usage: nex pane split|create|close|name|send|move [...]\n", stderr)
+        fputs("Usage: nex pane split|create|close|name|send|move|list [...]\n", stderr)
         exit(1)
     }
 
-    let paneID = requirePaneID()
-
     switch action {
     case "split":
+        let paneID = requirePaneID()
         let direction = parseFlag("--direction", from: &args)
         let path = parseFlag("--path", from: &args)
         let name = parseFlag("--name", from: &args)
@@ -306,6 +395,7 @@ func handlePane(_ args: inout ArraySlice<String>) {
         sendJSON(payload)
 
     case "create":
+        let paneID = requirePaneID()
         let path = parseFlag("--path", from: &args)
         let name = parseFlag("--name", from: &args)
         let target = parseFlag("--target", from: &args)
@@ -320,6 +410,7 @@ func handlePane(_ args: inout ArraySlice<String>) {
         sendJSON(payload)
 
     case "close":
+        let paneID = requirePaneID()
         let payload: [String: String] = [
             "command": "pane-close",
             "pane_id": paneID
@@ -327,6 +418,7 @@ func handlePane(_ args: inout ArraySlice<String>) {
         sendJSON(payload)
 
     case "name":
+        let paneID = requirePaneID()
         guard let name = args.popFirst() else {
             fputs("Usage: nex pane name <name>\n", stderr)
             exit(1)
@@ -340,6 +432,7 @@ func handlePane(_ args: inout ArraySlice<String>) {
         sendJSON(payload)
 
     case "send":
+        let paneID = requirePaneID()
         guard let target = parseFlag("--to", from: &args) else {
             fputs("Usage: nex pane send --to <name-or-uuid> <command...>\n", stderr)
             exit(1)
@@ -360,6 +453,7 @@ func handlePane(_ args: inout ArraySlice<String>) {
         sendJSON(payload)
 
     case "move":
+        let paneID = requirePaneID()
         guard let direction = args.popFirst() else {
             fputs("Usage: nex pane move [left|right|up|down]\n", stderr)
             exit(1)
@@ -377,6 +471,7 @@ func handlePane(_ args: inout ArraySlice<String>) {
         ])
 
     case "move-to-workspace":
+        let paneID = requirePaneID()
         guard let toWorkspace = parseFlag("--to-workspace", from: &args) else {
             fputs("Usage: nex pane move-to-workspace --to-workspace <name-or-uuid> [--create]\n", stderr)
             exit(1)
@@ -392,10 +487,146 @@ func handlePane(_ args: inout ArraySlice<String>) {
         }
         sendJSON(payload)
 
+    case "list":
+        handlePaneList(&args)
+
     default:
         fputs("Unknown pane action: \(action)\n", stderr)
-        fputs("Valid actions: split, create, close, name, send, move, move-to-workspace\n", stderr)
+        fputs("Valid actions: split, create, close, name, send, move, move-to-workspace, list\n", stderr)
         exit(1)
+    }
+}
+
+// MARK: - pane list
+
+func handlePaneList(_ args: inout ArraySlice<String>) {
+    let workspace = parseFlag("--workspace", from: &args)
+    let currentOnly = popSwitch("--current", from: &args)
+    let asJSON = popSwitch("--json", from: &args)
+    let noHeader = popSwitch("--no-header", from: &args)
+
+    if workspace != nil, currentOnly {
+        fputs("pane list: --workspace and --current are mutually exclusive\n", stderr)
+        exit(1)
+    }
+
+    var payload: [String: Any] = [
+        "command": "pane-list"
+    ]
+    if let workspace {
+        payload["workspace"] = workspace
+    }
+    if currentOnly {
+        // `--current` requires NEX_PANE_ID. Matches the existing
+        // silent-exit behaviour of other pane commands when not in a
+        // Nex pane.
+        payload["pane_id"] = requirePaneID()
+        payload["scope"] = "current"
+    }
+
+    guard let replyData = sendJSONAndReadReply(payload) else {
+        fputs("nex pane list: transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+
+    guard !replyData.isEmpty else {
+        fputs("nex pane list: no response from Nex (upgrade required? need v0.20+)\n", stderr)
+        exit(1)
+    }
+
+    guard let json = try? JSONSerialization.jsonObject(with: replyData) as? [String: Any] else {
+        fputs("nex pane list: invalid JSON response\n", stderr)
+        exit(1)
+    }
+
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex pane list: \(msg)\n", stderr)
+        exit(1)
+    }
+
+    let panes = (json["panes"] as? [[String: Any]]) ?? []
+
+    if asJSON {
+        // Print the panes array unwrapped — consumers get a stable
+        // shape, and exit code still encodes success.
+        if let out = try? JSONSerialization.data(withJSONObject: panes, options: [.sortedKeys]),
+           let s = String(data: out, encoding: .utf8) {
+            print(s)
+        }
+        return
+    }
+
+    printPaneTable(panes, noHeader: noHeader)
+}
+
+/// Render the `pane-list` response as a fixed-width table. Columns:
+/// ID (truncated UUID), LABEL, WORKSPACE, STATUS, CWD.
+///
+/// We truncate the UUID (first 8 + last 4) for readability; the
+/// `--json` output keeps the full UUID for scripts. Other fields
+/// print at their natural width with a 2-space gutter.
+func printPaneTable(_ panes: [[String: Any]], noHeader: Bool) {
+    struct Row {
+        let id: String
+        let label: String
+        let workspace: String
+        let status: String
+        let cwd: String
+    }
+
+    let home = ProcessInfo.processInfo.environment["HOME"] ?? ""
+
+    let rows: [Row] = panes.map { entry in
+        let fullID = (entry["id"] as? String) ?? ""
+        let shortID: String
+        if fullID.count >= 12 {
+            let prefix = fullID.prefix(8)
+            let suffix = fullID.suffix(4)
+            shortID = "\(prefix)…\(suffix)"
+        } else {
+            shortID = fullID
+        }
+        var cwd = (entry["working_directory"] as? String) ?? ""
+        if !home.isEmpty, cwd.hasPrefix(home) {
+            cwd = "~" + cwd.dropFirst(home.count)
+        }
+        return Row(
+            id: shortID,
+            label: (entry["label"] as? String) ?? "-",
+            workspace: (entry["workspace_name"] as? String) ?? "",
+            status: (entry["status"] as? String) ?? "",
+            cwd: cwd
+        )
+    }
+
+    // Compute column widths from data (and headers if shown).
+    var widths = [0, 0, 0, 0, 0]
+    let headers = ["ID", "LABEL", "WORKSPACE", "STATUS", "CWD"]
+    if !noHeader {
+        for (i, h) in headers.enumerated() {
+            widths[i] = max(widths[i], h.count)
+        }
+    }
+    for r in rows {
+        widths[0] = max(widths[0], r.id.count)
+        widths[1] = max(widths[1], r.label.count)
+        widths[2] = max(widths[2], r.workspace.count)
+        widths[3] = max(widths[3], r.status.count)
+        widths[4] = max(widths[4], r.cwd.count)
+    }
+
+    func pad(_ s: String, _ w: Int) -> String {
+        if s.count >= w { return s }
+        return s + String(repeating: " ", count: w - s.count)
+    }
+
+    if !noHeader {
+        // Last column is not padded so trailing whitespace is avoided.
+        print("\(pad(headers[0], widths[0]))  \(pad(headers[1], widths[1]))  \(pad(headers[2], widths[2]))  \(pad(headers[3], widths[3]))  \(headers[4])")
+    }
+    for r in rows {
+        print("\(pad(r.id, widths[0]))  \(pad(r.label, widths[1]))  \(pad(r.workspace, widths[2]))  \(pad(r.status, widths[3]))  \(r.cwd)")
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `nex pane list` subcommand returning panes (id, label, workspace, status, cwd, git branch) as a table or JSON
- Supports `--workspace <name-or-id>` filter and `--current` (restricts to the caller's workspace)
- Introduces a `ReplyHandle` primitive for request/response on the socket, gated by an opt-in allowlist so every existing fire-and-forget command stays byte-identical
- Unlocks future request/response commands (pane info, workspace list, richer error reporting)

## Test plan
- [x] Build succeeds, 475 tests pass (incl. 7 new `PaneListTests` + 6 new parsing cases), lint/format clean
- [x] `nex pane list` from a pane lists every pane across all workspaces
- [x] `--workspace <name>` filters to one workspace
- [x] `--current` restricts to the caller's workspace
- [x] `--json` produces a machine-readable array
- [x] Closing a pane in the UI removes it from subsequent `list` output (core use case)
- [x] Error paths: unknown workspace, `--workspace` + `--current` together, Nex not running

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)