### PR TITLE
feat: global hotkey to focus/hide Nex from anywhere

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0053A91856EF3EB22FEB03B7 /* PaneGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005B56542A2F5FD5D3BC588C /* PaneGridView.swift */; };
 		066D1D15DCA5E39EC770E77C /* StatusBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09102B6ADEAB463454E7F15E /* StatusBarController.swift */; };
 		089AA30B37857F3539BF81C3 /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D4EC6AC4CDFB5377057239 /* HelpView.swift */; };
+		0A339E290783C7347081E4FC /* GlobalHotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8340B6640D25908803B93C2A /* GlobalHotkeyService.swift */; };
 		0A3E7A2B0CB52F2FE791A2B5 /* GroupCustomEmojiSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD30BE0FDF3CC57813A5DB46 /* GroupCustomEmojiSheet.swift */; };
 		0CB9F718A5EF25AF73DED570 /* WorkspaceGroupRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2445F37BD230A19B4FA07CDC /* WorkspaceGroupRenderTests.swift */; };
 		0EAFF0FDB683293F95D8AB47 /* RenameWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */; };
@@ -45,6 +46,7 @@
 		6C50041FBB0F31598067D4FA /* LineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */; };
 		6CF210BA0C7BFE62B90844F7 /* KeybindingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439174A029FAFE2C252A1B8B /* KeybindingsSettingsView.swift */; };
 		741144CE5AC7DEC20A18A89D /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70E36C00A55A87562F4AC1D /* CommandPaletteView.swift */; };
+		759B67A4E8D35868EC6E2295 /* AppActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D46DA7C3A37F67FBBBEAC7 /* AppActivation.swift */; };
 		75BECE7D63EF981C344D4902 /* SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */; };
 		77C780C65EFA8114C681638B /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 8B14B7BF7BD4FCD61EBB97A9 /* ComposableArchitecture */; };
 		77CF808E3AF2C06BD12D11C0 /* SplitDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DED98594372C8E34542A5C2 /* SplitDividerView.swift */; };
@@ -176,6 +178,7 @@
 		7ED3289901F70616FC36F80B /* MarkdownEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownEditorView.swift; sourceTree = "<group>"; };
 		7F561A2375008B0EC39BF86D /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8322D3C28268495A01EA0597 /* SettingsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeature.swift; sourceTree = "<group>"; };
+		8340B6640D25908803B93C2A /* GlobalHotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalHotkeyService.swift; sourceTree = "<group>"; };
 		84D4EC6AC4CDFB5377057239 /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
 		852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineNumberRulerView.swift; sourceTree = "<group>"; };
 		89FC5F004277851CEA0CFF3F /* CommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteTests.swift; sourceTree = "<group>"; };
@@ -209,6 +212,7 @@
 		D0CED7EFE254E4491327CAE0 /* EditorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorService.swift; sourceTree = "<group>"; };
 		D6B83DC43AEA38B4929307FA /* AppReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReducerTests.swift; sourceTree = "<group>"; };
 		D70E36C00A55A87562F4AC1D /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
+		D7D46DA7C3A37F67FBBBEAC7 /* AppActivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivation.swift; sourceTree = "<group>"; };
 		D9335AE3C92A37DD50A5715A /* AppReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReducer.swift; sourceTree = "<group>"; };
 		D9EC869803E36C99B3653FF5 /* CLIInstallService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIInstallService.swift; sourceTree = "<group>"; };
 		DAE917FD003D3FFD196DBF77 /* PaneSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSearchOverlay.swift; sourceTree = "<group>"; };
@@ -419,11 +423,13 @@
 		6B9A3E1F3B72D1A26F249A1C /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				D7D46DA7C3A37F67FBBBEAC7 /* AppActivation.swift */,
 				D9EC869803E36C99B3653FF5 /* CLIInstallService.swift */,
 				CF4114D723403D4FF8F4AC1B /* ConfigParser.swift */,
 				3879BA745F8737CA5872F80D /* DatabaseService.swift */,
 				D0CED7EFE254E4491327CAE0 /* EditorService.swift */,
 				0153509BA13BB205C40DE2D5 /* GitService.swift */,
+				8340B6640D25908803B93C2A /* GlobalHotkeyService.swift */,
 				93D45D65A66C475B0CEEC53C /* KeybindingService.swift */,
 				CFE42A23C94DA8DA930C61E3 /* NotificationService.swift */,
 				CBEA23E4C37CB5B7A6F4963C /* PersistenceService.swift */,
@@ -671,6 +677,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				759B67A4E8D35868EC6E2295 /* AppActivation.swift in Sources */,
 				EC6971D2E311C8903C373778 /* AppReducer.swift in Sources */,
 				EFDCA64CD227A833D2801893 /* CLIInstallService.swift in Sources */,
 				B23A46CD372F9E16C2C1D716 /* CheckForUpdatesView.swift in Sources */,
@@ -687,6 +694,7 @@
 				7C78EA65C2D22749546715A0 /* GhosttySurface.swift in Sources */,
 				DBBD0CD88C3B7EF588D5CB04 /* GitService.swift in Sources */,
 				E19F4E0C87CB85D959F0C8F2 /* GitStatus.swift in Sources */,
+				0A339E290783C7347081E4FC /* GlobalHotkeyService.swift in Sources */,
 				0A3E7A2B0CB52F2FE791A2B5 /* GroupCustomEmojiSheet.swift in Sources */,
 				B2498EB9F42EA84196516DAE /* GroupHeaderRow.swift in Sources */,
 				E02D1D3DE36CC8F66B5072AB /* GroupIcon.swift in Sources */,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -29,6 +29,23 @@ struct AppReducer {
         var focusFollowsMouseDelay: Int = 100
         var tcpPort: Int = 0
         var tcpPortError: String?
+        var globalHotkey: KeyTrigger?
+        var globalHotkeyHideOnRepress: Bool = true
+        var globalHotkeyRegistrationError: String?
+
+        /// Collision between the current global hotkey and an in-app
+        /// keybinding. Computed so it always reflects the latest state —
+        /// `keybindings` and `globalHotkey` can land in state in either
+        /// order during `appLaunched`, and either one may change later.
+        var globalHotkeyConflictWithInApp: KeybindingConflict? {
+            guard let trigger = globalHotkey else { return nil }
+            return KeybindingConflict.check(
+                trigger: trigger,
+                in: keybindings,
+                globalHotkey: nil,
+                ignoreGlobalHotkey: true
+            )
+        }
 
         // Command Palette
         var isCommandPaletteVisible: Bool = false
@@ -330,12 +347,26 @@ struct AppReducer {
         case commandPaletteSelectPrevious
         case commandPaletteConfirm
 
-        // General config
-        case configLoaded(focusFollowsMouse: Bool, focusFollowsMouseDelay: Int, theme: String?, tcpPort: Int)
+        /// General config
+        case configLoaded(
+            focusFollowsMouse: Bool,
+            focusFollowsMouseDelay: Int,
+            theme: String?,
+            tcpPort: Int,
+            globalHotkey: KeyTrigger?,
+            globalHotkeyHideOnRepress: Bool
+        )
         case setFocusFollowsMouse(Bool)
         case setFocusFollowsMouseDelay(Int)
         case setTCPPort(Int)
         case tcpPortStartFailed(Int)
+
+        // Global Hotkey
+        case setGlobalHotkey(KeyTrigger?)
+        case setGlobalHotkeyHideOnRepress(Bool)
+        case globalHotkeyPressed
+        case globalHotkeyRegistrationFailed(reason: String)
+        case globalHotkeyRegistrationRejected(revertTo: KeyTrigger?, reason: String)
     }
 
     @Dependency(\.surfaceManager) var surfaceManager
@@ -345,6 +376,7 @@ struct AppReducer {
     @Dependency(\.notificationService) var notificationService
     @Dependency(\.statusBarController) var statusBarController
     @Dependency(\.ghosttyConfig) var ghosttyConfig
+    @Dependency(\.globalHotkeyService) var globalHotkeyService
     @Dependency(\.uuid) var uuid
     @Dependency(\.continuousClock) var clock
 
@@ -557,7 +589,9 @@ struct AppReducer {
                             focusFollowsMouse: config.focusFollowsMouse,
                             focusFollowsMouseDelay: config.focusFollowsMouseDelay,
                             theme: config.theme,
-                            tcpPort: config.tcpPort
+                            tcpPort: config.tcpPort,
+                            globalHotkey: config.globalHotkey,
+                            globalHotkeyHideOnRepress: config.globalHotkeyHideOnRepress
                         ))
                     }
                 )
@@ -1433,14 +1467,34 @@ struct AppReducer {
 
             // MARK: - General Config
 
-            case .configLoaded(let focusFollowsMouse, let focusFollowsMouseDelay, let themeID, let tcpPort):
+            case .configLoaded(
+                let focusFollowsMouse,
+                let focusFollowsMouseDelay,
+                let themeID,
+                let tcpPort,
+                let globalHotkey,
+                let globalHotkeyHideOnRepress
+            ):
                 state.focusFollowsMouse = focusFollowsMouse
                 state.focusFollowsMouseDelay = focusFollowsMouseDelay
                 state.tcpPort = tcpPort
-                if let themeID, let theme = NexTheme.named(themeID) {
-                    return .send(.settings(.selectTheme(theme)))
+                state.globalHotkey = globalHotkey
+                state.globalHotkeyHideOnRepress = globalHotkeyHideOnRepress
+                state.globalHotkeyRegistrationError = nil
+                let themeEffect: Effect<Action> = {
+                    if let themeID, let theme = NexTheme.named(themeID) {
+                        return .send(.settings(.selectTheme(theme)))
+                    }
+                    return .none
+                }()
+                let hotkeyEffect: Effect<Action> = .run { [trigger = globalHotkey, service = globalHotkeyService] send in
+                    do {
+                        try await service.register(trigger)
+                    } catch {
+                        await send(.globalHotkeyRegistrationFailed(reason: "\(error)"))
+                    }
                 }
-                return .none
+                return .merge(themeEffect, hotkeyEffect)
 
             case .setFocusFollowsMouse(let enabled):
                 state.focusFollowsMouse = enabled
@@ -1485,6 +1539,64 @@ struct AppReducer {
 
             case .tcpPortStartFailed(let port):
                 state.tcpPortError = "Port \(port) is unavailable"
+                return .none
+
+            // MARK: - Global Hotkey
+
+            case .setGlobalHotkey(let trigger):
+                // Optimistically update state; if Carbon rejects the new
+                // trigger, `globalHotkeyRegistrationRejected` will roll it
+                // back to `previousTrigger` and the config file is left
+                // untouched. The service keeps the previous registration
+                // alive on failure, so the user's working hotkey is never
+                // silently dropped.
+                let previousTrigger = state.globalHotkey
+                state.globalHotkey = trigger
+                state.globalHotkeyRegistrationError = nil
+                return .run { [trigger, previousTrigger, service = globalHotkeyService] send in
+                    do {
+                        try await service.register(trigger)
+                    } catch {
+                        await send(.globalHotkeyRegistrationRejected(
+                            revertTo: previousTrigger,
+                            reason: "\(error)"
+                        ))
+                        return
+                    }
+                    ConfigParser.setGeneralSetting(
+                        "global-hotkey",
+                        value: trigger?.configString ?? "none",
+                        inFile: KeybindingService.configPath
+                    )
+                }
+
+            case .setGlobalHotkeyHideOnRepress(let hide):
+                state.globalHotkeyHideOnRepress = hide
+                return .run { _ in
+                    ConfigParser.setGeneralSetting(
+                        "global-hotkey-hide-on-repress",
+                        value: hide ? "true" : "false",
+                        inFile: KeybindingService.configPath
+                    )
+                }
+
+            case .globalHotkeyPressed:
+                return .run { [hide = state.globalHotkeyHideOnRepress] _ in
+                    await MainActor.run {
+                        toggleAppFrontmost(hideOnRepress: hide)
+                    }
+                }
+
+            case .globalHotkeyRegistrationFailed(let reason):
+                // Used only by the config-load path — we want state to keep
+                // reflecting what's in the config file so the user can see
+                // and edit the failing value from Settings.
+                state.globalHotkeyRegistrationError = reason
+                return .none
+
+            case .globalHotkeyRegistrationRejected(let revertTo, let reason):
+                state.globalHotkey = revertTo
+                state.globalHotkeyRegistrationError = reason
                 return .none
 
             // MARK: - File Opening

--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -176,6 +176,14 @@ final class PaneShortcutMonitor {
         guard let activeID = store.activeWorkspaceID else { return false }
 
         let trigger = KeyTrigger(event: event)
+
+        // Belt-and-braces: if the user configured a global hotkey that also
+        // matches an in-app binding, skip the in-app dispatch. Carbon
+        // normally consumes matching events at the WindowServer level before
+        // Cocoa sees them, but this guard keeps behavior consistent even if
+        // the dispatcher order ever changes.
+        if store.globalHotkey == trigger { return false }
+
         guard let action = store.keybindings.action(for: trigger) else { return false }
 
         // Menu bar actions are handled by SwiftUI Commands — don't consume here.

--- a/Nex/Features/Settings/KeybindingsSettingsView.swift
+++ b/Nex/Features/Settings/KeybindingsSettingsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct KeybindingsSettingsView: View {
     let store: StoreOf<AppReducer>
     @State private var recordingAction: NexAction?
+    @State private var recordingGlobal: Bool = false
 
     private static let categoryOrder = [
         "Pane Management", "Navigation", "Workspaces", "View", "Files", "Search"
@@ -15,6 +16,33 @@ struct KeybindingsSettingsView: View {
         WithPerceptionTracking {
             VStack(spacing: 0) {
                 List {
+                    Section("Global") {
+                        globalHotkeyRow
+                        Toggle(
+                            "Press again to hide",
+                            isOn: Binding(
+                                get: { store.globalHotkeyHideOnRepress },
+                                set: { store.send(.setGlobalHotkeyHideOnRepress($0)) }
+                            )
+                        )
+                        .disabled(store.globalHotkey == nil)
+
+                        if let reason = store.globalHotkeyRegistrationError {
+                            Label(reason, systemImage: "exclamationmark.triangle.fill")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
+                        }
+
+                        if let conflict = store.globalHotkeyConflictWithInApp {
+                            Label(
+                                "Shadows in-app shortcut: \(conflict.message). The in-app shortcut will not fire while Nex is frontmost.",
+                                systemImage: "exclamationmark.triangle.fill"
+                            )
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                        }
+                    }
+
                     ForEach(Self.categoryOrder, id: \.self) { category in
                         let actions = NexAction.bindableActions.filter { $0.category == category }
                         if !actions.isEmpty {
@@ -42,14 +70,75 @@ struct KeybindingsSettingsView: View {
                 .padding(12)
             }
             .sheet(item: recordingActionBinding) { action in
-                KeyRecorderSheet(action: action) { trigger in
+                KeyRecorderSheet(
+                    action: action,
+                    currentMap: store.keybindings,
+                    globalHotkey: store.globalHotkey
+                ) { trigger in
                     if let trigger {
                         store.send(.setKeybinding(trigger, action))
                     }
                     recordingAction = nil
                 }
             }
+            .sheet(isPresented: $recordingGlobal) {
+                GlobalKeyRecorderSheet(
+                    currentMap: store.keybindings,
+                    currentGlobalHotkey: store.globalHotkey
+                ) { trigger in
+                    if let trigger {
+                        store.send(.setGlobalHotkey(trigger))
+                    }
+                    recordingGlobal = false
+                }
+            }
         }
+    }
+
+    private var globalHotkeyRow: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Global Hotkey")
+                Text("Works from any app. No Accessibility permission required.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let trigger = store.globalHotkey {
+                HStack(spacing: 2) {
+                    Text(trigger.displayString)
+                        .font(.system(.body, design: .rounded))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(.quaternary)
+                        )
+
+                    Button {
+                        store.send(.setGlobalHotkey(nil))
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .frame(minWidth: 120, alignment: .trailing)
+            } else {
+                Text("—")
+                    .foregroundStyle(.tertiary)
+                    .frame(minWidth: 120, alignment: .trailing)
+            }
+
+            Button("Record") {
+                recordingGlobal = true
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .padding(.vertical, 2)
     }
 
     @ViewBuilder
@@ -121,12 +210,78 @@ extension NexAction: Identifiable {
     var id: String { rawValue }
 }
 
+// MARK: - Global Hotkey Recorder Sheet
+
+/// Modal sheet for capturing the system-wide global hotkey.
+/// Rejects combos that are already bound to an in-app action; the user can
+/// press another combo without closing the sheet.
+private struct GlobalKeyRecorderSheet: View {
+    let currentMap: KeyBindingMap
+    let currentGlobalHotkey: KeyTrigger?
+    let onComplete: (KeyTrigger?) -> Void
+
+    @State private var conflictMessage: String?
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Record Global Hotkey")
+                .font(.headline)
+
+            Text("Press a key combination to bring Nex forward from any app.")
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            KeyRecorderView { trigger in
+                let conflict = KeybindingConflict.check(
+                    trigger: trigger,
+                    in: currentMap,
+                    globalHotkey: currentGlobalHotkey,
+                    ignoreGlobalHotkey: true
+                )
+                if let conflict {
+                    conflictMessage = conflict.message
+                    return
+                }
+                conflictMessage = nil
+                onComplete(trigger)
+            }
+            .frame(width: 240, height: 44)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.selection, lineWidth: 2)
+            )
+
+            if let conflictMessage {
+                Text(conflictMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+            }
+
+            HStack {
+                Button("Cancel") {
+                    onComplete(nil)
+                }
+                .keyboardShortcut(.cancelAction)
+            }
+        }
+        .padding(24)
+        .frame(width: 380)
+    }
+}
+
 // MARK: - Key Recorder Sheet
 
 /// Modal sheet that captures a single key combination.
+/// Rejects combos that collide with the global hotkey or a different action;
+/// re-recording the same combo for the same action is a no-op.
 private struct KeyRecorderSheet: View {
     let action: NexAction
+    let currentMap: KeyBindingMap
+    let globalHotkey: KeyTrigger?
     let onComplete: (KeyTrigger?) -> Void
+
+    @State private var conflictMessage: String?
 
     var body: some View {
         VStack(spacing: 16) {
@@ -137,6 +292,17 @@ private struct KeyRecorderSheet: View {
                 .foregroundStyle(.secondary)
 
             KeyRecorderView { trigger in
+                let conflict = KeybindingConflict.check(
+                    trigger: trigger,
+                    in: currentMap,
+                    globalHotkey: globalHotkey,
+                    excluding: action
+                )
+                if let conflict {
+                    conflictMessage = conflict.message
+                    return
+                }
+                conflictMessage = nil
                 onComplete(trigger)
             }
             .frame(width: 200, height: 44)
@@ -144,6 +310,13 @@ private struct KeyRecorderSheet: View {
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(.selection, lineWidth: 2)
             )
+
+            if let conflictMessage {
+                Text(conflictMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+            }
 
             HStack {
                 Button("Cancel") {

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -347,6 +347,48 @@ enum NexAction: String, CaseIterable {
     }
 }
 
+// MARK: - KeybindingConflict
+
+/// The outcome of checking whether a proposed trigger is already claimed.
+enum KeybindingConflict: Equatable {
+    case action(NexAction)
+    case globalHotkey
+
+    /// Human-readable reason for surfacing in the recorder sheet.
+    var message: String {
+        switch self {
+        case .action(let action):
+            "Already bound to \"\(action.displayName)\""
+        case .globalHotkey:
+            "Already bound to the global hotkey"
+        }
+    }
+
+    /// Look up whether `trigger` collides with any existing binding.
+    ///
+    /// - Parameters:
+    ///   - excluding: When recording a new combo for an action that already owns a
+    ///     binding, skip the match on its own current binding so re-recording the
+    ///     same combo is a no-op rather than a self-collision.
+    ///   - ignoreGlobalHotkey: Set when recording the global hotkey itself, so the
+    ///     check only considers in-app bindings.
+    static func check(
+        trigger: KeyTrigger,
+        in map: KeyBindingMap,
+        globalHotkey: KeyTrigger?,
+        excluding: NexAction? = nil,
+        ignoreGlobalHotkey: Bool = false
+    ) -> KeybindingConflict? {
+        if !ignoreGlobalHotkey, globalHotkey == trigger {
+            return .globalHotkey
+        }
+        if let existing = map.action(for: trigger), existing != excluding {
+            return .action(existing)
+        }
+        return nil
+    }
+}
+
 // MARK: - KeyBindingMap
 
 /// Maps key triggers to actions. Supports multiple triggers per action.

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -91,6 +91,13 @@ struct NexApp: App {
                         }
                     }
 
+                    // Global hotkey callback — registration happens from the
+                    // `.configLoaded` effect so it runs once the user's trigger
+                    // has actually been parsed off disk.
+                    GlobalHotkeyService.shared.onPressed = {
+                        store.send(.globalHotkeyPressed)
+                    }
+
                     store.send(.appLaunched)
 
                     let monitor = PaneShortcutMonitor(store: store)

--- a/Nex/Services/AppActivation.swift
+++ b/Nex/Services/AppActivation.swift
@@ -1,0 +1,30 @@
+import AppKit
+
+/// Bring Nex to the foreground (or optionally hide on re-press).
+///
+/// When `hideOnRepress` is true and Nex is already the active application,
+/// the hotkey acts as a toggle and hides the app. Otherwise we activate and
+/// deminiaturize any miniaturized windows.
+///
+/// We deliberately do NOT pick a specific "main" window: `NSApp.windows`
+/// contains Settings and Help alongside the primary content window, and
+/// filtering them apart reliably is fragile (multiple windows pass
+/// `canBecomeMain && isRestorable`). `NSApp.activate` already restores the
+/// most-recently-focused window via the standard macOS window-ordering
+/// behavior, so we let that happen and only step in when a window is
+/// miniaturized (otherwise activation would only bring the menu bar
+/// forward with no visible window).
+@MainActor
+func toggleAppFrontmost(hideOnRepress: Bool) {
+    if hideOnRepress, NSApp.isActive {
+        NSApp.hide(nil)
+        return
+    }
+
+    NSApp.activate(ignoringOtherApps: true)
+
+    for window in NSApp.windows
+        where window.isMiniaturized && !(window is NSPanel) {
+        window.deminiaturize(nil)
+    }
+}

--- a/Nex/Services/ConfigParser.swift
+++ b/Nex/Services/ConfigParser.swift
@@ -13,6 +13,8 @@ enum ConfigParser {
         var focusFollowsMouseDelay: Int = 100
         var theme: String?
         var tcpPort: Int = 0
+        var globalHotkey: KeyTrigger?
+        var globalHotkeyHideOnRepress: Bool = true
     }
 
     /// Parse general (non-keybind) settings from a config file.
@@ -50,6 +52,14 @@ enum ConfigParser {
                 if let port = Int(value), (1 ... 65535).contains(port) {
                     settings.tcpPort = port
                 }
+            case "global-hotkey":
+                if value == "none" || value == "unbind" || value.isEmpty {
+                    settings.globalHotkey = nil
+                } else if let trigger = KeyTrigger.parse(rawValue) {
+                    settings.globalHotkey = trigger
+                }
+            case "global-hotkey-hide-on-repress":
+                settings.globalHotkeyHideOnRepress = value != "false"
             default:
                 break
             }

--- a/Nex/Services/GlobalHotkeyService.swift
+++ b/Nex/Services/GlobalHotkeyService.swift
@@ -1,0 +1,207 @@
+import AppKit
+import Carbon.HIToolbox
+import ComposableArchitecture
+import Foundation
+import os.log
+
+enum GlobalHotkeyError: Error, CustomStringConvertible {
+    case registrationFailed(osStatus: OSStatus)
+    case handlerInstallFailed(osStatus: OSStatus)
+
+    var description: String {
+        switch self {
+        case .registrationFailed(let status):
+            if status == Int32(eventHotKeyExistsErr) {
+                return "This shortcut is already claimed by another app."
+            }
+            return "Could not register hotkey (OSStatus \(status))."
+        case .handlerInstallFailed(let status):
+            return "Could not install hotkey handler (OSStatus \(status))."
+        }
+    }
+}
+
+/// Service wrapping Carbon `RegisterEventHotKey` for a single app-wide global hotkey.
+/// Thread-safety: all methods must be called from the main actor.
+@MainActor
+final class GlobalHotkeyService: @unchecked Sendable {
+    static let shared = GlobalHotkeyService()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.benfriebe.nex",
+        category: "GlobalHotkeyService"
+    )
+
+    private static let hotKeySignature: FourCharCode = {
+        let chars = Array("NEX1".utf8)
+        return (FourCharCode(chars[0]) << 24)
+            | (FourCharCode(chars[1]) << 16)
+            | (FourCharCode(chars[2]) << 8)
+            | FourCharCode(chars[3])
+    }()
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var currentTrigger: KeyTrigger?
+    private var nextHotKeyID: UInt32 = 0
+    private var handlerRef: EventHandlerRef?
+
+    /// Invoked on the main actor when the hotkey is pressed.
+    var onPressed: (() -> Void)?
+
+    private init() {}
+
+    /// Register a trigger as the global hotkey, replacing any existing registration.
+    /// Passing `nil` clears the hotkey.
+    ///
+    /// Performs a staged swap: the new trigger is registered first, and only
+    /// after Carbon accepts it do we unregister the previous one. If Carbon
+    /// rejects the new trigger (e.g. another app owns the combo), the old
+    /// registration is left intact and this call throws — callers should treat
+    /// a throw as "no change happened" and roll back their own state.
+    func register(_ trigger: KeyTrigger?) throws {
+        guard let trigger else {
+            unregister()
+            return
+        }
+
+        // No-op when the current registration already matches.
+        if currentTrigger == trigger, hotKeyRef != nil { return }
+
+        try installHandlerIfNeeded()
+
+        nextHotKeyID &+= 1
+        let hotKeyID = EventHotKeyID(signature: Self.hotKeySignature, id: nextHotKeyID)
+        var newRef: EventHotKeyRef?
+        let status = RegisterEventHotKey(
+            UInt32(trigger.keyCode),
+            Self.carbonFlags(for: trigger.modifiers),
+            hotKeyID,
+            GetEventDispatcherTarget(),
+            0,
+            &newRef
+        )
+
+        guard status == noErr, let newRef else {
+            Self.logger.warning(
+                "RegisterEventHotKey failed with OSStatus \(status); preserving previous registration"
+            )
+            throw GlobalHotkeyError.registrationFailed(osStatus: status)
+        }
+
+        // Success: drop the previous registration (if any) and swap.
+        if let oldRef = hotKeyRef {
+            UnregisterEventHotKey(oldRef)
+        }
+        hotKeyRef = newRef
+        currentTrigger = trigger
+    }
+
+    func unregister() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+        }
+        hotKeyRef = nil
+        currentTrigger = nil
+    }
+
+    // MARK: - Private
+
+    private func installHandlerIfNeeded() throws {
+        guard handlerRef == nil else { return }
+
+        var spec = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+
+        let userData = Unmanaged.passUnretained(self).toOpaque()
+        var ref: EventHandlerRef?
+        let status = InstallEventHandler(
+            GetEventDispatcherTarget(),
+            Self.eventHandler,
+            1,
+            &spec,
+            userData,
+            &ref
+        )
+        guard status == noErr, let ref else {
+            Self.logger.error("InstallEventHandler failed with OSStatus \(status)")
+            throw GlobalHotkeyError.handlerInstallFailed(osStatus: status)
+        }
+        handlerRef = ref
+    }
+
+    private static let eventHandler: EventHandlerUPP = { _, event, userData in
+        guard let event, let userData else { return OSStatus(eventNotHandledErr) }
+
+        var hotKeyID = EventHotKeyID()
+        let status = GetEventParameter(
+            event,
+            EventParamName(kEventParamDirectObject),
+            EventParamType(typeEventHotKeyID),
+            nil,
+            MemoryLayout<EventHotKeyID>.size,
+            nil,
+            &hotKeyID
+        )
+        // Match on signature only — the `id` rotates on every successful
+        // `register(...)` call so a stale event (registered with an older
+        // id) still gets dispatched correctly.
+        guard status == noErr,
+              hotKeyID.signature == GlobalHotkeyService.hotKeySignature
+        else {
+            return status
+        }
+
+        let service = Unmanaged<GlobalHotkeyService>.fromOpaque(userData).takeUnretainedValue()
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                service.onPressed?()
+            }
+        }
+        return noErr
+    }
+
+    private static func carbonFlags(for modifiers: NSEvent.ModifierFlags) -> UInt32 {
+        var flags: UInt32 = 0
+        if modifiers.contains(.command) { flags |= UInt32(cmdKey) }
+        if modifiers.contains(.shift) { flags |= UInt32(shiftKey) }
+        if modifiers.contains(.option) { flags |= UInt32(optionKey) }
+        if modifiers.contains(.control) { flags |= UInt32(controlKey) }
+        return flags
+    }
+}
+
+// MARK: - TCA Dependency
+
+/// Protocol abstraction so tests can substitute a no-op implementation without touching Carbon.
+protocol GlobalHotkeyServicing: Sendable {
+    func register(_ trigger: KeyTrigger?) async throws
+}
+
+struct LiveGlobalHotkeyService: GlobalHotkeyServicing {
+    func register(_ trigger: KeyTrigger?) async throws {
+        try await MainActor.run {
+            // Belt-and-braces: never touch Carbon during XCTest runs.
+            // `isTestMode` is main-actor-isolated, so read it here.
+            guard !NexApp.isTestMode else { return }
+            try GlobalHotkeyService.shared.register(trigger)
+        }
+    }
+}
+
+struct NoopGlobalHotkeyService: GlobalHotkeyServicing {
+    func register(_: KeyTrigger?) async throws {}
+}
+
+private enum GlobalHotkeyServiceKey: DependencyKey {
+    static let liveValue: any GlobalHotkeyServicing = LiveGlobalHotkeyService()
+    static let testValue: any GlobalHotkeyServicing = NoopGlobalHotkeyService()
+}
+
+extension DependencyValues {
+    var globalHotkeyService: any GlobalHotkeyServicing {
+        get { self[GlobalHotkeyServiceKey.self] }
+        set { self[GlobalHotkeyServiceKey.self] = newValue }
+    }
+}

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -675,7 +675,12 @@ struct AppReducerTests {
         let store = makeStore()
 
         await store.send(.configLoaded(
-            focusFollowsMouse: false, focusFollowsMouseDelay: 100, theme: nil, tcpPort: 19400
+            focusFollowsMouse: false,
+            focusFollowsMouseDelay: 100,
+            theme: nil,
+            tcpPort: 19400,
+            globalHotkey: nil,
+            globalHotkeyHideOnRepress: true
         )) { state in
             #expect(state.tcpPort == 19400)
         }
@@ -685,12 +690,199 @@ struct AppReducerTests {
         let store = makeStore()
 
         await store.send(.configLoaded(
-            focusFollowsMouse: true, focusFollowsMouseDelay: 200, theme: nil, tcpPort: 0
+            focusFollowsMouse: true,
+            focusFollowsMouseDelay: 200,
+            theme: nil,
+            tcpPort: 0,
+            globalHotkey: nil,
+            globalHotkeyHideOnRepress: true
         )) { state in
             #expect(state.tcpPort == 0)
             #expect(state.focusFollowsMouse == true)
             #expect(state.focusFollowsMouseDelay == 200)
         }
+    }
+
+    // MARK: - Global Hotkey
+
+    /// Records every `register(_:)` call so tests can assert the reducer
+    /// is calling through to the hotkey service with the right trigger.
+    private actor RecordingGlobalHotkeyService: GlobalHotkeyServicing {
+        private var _calls: [KeyTrigger?] = []
+
+        nonisolated func register(_ trigger: KeyTrigger?) async throws {
+            await append(trigger)
+        }
+
+        private func append(_ trigger: KeyTrigger?) {
+            _calls.append(trigger)
+        }
+
+        func calls() -> [KeyTrigger?] {
+            _calls
+        }
+    }
+
+    /// Simulates a Carbon rejection (e.g. `eventHotKeyExistsErr`) so the
+    /// rollback path can be exercised in tests.
+    private struct FailingGlobalHotkeyService: GlobalHotkeyServicing {
+        struct RegistrationFailed: Error, CustomStringConvertible {
+            var description: String { "simulated registration failure" }
+        }
+
+        func register(_: KeyTrigger?) async throws {
+            throw RegistrationFailed()
+        }
+    }
+
+    @Test func configLoadedStoresGlobalHotkeyAndCallsRegister() async {
+        let recorder = RecordingGlobalHotkeyService()
+        let store = TestStore(initialState: AppReducer.State()) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.globalHotkeyService = recorder
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        let trigger = KeyTrigger(keyCode: 17, modifiers: [.command, .shift]) // ⌘⇧T
+        await store.send(.configLoaded(
+            focusFollowsMouse: false,
+            focusFollowsMouseDelay: 100,
+            theme: nil,
+            tcpPort: 0,
+            globalHotkey: trigger,
+            globalHotkeyHideOnRepress: false
+        )) { state in
+            state.globalHotkey = trigger
+            state.globalHotkeyHideOnRepress = false
+        }
+        await store.finish()
+        #expect(await recorder.calls() == [trigger])
+    }
+
+    @Test func setGlobalHotkeyUpdatesStateAndRegisters() async {
+        let recorder = RecordingGlobalHotkeyService()
+        let store = TestStore(initialState: AppReducer.State()) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.globalHotkeyService = recorder
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        let trigger = KeyTrigger(keyCode: 17, modifiers: [.command, .shift])
+        await store.send(.setGlobalHotkey(trigger)) { state in
+            state.globalHotkey = trigger
+            state.globalHotkeyRegistrationError = nil
+        }
+        await store.finish()
+        #expect(await recorder.calls() == [trigger])
+    }
+
+    @Test func setGlobalHotkeyNilClearsState() async {
+        var appState = AppReducer.State()
+        appState.globalHotkey = KeyTrigger(keyCode: 17, modifiers: [.command, .shift])
+        appState.globalHotkeyRegistrationError = "stale"
+
+        let recorder = RecordingGlobalHotkeyService()
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.globalHotkeyService = recorder
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.setGlobalHotkey(nil)) { state in
+            state.globalHotkey = nil
+            state.globalHotkeyRegistrationError = nil
+        }
+        await store.finish()
+        #expect(await recorder.calls() == [KeyTrigger?.none])
+    }
+
+    @Test func setGlobalHotkeyHideOnRepressUpdatesState() async {
+        let store = makeStore()
+
+        await store.send(.setGlobalHotkeyHideOnRepress(false)) { state in
+            state.globalHotkeyHideOnRepress = false
+        }
+    }
+
+    @Test func globalHotkeyRegistrationFailedSetsError() async {
+        let store = makeStore()
+
+        await store.send(.globalHotkeyRegistrationFailed(reason: "eventHotKeyExistsErr")) { state in
+            state.globalHotkeyRegistrationError = "eventHotKeyExistsErr"
+        }
+    }
+
+    @Test func setGlobalHotkeyRollsBackOnRegistrationFailure() async {
+        // Seed with a previously-working hotkey.
+        let previous = KeyTrigger(keyCode: 17, modifiers: [.command, .shift]) // ⌘⇧T
+        let attempted = KeyTrigger(keyCode: 2, modifiers: .command) // ⌘D (collides, say)
+
+        var appState = AppReducer.State()
+        appState.globalHotkey = previous
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.globalHotkeyService = FailingGlobalHotkeyService()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        // Optimistic update to the attempted trigger.
+        await store.send(.setGlobalHotkey(attempted)) { state in
+            state.globalHotkey = attempted
+            state.globalHotkeyRegistrationError = nil
+        }
+        // Rollback action fires and restores `previous`.
+        await store.receive(
+            .globalHotkeyRegistrationRejected(
+                revertTo: previous,
+                reason: "simulated registration failure"
+            )
+        ) { state in
+            state.globalHotkey = previous
+            state.globalHotkeyRegistrationError = "simulated registration failure"
+        }
+    }
+
+    @Test func globalHotkeyConflictWithInAppIsComputed() {
+        var state = AppReducer.State()
+        state.keybindings = .defaults
+        state.globalHotkey = KeyTrigger(keyCode: 2, modifiers: .command) // ⌘D → splitRight
+        #expect(state.globalHotkeyConflictWithInApp == .action(.splitRight))
+    }
+
+    @Test func globalHotkeyNoConflictWhenUnbound() {
+        var state = AppReducer.State()
+        state.keybindings = .defaults
+        // ⌃⌥L — not in defaults.
+        state.globalHotkey = KeyTrigger(keyCode: 37, modifiers: [.control, .option])
+        #expect(state.globalHotkeyConflictWithInApp == nil)
+    }
+
+    @Test func globalHotkeyConflictNilWhenNoHotkey() {
+        var state = AppReducer.State()
+        state.keybindings = .defaults
+        state.globalHotkey = nil
+        #expect(state.globalHotkeyConflictWithInApp == nil)
     }
 
     // MARK: - setTCPPort

--- a/NexTests/ConfigParserTests.swift
+++ b/NexTests/ConfigParserTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import Nex
 import Testing
 
@@ -148,5 +149,67 @@ struct ConfigParserTests {
     @Test func parseTCPPortOutOfRangeIgnored() {
         let result = ConfigParser.parseGeneralSettings(from: "tcp-port = 99999")
         #expect(result.tcpPort == 0)
+    }
+
+    // MARK: - Global Hotkey
+
+    @Test func parseGlobalHotkeyAbsentIsNil() {
+        let result = ConfigParser.parseGeneralSettings(from: "focus-follows-mouse = true")
+        #expect(result.globalHotkey == nil)
+    }
+
+    @Test func parseGlobalHotkeyWithModifiers() {
+        let result = ConfigParser.parseGeneralSettings(from: "global-hotkey = super+shift+t")
+        #expect(result.globalHotkey == KeyTrigger(keyCode: 17, modifiers: [.command, .shift]))
+    }
+
+    @Test func parseGlobalHotkeyNoneClears() {
+        let result = ConfigParser.parseGeneralSettings(from: "global-hotkey = none")
+        #expect(result.globalHotkey == nil)
+    }
+
+    @Test func parseGlobalHotkeyInvalidIgnored() {
+        let result = ConfigParser.parseGeneralSettings(from: "global-hotkey = super+badkey")
+        #expect(result.globalHotkey == nil)
+    }
+
+    @Test func parseGlobalHotkeyHideOnRepressDefaultsTrue() {
+        let result = ConfigParser.parseGeneralSettings(from: "")
+        #expect(result.globalHotkeyHideOnRepress == true)
+    }
+
+    @Test func parseGlobalHotkeyHideOnRepressFalse() {
+        let result = ConfigParser.parseGeneralSettings(from: "global-hotkey-hide-on-repress = false")
+        #expect(result.globalHotkeyHideOnRepress == false)
+    }
+
+    @Test func parseGlobalHotkeyHideOnRepressTrue() {
+        let result = ConfigParser.parseGeneralSettings(from: "global-hotkey-hide-on-repress = true")
+        #expect(result.globalHotkeyHideOnRepress == true)
+    }
+
+    @Test func globalHotkeyRoundTripThroughSetGeneralSetting() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("nex-test-\(UUID().uuidString).config")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Seed file with an unrelated setting to verify preservation.
+        try "focus-follows-mouse = true\n".write(to: tmp, atomically: true, encoding: .utf8)
+
+        ConfigParser.setGeneralSetting("global-hotkey", value: "super+shift+t", inFile: tmp.path)
+        ConfigParser.setGeneralSetting(
+            "global-hotkey-hide-on-repress", value: "false", inFile: tmp.path
+        )
+
+        let parsed = ConfigParser.parseGeneralSettings(fromFile: tmp.path)
+        #expect(parsed.globalHotkey == KeyTrigger(keyCode: 17, modifiers: [.command, .shift]))
+        #expect(parsed.globalHotkeyHideOnRepress == false)
+        #expect(parsed.focusFollowsMouse == true)
+
+        // Clear the hotkey.
+        ConfigParser.setGeneralSetting("global-hotkey", value: "none", inFile: tmp.path)
+        let cleared = ConfigParser.parseGeneralSettings(fromFile: tmp.path)
+        #expect(cleared.globalHotkey == nil)
+        #expect(cleared.focusFollowsMouse == true)
     }
 }

--- a/NexTests/KeyBindingTests.swift
+++ b/NexTests/KeyBindingTests.swift
@@ -309,3 +309,79 @@ struct KeyBindingMapTests {
         #expect(map.action(for: cmdP) == .commandPalette)
     }
 }
+
+@MainActor
+struct KeybindingConflictTests {
+    private let cmdShiftT = KeyTrigger(keyCode: 17, modifiers: [.command, .shift])
+    private let cmdD = KeyTrigger(keyCode: 2, modifiers: .command)
+    private let ctrlAltL = KeyTrigger(keyCode: 37, modifiers: [.control, .option])
+
+    @Test func conflictWithExistingActionReturnsAction() {
+        let conflict = KeybindingConflict.check(
+            trigger: cmdD,
+            in: .defaults,
+            globalHotkey: nil
+        )
+        #expect(conflict == .action(.splitRight))
+    }
+
+    @Test func conflictWithGlobalHotkeyWins() {
+        // cmdShiftT is bound to .reopenClosedPane by default; ensure the
+        // global-hotkey check fires first when both would match.
+        let conflict = KeybindingConflict.check(
+            trigger: cmdShiftT,
+            in: .defaults,
+            globalHotkey: cmdShiftT
+        )
+        #expect(conflict == .globalHotkey)
+    }
+
+    @Test func conflictExcludingSameActionIsNil() {
+        // Re-recording ⌘D for split_right (its current binding) should not
+        // report a self-collision.
+        let conflict = KeybindingConflict.check(
+            trigger: cmdD,
+            in: .defaults,
+            globalHotkey: nil,
+            excluding: .splitRight
+        )
+        #expect(conflict == nil)
+    }
+
+    @Test func conflictExcludingDifferentActionStillReports() {
+        // Recording ⌘D for close_pane must still collide with split_right.
+        let conflict = KeybindingConflict.check(
+            trigger: cmdD,
+            in: .defaults,
+            globalHotkey: nil,
+            excluding: .closePane
+        )
+        #expect(conflict == .action(.splitRight))
+    }
+
+    @Test func ignoreGlobalHotkeyFlagSkipsGlobalMatch() {
+        // Editing the global hotkey itself: a match against the current
+        // global trigger is not a conflict.
+        let conflict = KeybindingConflict.check(
+            trigger: cmdShiftT,
+            in: KeyBindingMap(),
+            globalHotkey: cmdShiftT,
+            ignoreGlobalHotkey: true
+        )
+        #expect(conflict == nil)
+    }
+
+    @Test func nonCollidingTriggerReturnsNil() {
+        let conflict = KeybindingConflict.check(
+            trigger: ctrlAltL,
+            in: .defaults,
+            globalHotkey: nil
+        )
+        #expect(conflict == nil)
+    }
+
+    @Test func messageIncludesActionDisplayName() {
+        #expect(KeybindingConflict.action(.splitRight).message.contains("Split Right"))
+        #expect(KeybindingConflict.globalHotkey.message.contains("global hotkey"))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Available actions: `new_workspace`, `open_file`, `switch_to_workspace_1`–`9`, 
 A single system-wide hotkey can bring Nex forward from any app. Set it in **Settings > Keybindings > Global**, or via the config file:
 
 ```
-global-hotkey = super+shift+t
+global-hotkey = opt+shift+x
 global-hotkey-hide-on-repress = true
 ```
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ You can also edit keybindings in **Settings > Keybindings** with a visual key re
 
 Available actions: `new_workspace`, `open_file`, `switch_to_workspace_1`–`9`, `toggle_sidebar`, `toggle_inspector`, `split_right`, `split_down`, `close_pane`, `focus_next_pane`, `focus_previous_pane`, `next_workspace`, `previous_workspace`, `toggle_markdown_edit`, `toggle_zoom`, `reopen_closed_pane`, `toggle_search`, `close_search`, `cycle_layout`, `move_pane_left`, `move_pane_right`, `move_pane_up`, `move_pane_down`.
 
+### Global hotkey
+
+A single system-wide hotkey can bring Nex forward from any app. Set it in **Settings > Keybindings > Global**, or via the config file:
+
+```
+global-hotkey = super+shift+t
+global-hotkey-hide-on-repress = true
+```
+
+Set `global-hotkey = none` to clear. `global-hotkey-hide-on-repress` (default `true`) hides Nex when the hotkey is pressed while Nex is already frontmost.
+
+No Accessibility permission is required. The hotkey only works while Nex is running; if another app has already claimed the combination, Settings will surface a warning.
+
 ### Settings
 
 Open settings with `Cmd+,`. Available options:


### PR DESCRIPTION
## Summary
- Add an opt-in system-wide hotkey that brings Nex forward from any app, with an optional "press again to hide" toggle
- Uses Carbon `RegisterEventHotKey`, so no Accessibility permission is required and the event is consumed at the WindowServer level (won't leak to the focused app)
- Surfaced in Settings ▸ Keybindings ▸ Global (record/clear/hide-on-repress) and in `~/.config/nex/config`:
  ```
  global-hotkey = opt+shift+x
  global-hotkey-hide-on-repress = true  # default
  ```
- Conflict detection: the recorder warns if the combo is already claimed by an in-app binding or vice versa; `PaneShortcutMonitor` has a defensive guard so an in-app binding matching the global hotkey can't fire

## Scope notes
- v1 only registers while Nex is running (no login-item helper). If you want it always available, use macOS "Open at Login" on Nex.app.
- If the closed-main-window edge case comes up (⌘W'd down to the Dock), the hotkey still activates the app but may not re-open a new window — matches the plan's explicit v1 punt.

## Test plan
- [x] Build succeeds, 475 tests pass (incl. new reducer + config-parser + conflict-check tests), lint/format clean
- [x] Set `⌥⇧X` via Settings; press from Safari → Nex comes forward
- [x] Press again with Nex frontmost → Nex hides
- [x] Deminiaturize: ⌘M Nex, switch away, press hotkey → Nex un-minimizes and focuses
- [x] Uncheck "Press again to hide"; hotkey while frontmost is a no-op
- [x] Set a combo owned by another app (e.g. Raycast's `⌘⌃Space`) → warning row appears, combo doesn't activate Nex
- [x] Rebind to a free combo; old combo stops working, new one activates
- [x] Clear via × → `global-hotkey = none` in config
- [x] Invalid combo in config file → Nex starts with no hotkey, no crash

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)