### PR TITLE
feat: sidebar drop-expand setting + nex pane id subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ make check
   - `nex event stop|start|error|notification|session-start [--message ...] [--title ...] [--body ...]`
   - `nex pane split|create|close|name|send|move|move-to-workspace [options]`
   - `nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]` — only command that returns data; prints a human-readable table by default, JSON array with `--json`
+  - `nex pane id` — prints current `NEX_PANE_ID` (exit 0) or exits 1 if not set. Local only; doesn't touch the socket. Useful as a cheap in-Nex check
   - `nex workspace create [--name ...] [--path ...] [--color ...] [--group <name>]`
   - `nex workspace move <name-or-id> (--group <name> | --top-level) [--index N]`
   - `nex group create <name> [--color blue]`

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -1222,9 +1222,8 @@ struct AppReducer {
                     let insertAt = index.map { max(0, min($0, order.count)) } ?? order.count
                     order.insert(workspaceID, at: insertAt)
                     state.groups[id: targetGroupID]?.childOrder = order
-                    // Auto-expand the destination group so the moved workspace
-                    // is visible after the move.
-                    if state.groups[id: targetGroupID]?.isCollapsed == true {
+                    if state.settings.expandGroupOnWorkspaceDrop,
+                       state.groups[id: targetGroupID]?.isCollapsed == true {
                         state.groups[id: targetGroupID]?.isCollapsed = false
                     }
                 } else {

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -16,6 +16,7 @@ struct SettingsFeature {
         var selectedTheme: NexTheme?
         var autoDetectRepos: Bool = true
         var inheritGroupOnNewWorkspace: Bool = true
+        var expandGroupOnWorkspaceDrop: Bool = true
 
         /// The resolved absolute worktree base path. Expands ~ and substitutes
         /// the `<repo>` placeholder:
@@ -41,6 +42,7 @@ struct SettingsFeature {
         case setWorktreeBasePath(String)
         case setAutoDetectRepos(Bool)
         case setInheritGroupOnNewWorkspace(Bool)
+        case setExpandGroupOnWorkspaceDrop(Bool)
         case selectTheme(NexTheme?)
         case applyAppearance(opacity: Double, r: Double, g: Double, b: Double, theme: NexTheme?)
     }
@@ -56,6 +58,7 @@ struct SettingsFeature {
     static let defaultsKeySelectedTheme = "settings.selectedTheme"
     static let defaultsKeyAutoDetectRepos = "settings.autoDetectRepos"
     static let defaultsKeyInheritGroupOnNewWorkspace = "settings.inheritGroupOnNewWorkspace"
+    static let defaultsKeyExpandGroupOnWorkspaceDrop = "settings.expandGroupOnWorkspaceDrop"
 
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.userDefaults) var userDefaults
@@ -75,6 +78,9 @@ struct SettingsFeature {
                 }
                 if userDefaults.hasKey(Self.defaultsKeyInheritGroupOnNewWorkspace) {
                     state.inheritGroupOnNewWorkspace = userDefaults.boolForKey(Self.defaultsKeyInheritGroupOnNewWorkspace)
+                }
+                if userDefaults.hasKey(Self.defaultsKeyExpandGroupOnWorkspaceDrop) {
+                    state.expandGroupOnWorkspaceDrop = userDefaults.boolForKey(Self.defaultsKeyExpandGroupOnWorkspaceDrop)
                 }
                 if userDefaults.boolForKey(Self.defaultsKeyHasCustomColor) {
                     state.backgroundColorR = userDefaults.doubleForKey(Self.defaultsKeyColorR)
@@ -138,6 +144,11 @@ struct SettingsFeature {
             case .setInheritGroupOnNewWorkspace(let enabled):
                 state.inheritGroupOnNewWorkspace = enabled
                 userDefaults.setBool(enabled, Self.defaultsKeyInheritGroupOnNewWorkspace)
+                return .none
+
+            case .setExpandGroupOnWorkspaceDrop(let enabled):
+                state.expandGroupOnWorkspaceDrop = enabled
+                userDefaults.setBool(enabled, Self.defaultsKeyExpandGroupOnWorkspaceDrop)
                 return .none
 
             case .selectTheme(let theme):

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -94,6 +94,14 @@ private struct GeneralSettingsView: View {
                     Text("When the active workspace belongs to a group, new workspaces are created inside that same group. Disable to always create at the top level.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    Toggle("Expand group when a workspace is dropped into it", isOn: Binding(
+                        get: { settingsStore.expandGroupOnWorkspaceDrop },
+                        set: { settingsStore.send(.setExpandGroupOnWorkspaceDrop($0)) }
+                    ))
+                    Text("When dragging a workspace into a collapsed group, expand the group on drop so the moved workspace is visible. Disable to keep the group collapsed and avoid disrupting the sidebar layout.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 Section("Panes") {

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -48,6 +48,20 @@ struct WorkspaceListView: View {
     /// the other selected rows behind in their original slots.
     @State private var hiddenMultiDragIDs: Set<UUID> = []
 
+    /// Post-release "land into collapsed group" override. When dropping a
+    /// row onto a collapsed group that stays collapsed, the default
+    /// release (offset → 0 + entries-change fade) makes the row visually
+    /// fly back to its top-level slot before fading — confusing, since
+    /// the workspace actually went into the group. `landingPreview`
+    /// pins the row's offset to the group header's Y so it animates
+    /// "into" the group and fades there instead.
+    private struct LandingPreview: Equatable {
+        let workspaceID: UUID
+        let offsetY: CGFloat
+    }
+
+    @State private var landingPreview: LandingPreview?
+
     /// Underlying `NSScrollView` hosting the sidebar content. Captured
     /// via `ScrollViewFinder` once the view is in a window. Provides
     /// the authoritative scroll offset + viewport height and is driven
@@ -680,6 +694,10 @@ struct WorkspaceListView: View {
             // after a multi-select drag.
             let flatIndex = store.state.visibleWorkspaceOrder.firstIndex(of: workspaceID) ?? 0
             let isDragging = draggedWorkspaceID == workspaceID
+            // True while the row is playing the "falling into group" drop
+            // animation — styled smaller + more transparent so it reads
+            // as being consumed by the group rather than flying away.
+            let isLanding = landingPreview?.workspaceID == workspaceID
 
             let aggregateStatus = aggregateGitStatus(for: workspaceStore.state)
             // Show the dragged row nested when the current target is a
@@ -728,10 +746,15 @@ struct WorkspaceListView: View {
                         .allowsHitTesting(false)
                 }
             }
-            .zIndex(isDragging ? 1 : 0)
-            .opacity(isDragging ? 0.8 : 1)
-            .scaleEffect(isDragging ? 1.03 : 1.0)
-            .shadow(color: isDragging ? .black.opacity(0.3) : .clear, radius: 4, y: 2)
+            .zIndex(isDragging || isLanding ? 1 : 0)
+            .opacity(isLanding ? 0.15 : (isDragging ? 0.8 : 1))
+            // Drag lift: centered 1.03. Cleared when landing so the
+            // shrink below starts from identity.
+            .scaleEffect(isDragging && !isLanding ? 1.03 : 1.0)
+            // Landing shrink: scale in place (center anchor) so the row
+            // doesn't drift sideways as it collapses into the group.
+            .scaleEffect(isLanding ? 0.2 : 1.0)
+            .shadow(color: isDragging && !isLanding ? .black.opacity(0.3) : .clear, radius: 4, y: 2)
             // Animate reorders for non-grabbed rows. The grabbed row
             // gets `.none` so its leadingInset and styling changes
             // don't spring against cursor tracking. `sidebarLayoutKey`
@@ -755,7 +778,7 @@ struct WorkspaceListView: View {
             // container-jump height at the animation midpoint. Keep
             // this last so the offset snaps straight to the new
             // cursor-tracking value every frame.
-            .offset(y: isDragging ? dragCurrentY - dragGrabOffset - workspaceStartY(workspaceID) : 0)
+            .offset(y: rowOffsetY(workspaceID: workspaceID, isDragging: isDragging))
             .gesture(
                 DragGesture(minimumDistance: 5, coordinateSpace: .named("workspaceList"))
                     .onChanged { value in
@@ -852,8 +875,56 @@ struct WorkspaceListView: View {
                                 )
                             }
                         }
-                        cancelSpringLoad()
+                        // Cancel the pending spring-load timer. Keep
+                        // `springLoadedGroupID` though — a spring-loaded
+                        // group should stay visually expanded through
+                        // the drop animation so the row lands in a
+                        // visible slot; it collapses in the animation's
+                        // completion below.
+                        springLoadTask?.cancel()
+                        springLoadTask = nil
+                        springLoadTargetID = nil
+                        let persistingSpringLoad = springLoadedGroupID
                         cancelAutoScroll()
+
+                        // Special case: single-drag release onto a
+                        // collapsed group header that will stay collapsed.
+                        // Animate the row into the header's position so
+                        // the workspace visually "falls into" the group,
+                        // then commit the drop. Skipped when the group is
+                        // currently spring-loaded (visibly expanded) —
+                        // the normal animation already lands the row in
+                        // a visible child slot before the group collapses.
+                        if bulkIDs.isEmpty, singleNeedsRelease,
+                           case .ontoGroupHeader(let gid) = singleTarget,
+                           store.groups[id: gid]?.isCollapsed == true,
+                           persistingSpringLoad != gid,
+                           !store.settings.expandGroupOnWorkspaceDrop {
+                            let landingY = groupStartY(gid) - workspaceStartY(sourceID)
+                            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                                landingPreview = LandingPreview(workspaceID: sourceID, offsetY: landingY)
+                                currentDropTarget = nil
+                            } completion: {
+                                // Row has "landed" at the header — commit
+                                // the move. The row exits via the entries
+                                // change; `landingPreview` keeps its
+                                // offset pinned so the fade plays at the
+                                // header rather than the old slot.
+                                applyDropTarget(.ontoGroupHeader(groupID: gid), workspaceID: sourceID)
+                                draggedWorkspaceID = nil
+                                dragCurrentY = 0
+                                dragViewportY = 0
+                                dragGrabOffset = 0
+                                multiDragIDs = []
+                                hiddenMultiDragIDs = []
+                                Task { @MainActor in
+                                    try? await Task.sleep(for: .milliseconds(400))
+                                    landingPreview = nil
+                                }
+                            }
+                            return
+                        }
+
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                             draggedWorkspaceID = nil
                             dragCurrentY = 0
@@ -872,6 +943,19 @@ struct WorkspaceListView: View {
                                 }
                             } else if singleNeedsRelease, let singleTarget {
                                 applyDropTarget(singleTarget, workspaceID: sourceID)
+                            }
+                        } completion: {
+                            // After the row has settled, collapse any
+                            // spring-loaded group we kept open through
+                            // the drop animation. Only relevant when the
+                            // group is still persisted as collapsed —
+                            // drops that expand the group (via
+                            // expandGroupOnWorkspaceDrop) already cleared
+                            // isCollapsed so there's nothing to do.
+                            if persistingSpringLoad != nil {
+                                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                                    springLoadedGroupID = nil
+                                }
                             }
                         }
                     }
@@ -1051,6 +1135,18 @@ struct WorkspaceListView: View {
             }
             return h
         }
+    }
+
+    /// Offset applied to a workspace row. During an active drag the
+    /// grabbed row tracks the cursor; when a `landingPreview` is set
+    /// (release onto a collapsed group that stays collapsed) the row is
+    /// pinned to a fixed target so it animates toward the group header
+    /// and fades there rather than snapping back to its old slot.
+    private func rowOffsetY(workspaceID: UUID, isDragging: Bool) -> CGFloat {
+        if let landing = landingPreview, landing.workspaceID == workspaceID {
+            return landing.offsetY
+        }
+        return isDragging ? dragCurrentY - dragGrabOffset - workspaceStartY(workspaceID) : 0
     }
 
     /// Y of the resting top edge of the given workspace row in the drag

--- a/NexTests/WorkspaceGroupCRUDTests.swift
+++ b/NexTests/WorkspaceGroupCRUDTests.swift
@@ -406,7 +406,10 @@ struct WorkspaceGroupCRUDTests {
         }
     }
 
-    @Test func moveWorkspaceIntoCollapsedGroupExpandsIt() async {
+    @Test func moveWorkspaceIntoCollapsedGroupExpandsByDefault() async {
+        // Default (`settings.expandGroupOnWorkspaceDrop == true`): dropping a
+        // workspace into a collapsed group auto-expands it so the moved
+        // workspace is immediately visible.
         let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
         let group = WorkspaceGroup(
             id: Self.groupA,
@@ -424,6 +427,44 @@ struct WorkspaceGroupCRUDTests {
             workspaceID: Self.wsID1, groupID: Self.groupA, index: nil
         )) { state in
             #expect(state.groups[id: Self.groupA]?.isCollapsed == false)
+            #expect(state.groups[id: Self.groupA]?.childOrder == [Self.wsID1])
+        }
+    }
+
+    @Test func moveWorkspaceIntoCollapsedGroupKeepsItCollapsedWhenSettingDisabled() async {
+        // Issue #59: with `expandGroupOnWorkspaceDrop` off, dropping a
+        // workspace into a collapsed group must not expand it — the move is
+        // silent and the workspace becomes visible only when the user
+        // expands the group themselves.
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
+        let group = WorkspaceGroup(
+            id: Self.groupA,
+            name: "G",
+            isCollapsed: true,
+            childOrder: []
+        )
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1]
+        appState.groups = [group]
+        appState.topLevelOrder = [.workspace(Self.wsID1), .group(Self.groupA)]
+        appState.settings.expandGroupOnWorkspaceDrop = false
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = UUIDGenerator { Self.groupA }
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.moveWorkspaceToGroup(
+            workspaceID: Self.wsID1, groupID: Self.groupA, index: nil
+        )) { state in
+            #expect(state.groups[id: Self.groupA]?.isCollapsed == true)
             #expect(state.groups[id: Self.groupA]?.childOrder == [Self.wsID1])
         }
     }

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -13,6 +13,7 @@
 //   nex pane move [left|right|up|down]
 //   nex pane move-to-workspace --to-workspace <name-or-uuid> [--create]
 //   nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]
+//   nex pane id
 //   nex workspace create [--name "..."] [--path /dir] [--color blue] [--group <name>]
 //   nex workspace move <name-or-id> (--group <name> | --top-level) [--index N]
 //   nex group create <name> [--color blue]
@@ -82,6 +83,7 @@ func printUsage() {
       nex pane move [left|right|up|down]
       nex pane move-to-workspace --to-workspace <name-or-uuid> [--create]
       nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]
+      nex pane id
       nex workspace create [--name "..."] [--path /dir] [--color blue] [--group <name>]
       nex workspace move <name-or-id> (--group <name> | --top-level) [--index N]
       nex group create <name> [--color blue]
@@ -372,11 +374,19 @@ func handleEvent(_ args: inout ArraySlice<String>) {
 
 func handlePane(_ args: inout ArraySlice<String>) {
     guard let action = args.popFirst() else {
-        fputs("Usage: nex pane split|create|close|name|send|move|list [...]\n", stderr)
+        fputs("Usage: nex pane split|create|close|name|send|move|list|id [...]\n", stderr)
         exit(1)
     }
 
     switch action {
+    case "id":
+        guard let paneID = ProcessInfo.processInfo.environment["NEX_PANE_ID"],
+              !paneID.isEmpty
+        else {
+            exit(1)
+        }
+        print(paneID)
+
     case "split":
         let paneID = requirePaneID()
         let direction = parseFlag("--direction", from: &args)
@@ -492,7 +502,7 @@ func handlePane(_ args: inout ArraySlice<String>) {
 
     default:
         fputs("Unknown pane action: \(action)\n", stderr)
-        fputs("Valid actions: split, create, close, name, send, move, move-to-workspace, list\n", stderr)
+        fputs("Valid actions: split, create, close, name, send, move, move-to-workspace, list, id\n", stderr)
         exit(1)
     }
 }


### PR DESCRIPTION
Bundles two small changes that landed on the same branch.

## 1. Settings toggle to expand group on workspace drop

- Adds a user preference controlling whether dropping a workspace into a collapsed sidebar group auto-expands the group.
- Exposed as a toggle in **Settings > General > Workspaces** ("Expand group when a workspace is dropped into it"), defaulting to **on** (the pre-existing behaviour).
- With the toggle off, collapsed groups stay collapsed after a drop (fixes the UX reported in #59). The moved workspace is inside the group and becomes visible when the user expands it themselves.
- Persisted in UserDefaults under `settings.expandGroupOnWorkspaceDrop`.

The sidebar drop handler in `AppReducer.moveWorkspaceToGroup` now only auto-expands the destination group when the setting is enabled.

Closes #59

## 2. `nex pane id` subcommand

- Prints `NEX_PANE_ID` to stdout (exit 0) or exits 1 if unset.
- Purely local — no socket call, no shell expansion — so scripts and skill pre-flight checks can allowlist it as `Bash(nex pane id)` without opening the door to arbitrary `$VAR` expansion.

## Test plan

- [ ] Open Settings > General > Workspaces and verify the new toggle appears, defaulting to on.
- [ ] With the toggle **on**, drag a workspace onto a collapsed group in the sidebar. Expected: group expands and the moved workspace is visible.
- [ ] With the toggle **off**, drag a workspace onto a collapsed group. Expected: group stays collapsed; expanding it manually shows the moved workspace at the end.
- [ ] Quit and relaunch Nex; the toggle state should persist.
- [ ] Inside a Nex pane: \`nex pane id\` prints the pane UUID and exits 0.
- [ ] Outside Nex: \`nex pane id\` exits 1 with no output.
- [ ] \`make check\` passes (505 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)