### PR TITLE
fix: tab key focus in new workspace dialog (#64)

### DIFF
--- a/Nex/Features/RepoRegistry/RepoPickerView.swift
+++ b/Nex/Features/RepoRegistry/RepoPickerView.swift
@@ -3,12 +3,24 @@ import SwiftUI
 
 /// Fuzzy search picker for selecting a repo from the global registry.
 struct RepoPickerView: View {
+    /// Focusable controls in tab order. The repo list is a single Tab stop:
+    /// once focused, Up/Down arrows move the highlight and Return/Space
+    /// selects. This keeps Tab predictable regardless of list length and the
+    /// macOS "Keyboard navigation" system setting (#64).
+    private enum Field: Hashable {
+        case search
+        case list
+        case cancel
+    }
+
     let repos: IdentifiedArrayOf<Repo>
     let alreadyAssociatedRepoIDs: Set<UUID>
     let onSelect: (Repo) -> Void
     let onCancel: () -> Void
 
     @State private var searchText = ""
+    @State private var highlightedRepoID: UUID?
+    @FocusState private var focusedField: Field?
 
     var body: some View {
         VStack(spacing: 12) {
@@ -17,6 +29,12 @@ struct RepoPickerView: View {
 
             TextField("Search repos...", text: $searchText)
                 .textFieldStyle(.roundedBorder)
+                .focused($focusedField, equals: .search)
+                .onKeyPress(keys: [.tab]) { handleTab($0) }
+                .onChange(of: searchText) { _, _ in
+                    clampHighlight()
+                }
+                .onSubmit { _ = selectHighlighted() }
 
             if filteredRepos.isEmpty {
                 VStack(spacing: 4) {
@@ -28,42 +46,87 @@ struct RepoPickerView: View {
                 }
                 .frame(maxHeight: .infinity)
             } else {
-                List(filteredRepos) { repo in
-                    let isAlready = alreadyAssociatedRepoIDs.contains(repo.id)
-                    Button(action: { if !isAlready { onSelect(repo) } }) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(repo.name)
-                                    .font(.system(size: 13, weight: .medium))
-                                Text(repo.path)
-                                    .font(.system(size: 11))
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                            }
-                            Spacer()
-                            if isAlready {
-                                Text("Added")
-                                    .font(.caption)
-                                    .foregroundStyle(.tertiary)
-                            }
-                        }
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .opacity(isAlready ? 0.5 : 1.0)
-                }
-                .listStyle(.inset)
+                repoList
             }
 
             HStack {
                 Button("Cancel", action: onCancel)
                     .keyboardShortcut(.cancelAction)
+                    .focused($focusedField, equals: .cancel)
+                    .onKeyPress(keys: [.tab]) { handleTab($0) }
                 Spacer()
             }
         }
         .padding(16)
         .frame(width: 360, height: 300)
+        .onAppear {
+            DispatchQueue.main.async {
+                focusedField = .search
+                highlightedRepoID = filteredRepos.first?.id
+            }
+        }
+    }
+
+    private var repoList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(filteredRepos) { repo in
+                        row(for: repo)
+                            .id(repo.id)
+                    }
+                }
+                .padding(4)
+            }
+            .background(Color(NSColor.textBackgroundColor).opacity(0.3))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(Color.secondary.opacity(0.3), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .focusable()
+            .focused($focusedField, equals: .list)
+            .onKeyPress(.upArrow) { moveHighlight(by: -1, proxy: proxy) }
+            .onKeyPress(.downArrow) { moveHighlight(by: 1, proxy: proxy) }
+            .onKeyPress(.return) { selectHighlighted() }
+            .onKeyPress(.space) { selectHighlighted() }
+            .onKeyPress(keys: [.tab]) { handleTab($0) }
+        }
+    }
+
+    @ViewBuilder
+    private func row(for repo: Repo) -> some View {
+        let isAlready = alreadyAssociatedRepoIDs.contains(repo.id)
+        let isHighlighted = focusedField == .list && highlightedRepoID == repo.id
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(repo.name)
+                    .font(.system(size: 13, weight: .medium))
+                Text(repo.path)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            if isAlready {
+                Text("Added")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isHighlighted ? Color.accentColor.opacity(0.25) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .opacity(isAlready ? 0.5 : 1.0)
+        .onTapGesture {
+            if !isAlready { onSelect(repo) }
+        }
     }
 
     private var filteredRepos: IdentifiedArrayOf<Repo> {
@@ -74,5 +137,59 @@ struct RepoPickerView: View {
         return repos.filter {
             $0.name.lowercased().contains(query) || $0.path.lowercased().contains(query)
         }
+    }
+
+    private var visibleFields: [Field] {
+        var fields: [Field] = [.search]
+        if !filteredRepos.isEmpty {
+            fields.append(.list)
+        }
+        fields.append(.cancel)
+        return fields
+    }
+
+    private func handleTab(_ press: KeyPress) -> KeyPress.Result {
+        advanceFocus(by: press.modifiers.contains(.shift) ? -1 : 1)
+    }
+
+    private func advanceFocus(by delta: Int) -> KeyPress.Result {
+        let fields = visibleFields
+        guard let current = focusedField,
+              let idx = fields.firstIndex(of: current) else { return .ignored }
+        let count = fields.count
+        let next = fields[(idx + delta + count) % count]
+        focusedField = next
+        if next == .list, highlightedRepoID == nil {
+            highlightedRepoID = filteredRepos.first?.id
+        }
+        return .handled
+    }
+
+    private func moveHighlight(by delta: Int, proxy: ScrollViewProxy) -> KeyPress.Result {
+        let rows = filteredRepos
+        guard !rows.isEmpty else { return .ignored }
+        let currentIdx = rows.firstIndex(where: { $0.id == highlightedRepoID }) ?? 0
+        let newIdx = min(max(currentIdx + delta, 0), rows.count - 1)
+        let newID = rows[newIdx].id
+        highlightedRepoID = newID
+        withAnimation(.linear(duration: 0.1)) {
+            proxy.scrollTo(newID, anchor: .center)
+        }
+        return .handled
+    }
+
+    private func selectHighlighted() -> KeyPress.Result {
+        guard let id = highlightedRepoID,
+              let repo = filteredRepos[id: id],
+              !alreadyAssociatedRepoIDs.contains(id) else { return .ignored }
+        onSelect(repo)
+        return .handled
+    }
+
+    private func clampHighlight() {
+        if let current = highlightedRepoID, filteredRepos[id: current] != nil {
+            return
+        }
+        highlightedRepoID = filteredRepos.first?.id
     }
 }

--- a/Nex/Features/Workspace/NewWorkspaceSheet.swift
+++ b/Nex/Features/Workspace/NewWorkspaceSheet.swift
@@ -50,6 +50,7 @@ struct NewWorkspaceSheet: View {
                     .textFieldStyle(.roundedBorder)
                     .focused($focusedField, equals: .name)
                     .onSubmit(create)
+                    .onKeyPress(keys: [.tab]) { handleTab($0) }
 
                 HStack(spacing: 8) {
                     ForEach(WorkspaceColor.allCases) { c in
@@ -67,6 +68,7 @@ struct NewWorkspaceSheet: View {
                 .focused($focusedField, equals: .color)
                 .onKeyPress(.leftArrow) { cycleColor(-1) }
                 .onKeyPress(.rightArrow) { cycleColor(1) }
+                .onKeyPress(keys: [.tab]) { handleTab($0) }
 
                 if !store.groups.isEmpty {
                     HStack {
@@ -83,6 +85,7 @@ struct NewWorkspaceSheet: View {
                         .labelsHidden()
                         .pickerStyle(.menu)
                         .focused($focusedField, equals: .group)
+                        .onKeyPress(keys: [.tab]) { handleTab($0) }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -102,14 +105,13 @@ struct NewWorkspaceSheet: View {
                                     Text(repo.name)
                                         .font(.system(size: 12))
                                     Spacer()
-                                    Button(action: {
-                                        selectedRepos.removeAll(where: { $0.id == repo.id })
-                                    }) {
+                                    Button(action: { removeRepo(repo.id) }) {
                                         Image(systemName: "xmark.circle.fill")
                                             .foregroundStyle(.secondary)
                                     }
                                     .buttonStyle(.plain)
                                     .focused($focusedField, equals: .removeRepo(repo.id))
+                                    .onKeyPress(keys: [.tab]) { handleTab($0) }
                                 }
                                 .padding(.vertical, 2)
                             }
@@ -121,6 +123,7 @@ struct NewWorkspaceSheet: View {
                         }
                         .buttonStyle(.borderless)
                         .focused($focusedField, equals: .addRepository)
+                        .onKeyPress(keys: [.tab]) { handleTab($0) }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -131,13 +134,15 @@ struct NewWorkspaceSheet: View {
                     }
                     .keyboardShortcut(.cancelAction)
                     .focused($focusedField, equals: .cancel)
+                    .onKeyPress(keys: [.tab]) { handleTab($0) }
 
                     Spacer()
 
                     Button("Create", action: create)
                         .keyboardShortcut(.defaultAction)
-                        .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                        .disabled(!isCreateEnabled)
                         .focused($focusedField, equals: .create)
+                        .onKeyPress(keys: [.tab]) { handleTab($0) }
                 }
             }
             .padding(20)
@@ -182,6 +187,62 @@ struct NewWorkspaceSheet: View {
         let count = cases.count
         let newIdx = (idx + delta + count) % count
         color = cases[newIdx]
+        return .handled
+    }
+
+    /// macOS's "Keyboard navigation" system setting gates whether Tab reaches
+    /// buttons/pickers. We bypass that by driving focus ourselves from a Tab
+    /// handler on every focusable control in the sheet (#64).
+    ///
+    /// `.create` is omitted while the button is disabled — AppKit refuses to
+    /// make a disabled button first responder, so including it would silently
+    /// break the cycle when the name field is empty.
+    private var visibleFields: [Field] {
+        var fields: [Field] = [.name, .color]
+        if !store.groups.isEmpty {
+            fields.append(.group)
+        }
+        if !store.repoRegistry.isEmpty {
+            fields.append(contentsOf: selectedRepos.map { Field.removeRepo($0.id) })
+            fields.append(.addRepository)
+        }
+        fields.append(.cancel)
+        if isCreateEnabled {
+            fields.append(.create)
+        }
+        return fields
+    }
+
+    private var isCreateEnabled: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    /// Move focus off the row being deleted before mutating the array, so
+    /// `focusedField` never points at a removed case (which would strand the
+    /// tab loop until the user clicked somewhere). Prefer the next row, then
+    /// fall back to the Add Repository button.
+    private func removeRepo(_ id: UUID) {
+        guard let idx = selectedRepos.firstIndex(where: { $0.id == id }) else { return }
+        let wasFocused = focusedField == .removeRepo(id)
+        selectedRepos.remove(at: idx)
+        guard wasFocused else { return }
+        if idx < selectedRepos.count {
+            focusedField = .removeRepo(selectedRepos[idx].id)
+        } else {
+            focusedField = .addRepository
+        }
+    }
+
+    private func handleTab(_ press: KeyPress) -> KeyPress.Result {
+        advanceFocus(by: press.modifiers.contains(.shift) ? -1 : 1)
+    }
+
+    private func advanceFocus(by delta: Int) -> KeyPress.Result {
+        let fields = visibleFields
+        guard let current = focusedField,
+              let idx = fields.firstIndex(of: current) else { return .ignored }
+        let count = fields.count
+        focusedField = fields[(idx + delta + count) % count]
         return .handled
     }
 }

--- a/Nex/Features/Workspace/NewWorkspaceSheet.swift
+++ b/Nex/Features/Workspace/NewWorkspaceSheet.swift
@@ -3,6 +3,14 @@ import SwiftUI
 
 /// Sheet for creating a new workspace with name, color, and optional repo associations.
 struct NewWorkspaceSheet: View {
+    /// Focusable inputs in reading order. Binding each with `.focused(...)`
+    /// gives SwiftUI explicit hops for Tab / Shift+Tab, and lets us land
+    /// initial focus on the name field when the sheet opens (#64).
+    private enum Field: Hashable {
+        case name
+        case group
+    }
+
     let store: StoreOf<AppReducer>
 
     @State private var name = ""
@@ -10,6 +18,7 @@ struct NewWorkspaceSheet: View {
     @State private var selectedRepos: [Repo] = []
     @State private var isRepoPickerPresented = false
     @State private var selectedGroupID: UUID?
+    @FocusState private var focusedField: Field?
 
     init(store: StoreOf<AppReducer>) {
         self.store = store
@@ -33,6 +42,7 @@ struct NewWorkspaceSheet: View {
 
                 TextField("Workspace name", text: $name)
                     .textFieldStyle(.roundedBorder)
+                    .focused($focusedField, equals: .name)
                     .onSubmit(create)
 
                 HStack(spacing: 8) {
@@ -62,6 +72,7 @@ struct NewWorkspaceSheet: View {
                         }
                         .labelsHidden()
                         .pickerStyle(.menu)
+                        .focused($focusedField, equals: .group)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -117,6 +128,12 @@ struct NewWorkspaceSheet: View {
             }
             .padding(20)
             .frame(width: 360)
+            .onAppear {
+                // Dispatching lets the sheet finish presenting before we
+                // steal first responder. Without this, the TextField
+                // sometimes loses focus back to the window on macOS.
+                DispatchQueue.main.async { focusedField = .name }
+            }
             .sheet(isPresented: $isRepoPickerPresented) {
                 RepoPickerView(
                     repos: store.repoRegistry,

--- a/Nex/Features/Workspace/NewWorkspaceSheet.swift
+++ b/Nex/Features/Workspace/NewWorkspaceSheet.swift
@@ -3,12 +3,18 @@ import SwiftUI
 
 /// Sheet for creating a new workspace with name, color, and optional repo associations.
 struct NewWorkspaceSheet: View {
-    /// Focusable inputs in reading order. Binding each with `.focused(...)`
-    /// gives SwiftUI explicit hops for Tab / Shift+Tab, and lets us land
-    /// initial focus on the name field when the sheet opens (#64).
+    /// Focusable controls in reading order. Tab / Shift+Tab hop between these
+    /// via the `.focused(...)` bindings. The color row is a single focus stop
+    /// (arrow keys move the selection within it) so the tab loop mirrors a
+    /// macOS radio group rather than producing one stop per swatch (#64).
     private enum Field: Hashable {
         case name
+        case color
         case group
+        case removeRepo(UUID)
+        case addRepository
+        case cancel
+        case create
     }
 
     let store: StoreOf<AppReducer>
@@ -57,6 +63,10 @@ struct NewWorkspaceSheet: View {
                             .onTapGesture { color = c }
                     }
                 }
+                .focusable()
+                .focused($focusedField, equals: .color)
+                .onKeyPress(.leftArrow) { cycleColor(-1) }
+                .onKeyPress(.rightArrow) { cycleColor(1) }
 
                 if !store.groups.isEmpty {
                     HStack {
@@ -99,6 +109,7 @@ struct NewWorkspaceSheet: View {
                                             .foregroundStyle(.secondary)
                                     }
                                     .buttonStyle(.plain)
+                                    .focused($focusedField, equals: .removeRepo(repo.id))
                                 }
                                 .padding(.vertical, 2)
                             }
@@ -109,6 +120,7 @@ struct NewWorkspaceSheet: View {
                                 .font(.system(size: 12))
                         }
                         .buttonStyle(.borderless)
+                        .focused($focusedField, equals: .addRepository)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -118,12 +130,14 @@ struct NewWorkspaceSheet: View {
                         store.send(.dismissNewWorkspaceSheet)
                     }
                     .keyboardShortcut(.cancelAction)
+                    .focused($focusedField, equals: .cancel)
 
                     Spacer()
 
                     Button("Create", action: create)
                         .keyboardShortcut(.defaultAction)
                         .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                        .focused($focusedField, equals: .create)
                 }
             }
             .padding(20)
@@ -160,5 +174,14 @@ struct NewWorkspaceSheet: View {
             repos: selectedRepos,
             groupID: selectedGroupID
         ))
+    }
+
+    private func cycleColor(_ delta: Int) -> KeyPress.Result {
+        let cases = WorkspaceColor.allCases
+        guard let idx = cases.firstIndex(of: color) else { return .ignored }
+        let count = cases.count
+        let newIdx = (idx + delta + count) % count
+        color = cases[newIdx]
+        return .handled
     }
 }


### PR DESCRIPTION
## Summary

- Adds `@FocusState` wiring across every interactive control in `NewWorkspaceSheet` so Tab / Shift+Tab cycle in natural reading order: name → color → group → per-repo remove → add-repo → cancel → create
- First field (name) receives focus on appear

Fixes #64.

## Test plan

- [ ] Open "New Workspace", first field (Name) is focused automatically
- [ ] Tab cycles forward through name → color → group → repo list → add-repo → cancel → create
- [ ] Shift+Tab cycles backward through the same order
- [ ] `make check` green (505 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)