### PR TITLE
fix: point `make test` at the `Nex` scheme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,14 @@ xcodegen generate --spec project.yml
 # Build (also serves as typecheck — there is no separate typecheck step)
 xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation build
 
-# Run all tests
-xcodebuild -scheme NexTests -destination 'platform=macOS' -skipMacroValidation test
+# Run all tests (the `Nex` scheme's testTargets wiring routes the run
+# into the `NexTests` target — there is no standalone `NexTests` scheme)
+xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation test
 
 # Run a single test class or method
-xcodebuild -scheme NexTests -destination 'platform=macOS' -skipMacroValidation \
+xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation \
   -only-testing:NexTests/PaneLayoutTests test
-xcodebuild -scheme NexTests -destination 'platform=macOS' -skipMacroValidation \
+xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation \
   -only-testing:NexTests/PaneLayoutTests/testSplitHorizontal test
 
 # Lint & format

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build:
 	xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation build
 
 test:
-	xcodebuild -scheme NexTests -destination 'platform=macOS' -skipMacroValidation test
+	xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation test
 
 check: format-check lint build test
 


### PR DESCRIPTION
## Summary

- `make test` (and therefore `make check`) was failing because it
  referenced `-scheme NexTests`, but xcodegen only emits a shared
  scheme for the `Nex` target. There is no standalone `NexTests`
  scheme.
- Switch the Makefile's `test` target and CLAUDE.md's test commands
  to `-scheme Nex`. The `Nex` scheme's `testTargets: [NexTests]`
  wiring is how the test target actually runs.

Before:

```
$ make test
xcodebuild: error: The project named "Nex" does not contain a scheme named "NexTests".
```

After: 475 tests in 29 suites pass.

## Test plan

- [x] `make test` → BUILD SUCCEEDED, 475 tests passing
- [x] `make check` → format-check → lint → build → test, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)