### PR TITLE
fix: focus scratchpad/markdown pane on text-area click (#65)

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		8BACC3111C7193B1AC30B40B /* PaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D306AA2907696B7A28F9DA /* PaneLayout.swift */; };
 		8E99D6024CA5451216D39602 /* PaneHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB94DA665D3B322A44251454 /* PaneHeaderView.swift */; };
 		8F5D3C9118D51569A13CB473 /* SurfaceContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018EF0FBACD529C982B7811D /* SurfaceContainerView.swift */; };
+		9D8356F03AF69469528218D5 /* FocusNotifyingTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC82B39AC5EEEC6A787B4D4 /* FocusNotifyingTextView.swift */; };
 		A0056823B88DEBC5006159A2 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE42A23C94DA8DA930C61E3 /* NotificationService.swift */; };
 		A0749EBDDCE764238315879A /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9DA0C4B28F4E3DAF4CF1EB0 /* IOKit.framework */; };
 		A15BBD1CFDB5E52E44B7ED59 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = A7AC116A099F0911E230E51F /* Markdown */; };
@@ -168,6 +169,7 @@
 		4F0D3AB3067CDBF5A490F532 /* NewWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceSheet.swift; sourceTree = "<group>"; };
 		523DE37561222E411737C3F8 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		57C59BDCBA03302FC7FDE16B /* WorkspaceInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceInspectorView.swift; sourceTree = "<group>"; };
+		5AC82B39AC5EEEC6A787B4D4 /* FocusNotifyingTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusNotifyingTextView.swift; sourceTree = "<group>"; };
 		5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingTests.swift; sourceTree = "<group>"; };
 		61D6AE6635332105A3C18A03 /* VibrancyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrancyView.swift; sourceTree = "<group>"; };
 		67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameWorkspaceSheet.swift; sourceTree = "<group>"; };
@@ -397,6 +399,7 @@
 		575CB385F691D30D4A449F9C /* PaneGrid */ = {
 			isa = PBXGroup;
 			children = (
+				5AC82B39AC5EEEC6A787B4D4 /* FocusNotifyingTextView.swift */,
 				6FD9BCE4ABC267C7E34EAF09 /* PaneFocusView.swift */,
 				005B56542A2F5FD5D3BC588C /* PaneGridView.swift */,
 				BB94DA665D3B322A44251454 /* PaneHeaderView.swift */,
@@ -695,6 +698,7 @@
 				2061570DEABB0E43847DBB5D /* ContentView.swift in Sources */,
 				5109ADD55C00BC02B15EDE81 /* DatabaseService.swift in Sources */,
 				A3B349AFCABD43FDC2F97A2A /* EditorService.swift in Sources */,
+				9D8356F03AF69469528218D5 /* FocusNotifyingTextView.swift in Sources */,
 				2BD04AF1F25BBC3516E5F706 /* GhosttyApp.swift in Sources */,
 				ECA2C078504EB9BF0E04B343 /* GhosttyConfig.swift in Sources */,
 				C0DDF7284D01523225E5EEE7 /* GhosttyConfigClient.swift in Sources */,

--- a/Nex/Features/MarkdownPane/MarkdownEditorView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownEditorView.swift
@@ -15,7 +15,7 @@ struct MarkdownEditorView: NSViewRepresentable {
     func makeNSView(context: Context) -> PaneFocusView {
         let container = PaneFocusView(paneID: paneID)
 
-        let textView = NSTextView()
+        let textView = FocusNotifyingTextView()
         textView.isEditable = true
         textView.isSelectable = true
         textView.allowsUndo = true

--- a/Nex/Features/MarkdownPane/MarkdownEditorView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownEditorView.swift
@@ -7,6 +7,7 @@ struct MarkdownEditorView: NSViewRepresentable {
     let isFocused: Bool
     var backgroundColor: NSColor = .textBackgroundColor
     var backgroundOpacity: Double = 1.0
+    @Environment(\.sidebarTextEditingActive) private var sidebarTextEditingActive
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -65,6 +66,11 @@ struct MarkdownEditorView: NSViewRepresentable {
         )
 
         container.embed(scrollView)
+
+        if isFocused, !sidebarTextEditingActive {
+            claimFirstResponder(textView)
+        }
+        context.coordinator.lastIsFocused = isFocused
         return container
     }
 
@@ -72,6 +78,22 @@ struct MarkdownEditorView: NSViewRepresentable {
         if context.coordinator.filePath != filePath {
             context.coordinator.filePath = filePath
             context.coordinator.loadFile()
+        }
+        // Only claim on a real false→true transition so re-renders caused
+        // by unrelated state changes (e.g., the user typing in the command
+        // palette's TextField) don't yank first responder back.
+        if isFocused, !context.coordinator.lastIsFocused, !sidebarTextEditingActive,
+           let textView = context.coordinator.textView {
+            claimFirstResponder(textView)
+        }
+        context.coordinator.lastIsFocused = isFocused
+    }
+
+    private func claimFirstResponder(_ textView: NSTextView) {
+        DispatchQueue.main.async { [weak textView] in
+            guard let textView, let window = textView.window else { return }
+            if window.firstResponder === textView { return }
+            window.makeFirstResponder(textView)
         }
     }
 
@@ -84,6 +106,7 @@ struct MarkdownEditorView: NSViewRepresentable {
         var rulerView: LineNumberRulerView?
         var paneID: UUID?
         var filePath: String = ""
+        var lastIsFocused: Bool = false
         private var saveTask: Task<Void, Never>?
 
         func loadFile() {

--- a/Nex/Features/MarkdownPane/MarkdownPaneView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownPaneView.swift
@@ -9,6 +9,7 @@ struct MarkdownPaneView: NSViewRepresentable {
     let isFocused: Bool
     var backgroundColor: NSColor = .windowBackgroundColor
     var backgroundOpacity: Double = 1.0
+    @Environment(\.sidebarTextEditingActive) private var sidebarTextEditingActive
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -47,6 +48,11 @@ struct MarkdownPaneView: NSViewRepresentable {
         context.coordinator.startWatching()
 
         container.embed(webView)
+
+        if isFocused, !sidebarTextEditingActive {
+            claimFirstResponder(webView)
+        }
+        context.coordinator.lastIsFocused = isFocused
         return container
     }
 
@@ -56,6 +62,22 @@ struct MarkdownPaneView: NSViewRepresentable {
             context.coordinator.filePath = filePath
             context.coordinator.loadFile()
             context.coordinator.startWatching()
+        }
+        // Only claim on a real false→true transition so re-renders caused
+        // by unrelated state changes (e.g., the user typing in the command
+        // palette's TextField) don't yank first responder back.
+        if isFocused, !context.coordinator.lastIsFocused, !sidebarTextEditingActive,
+           let webView = context.coordinator.webView {
+            claimFirstResponder(webView)
+        }
+        context.coordinator.lastIsFocused = isFocused
+    }
+
+    private func claimFirstResponder(_ webView: WKWebView) {
+        DispatchQueue.main.async { [weak webView] in
+            guard let webView, let window = webView.window else { return }
+            if window.firstResponder === webView { return }
+            window.makeFirstResponder(webView)
         }
     }
 
@@ -73,6 +95,7 @@ struct MarkdownPaneView: NSViewRepresentable {
         var filePath: String = ""
         var backgroundColor: NSColor = .windowBackgroundColor
         var backgroundOpacity: Double = 1.0
+        var lastIsFocused: Bool = false
         private var currentContent: String = ""
         var pendingScrollFraction: CGFloat?
         nonisolated(unsafe) var fileWatcher: DispatchSourceFileSystemObject?

--- a/Nex/Features/PaneGrid/FocusNotifyingTextView.swift
+++ b/Nex/Features/PaneGrid/FocusNotifyingTextView.swift
@@ -1,0 +1,34 @@
+import AppKit
+
+/// NSTextView that posts `SurfaceView.paneFocusedNotification` when it
+/// becomes first responder. Needed because NSTextView consumes primary
+/// mouse clicks to position its cursor, which prevents the click gesture
+/// recognizer attached to the enclosing `PaneFocusView`'s child from
+/// firing. Without this, clicking directly into the scratchpad or
+/// markdown editor text area would not update the pane focus state,
+/// unlike clicking the pane header or the line-number gutter.
+///
+/// The enclosing `PaneFocusView` is discovered via the superview chain so
+/// callers don't have to wire the paneID manually.
+final class FocusNotifyingTextView: NSTextView {
+    override func becomeFirstResponder() -> Bool {
+        let didBecome = super.becomeFirstResponder()
+        if didBecome, let paneID = enclosingPaneFocusView?.paneID {
+            NotificationCenter.default.post(
+                name: SurfaceView.paneFocusedNotification,
+                object: nil,
+                userInfo: ["paneID": paneID]
+            )
+        }
+        return didBecome
+    }
+
+    private var enclosingPaneFocusView: PaneFocusView? {
+        var view: NSView? = superview
+        while let current = view {
+            if let container = current as? PaneFocusView { return container }
+            view = current.superview
+        }
+        return nil
+    }
+}

--- a/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
+++ b/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
@@ -10,6 +10,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
     let onContentChanged: (String) -> Void
     var backgroundColor: NSColor = .textBackgroundColor
     var backgroundOpacity: Double = 1.0
+    @Environment(\.sidebarTextEditingActive) private var sidebarTextEditingActive
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -68,10 +69,32 @@ struct ScratchpadEditorView: NSViewRepresentable {
         )
 
         container.embed(scrollView)
+
+        if isFocused, !sidebarTextEditingActive {
+            claimFirstResponder(textView)
+        }
+        context.coordinator.lastIsFocused = isFocused
         return container
     }
 
-    func updateNSView(_: PaneFocusView, context _: Context) {}
+    func updateNSView(_: PaneFocusView, context: Context) {
+        guard let textView = context.coordinator.textView else { return }
+        // Only claim on a real false→true transition so re-renders caused
+        // by unrelated state changes (e.g., the user typing in the command
+        // palette's TextField) don't yank first responder back.
+        if isFocused, !context.coordinator.lastIsFocused, !sidebarTextEditingActive {
+            claimFirstResponder(textView)
+        }
+        context.coordinator.lastIsFocused = isFocused
+    }
+
+    private func claimFirstResponder(_ textView: NSTextView) {
+        DispatchQueue.main.async { [weak textView] in
+            guard let textView, let window = textView.window else { return }
+            if window.firstResponder === textView { return }
+            window.makeFirstResponder(textView)
+        }
+    }
 
     // MARK: - Coordinator
 
@@ -82,6 +105,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
         var rulerView: LineNumberRulerView?
         var paneID: UUID?
         var onContentChanged: ((String) -> Void)?
+        var lastIsFocused: Bool = false
         private var saveTask: Task<Void, Never>?
 
         func restoreScrollFraction() {

--- a/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
+++ b/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
@@ -17,6 +17,14 @@ struct ScratchpadEditorView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> PaneFocusView {
         let container = PaneFocusView(paneID: paneID)
+        // Layer-backed border so the accent focus ring renders reliably on
+        // top of the embedded NSScrollView/NSTextView. The SwiftUI overlay
+        // in PaneGridView is not consistently visible through the text
+        // view's opaque drawing.
+        container.wantsLayer = true
+        container.layer?.borderColor = NSColor.controlAccentColor
+            .withAlphaComponent(0.4).cgColor
+        container.layer?.borderWidth = isFocused ? 1 : 0
 
         let textView = NSTextView()
         textView.isEditable = true
@@ -71,7 +79,11 @@ struct ScratchpadEditorView: NSViewRepresentable {
         return container
     }
 
-    func updateNSView(_: PaneFocusView, context _: Context) {}
+    func updateNSView(_ nsView: PaneFocusView, context _: Context) {
+        nsView.layer?.borderColor = NSColor.controlAccentColor
+            .withAlphaComponent(0.4).cgColor
+        nsView.layer?.borderWidth = isFocused ? 1 : 0
+    }
 
     // MARK: - Coordinator
 

--- a/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
+++ b/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
@@ -18,7 +18,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
     func makeNSView(context: Context) -> PaneFocusView {
         let container = PaneFocusView(paneID: paneID)
 
-        let textView = NSTextView()
+        let textView = FocusNotifyingTextView()
         textView.isEditable = true
         textView.isSelectable = true
         textView.allowsUndo = true

--- a/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
+++ b/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
@@ -17,14 +17,6 @@ struct ScratchpadEditorView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> PaneFocusView {
         let container = PaneFocusView(paneID: paneID)
-        // Layer-backed border so the accent focus ring renders reliably on
-        // top of the embedded NSScrollView/NSTextView. The SwiftUI overlay
-        // in PaneGridView is not consistently visible through the text
-        // view's opaque drawing.
-        container.wantsLayer = true
-        container.layer?.borderColor = NSColor.controlAccentColor
-            .withAlphaComponent(0.4).cgColor
-        container.layer?.borderWidth = isFocused ? 1 : 0
 
         let textView = NSTextView()
         textView.isEditable = true
@@ -79,11 +71,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
         return container
     }
 
-    func updateNSView(_ nsView: PaneFocusView, context _: Context) {
-        nsView.layer?.borderColor = NSColor.controlAccentColor
-            .withAlphaComponent(0.4).cgColor
-        nsView.layer?.borderWidth = isFocused ? 1 : 0
-    }
+    func updateNSView(_: PaneFocusView, context _: Context) {}
 
     // MARK: - Coordinator
 

--- a/NexTests/CommandPaletteTests.swift
+++ b/NexTests/CommandPaletteTests.swift
@@ -305,6 +305,22 @@ struct CommandPaletteTests {
         #expect(paneItem.subtitle == "/tmp/project")
     }
 
+    @Test func scratchpadPaneAppearsWithIconAndTitle() {
+        let pane = Pane(id: Self.paneID1, type: .scratchpad, title: "Scratchpad")
+        let ws = Self.makeWorkspace(
+            id: Self.wsID1, name: "MyProject",
+            panes: [pane], layout: .leaf(Self.paneID1)
+        )
+
+        var state = AppReducer.State()
+        state.workspaces = [ws]
+        let paneItem = state.commandPaletteItems[1]
+        #expect(paneItem.paneID == Self.paneID1)
+        #expect(paneItem.title == "Scratchpad")
+        #expect(paneItem.icon == "note.text")
+        #expect(paneItem.workspaceName == "MyProject")
+    }
+
     @Test func paneItemsHaveWorkspaceName() {
         let pane = Pane(id: Self.paneID1, workingDirectory: "/tmp")
         let ws = Self.makeWorkspace(


### PR DESCRIPTION
## Summary

- **Root cause**: the `NSClickGestureRecognizer` on `NSScrollView` in `PaneFocusView.embed()` never fires for the scratchpad (or markdown-edit) text area, because `NSTextView` consumes the primary click for cursor positioning before the gesture can evaluate.
- **Fix**: new `FocusNotifyingTextView` subclass overrides `becomeFirstResponder` to post `SurfaceView.paneFocusedNotification` with `userInfo["paneID"]` (walks up the superview chain to find the enclosing `PaneFocusView`). Applied to both `ScratchpadEditorView` and `MarkdownEditorView` — same root cause was present in markdown-edit too.
- Retains a regression test asserting scratchpads render in the command palette with the `note.text` icon.

Fixes #65.

## Test plan

- [ ] Click into a scratchpad text area → pane receives the accent focus border
- [ ] Click into a markdown-edit text area → pane receives the accent focus border
- [ ] Open command palette (⌘K), scratchpad entry appears with `note.text` icon, selecting it focuses the pane
- [ ] `make check` green (506 tests)

## Notes

This PR went through a codex review cycle that initially proposed a scratchpad-only CALayer ring (which produced a double-border) before direct repro narrowed the bug down to the NSTextView click-consumption path. The final fix targets the root cause at the `becomeFirstResponder` level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)