### PR TITLE
feat: option for new groups at end of workspace list (#58)

### DIFF
--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -64,11 +64,31 @@ struct AppReducer {
         /// group's entry when nested. `nil` when there's no active
         /// workspace or it isn't yet in the sidebar.
         var activeWorkspaceSidebarAnchor: SidebarID? {
-            guard let activeID = activeWorkspaceID else { return nil }
-            if topLevelOrder.contains(.workspace(activeID)) {
-                return .workspace(activeID)
+            sidebarAnchor(for: activeWorkspaceID)
+        }
+
+        /// Anchor used by `.nearSelection` group placement. Prefers the
+        /// first workspace being folded into the new group (so a row-level
+        /// "New Group..." on a non-active workspace lands next to that
+        /// row, not next to the previously active workspace). Falls back
+        /// to the active workspace for the empty-group flow.
+        func nearSelectionAnchor(for initialWorkspaceIDs: [UUID]) -> SidebarID? {
+            if let firstInitial = initialWorkspaceIDs.first,
+               let anchor = sidebarAnchor(for: firstInitial) {
+                return anchor
             }
-            for group in groups where group.childOrder.contains(activeID) {
+            return activeWorkspaceSidebarAnchor
+        }
+
+        /// Resolve a workspace ID to its sidebar entry: the workspace's
+        /// own top-level entry when it's top-level, its parent group's
+        /// entry when nested, or `nil` if the workspace isn't placed yet.
+        private func sidebarAnchor(for workspaceID: UUID?) -> SidebarID? {
+            guard let workspaceID else { return nil }
+            if topLevelOrder.contains(.workspace(workspaceID)) {
+                return .workspace(workspaceID)
+            }
+            for group in groups where group.childOrder.contains(workspaceID) {
                 return .group(group.id)
             }
             return nil
@@ -1069,11 +1089,14 @@ struct AppReducer {
                     validInitial.append(id)
                 }
 
-                // Resolve the insertion anchor before any mutations. When the
-                // caller specifies an explicit anchor, use it. Otherwise fall
-                // back to the `newGroupPlacement` setting: `.nearSelection`
-                // anchors off the active workspace (or its parent group),
-                // `.endOfList` always appends.
+                // Resolve the insertion anchor before any mutations. When
+                // the caller specifies an explicit anchor, use it. Otherwise
+                // fall back to the `newGroupPlacement` setting:
+                //   - `.endOfList` always appends.
+                //   - `.nearSelection` prefers the first `initialWorkspaceIDs`
+                //     entry (the row the action was launched from in the
+                //     workspace-row "New Group..." flow) and only falls back
+                //     to the active workspace for the empty-group flow.
                 let resolvedInsertAfter: SidebarID? = if let insertAfter {
                     insertAfter
                 } else {
@@ -1081,9 +1104,31 @@ struct AppReducer {
                     case .endOfList:
                         nil
                     case .nearSelection:
-                        state.activeWorkspaceSidebarAnchor
+                        state.nearSelectionAnchor(for: validInitial)
                     }
                 }
+
+                // Capture the anchor's position and whether it will be
+                // detached *before* mutating `topLevelOrder`, so the new
+                // group can slot into the spot the row occupied even when
+                // that row is about to be folded into the new group.
+                let anchorIndexBefore: Int? =
+                    resolvedInsertAfter.flatMap { state.topLevelOrder.firstIndex(of: $0) }
+                let anchorWillBeDetached: Bool = {
+                    guard case .workspace(let id) = resolvedInsertAfter else { return false }
+                    return validInitial.contains(id)
+                }()
+                let removedBeforeAnchor: Int = {
+                    guard let anchorIdx = anchorIndexBefore, !validInitial.isEmpty else { return 0 }
+                    let moved = Set(validInitial)
+                    var count = 0
+                    for i in 0 ..< anchorIdx {
+                        if case .workspace(let id) = state.topLevelOrder[i], moved.contains(id) {
+                            count += 1
+                        }
+                    }
+                    return count
+                }()
 
                 let newGroup = WorkspaceGroup(
                     id: uuid(),
@@ -1109,8 +1154,15 @@ struct AppReducer {
 
                 // Insertion position in `topLevelOrder`.
                 let newEntry: SidebarID = .group(newGroup.id)
-                if let anchor = resolvedInsertAfter, let idx = state.topLevelOrder.firstIndex(of: anchor) {
-                    state.topLevelOrder.insert(newEntry, at: idx + 1)
+                if let anchorIdx = anchorIndexBefore {
+                    // Adjust for removals that were strictly before the anchor.
+                    let adjusted = anchorIdx - removedBeforeAnchor
+                    // If the anchor itself was removed (it was the workspace
+                    // being grouped), its slot is now free and becomes the
+                    // insertion point. Otherwise insert right after the anchor.
+                    let target = anchorWillBeDetached ? adjusted : adjusted + 1
+                    let bounded = max(0, min(target, state.topLevelOrder.count))
+                    state.topLevelOrder.insert(newEntry, at: bounded)
                 } else {
                     state.topLevelOrder.append(newEntry)
                 }

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -58,6 +58,22 @@ struct AppReducer {
             return workspaces[id: id]
         }
 
+        /// Sidebar entry that the active workspace occupies, used as an
+        /// insertion anchor for `.nearSelection` group placement. Returns
+        /// the workspace's own entry when it's top-level, or its parent
+        /// group's entry when nested. `nil` when there's no active
+        /// workspace or it isn't yet in the sidebar.
+        var activeWorkspaceSidebarAnchor: SidebarID? {
+            guard let activeID = activeWorkspaceID else { return nil }
+            if topLevelOrder.contains(.workspace(activeID)) {
+                return .workspace(activeID)
+            }
+            for group in groups where group.childOrder.contains(activeID) {
+                return .group(group.id)
+            }
+            return nil
+        }
+
         var commandPaletteItems: [CommandPaletteItem] {
             var items: [CommandPaletteItem] = []
             let home = NSHomeDirectory()
@@ -1053,6 +1069,22 @@ struct AppReducer {
                     validInitial.append(id)
                 }
 
+                // Resolve the insertion anchor before any mutations. When the
+                // caller specifies an explicit anchor, use it. Otherwise fall
+                // back to the `newGroupPlacement` setting: `.nearSelection`
+                // anchors off the active workspace (or its parent group),
+                // `.endOfList` always appends.
+                let resolvedInsertAfter: SidebarID? = if let insertAfter {
+                    insertAfter
+                } else {
+                    switch state.settings.newGroupPlacement {
+                    case .endOfList:
+                        nil
+                    case .nearSelection:
+                        state.activeWorkspaceSidebarAnchor
+                    }
+                }
+
                 let newGroup = WorkspaceGroup(
                     id: uuid(),
                     name: trimmed,
@@ -1077,7 +1109,7 @@ struct AppReducer {
 
                 // Insertion position in `topLevelOrder`.
                 let newEntry: SidebarID = .group(newGroup.id)
-                if let insertAfter, let idx = state.topLevelOrder.firstIndex(of: insertAfter) {
+                if let anchor = resolvedInsertAfter, let idx = state.topLevelOrder.firstIndex(of: anchor) {
                     state.topLevelOrder.insert(newEntry, at: idx + 1)
                 } else {
                     state.topLevelOrder.append(newEntry)

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -518,6 +518,10 @@ struct AppReducer {
         if let path {
             seeded.panes[seeded.panes.startIndex].workingDirectory = path
         }
+        // Capture the anchor for `.nearSelection` BEFORE overwriting
+        // `activeWorkspaceID` — the previously active workspace is what
+        // we want the new one to land next to within the target group.
+        let previousActiveID = state.activeWorkspaceID
         state.workspaces.append(seeded)
         state.topLevelOrder.append(.workspace(newWorkspaceID))
         state.activeWorkspaceID = newWorkspaceID
@@ -532,6 +536,27 @@ struct AppReducer {
             state.topLevelOrder.append(.group(newGroup.id))
             targetGroupID = newGroup.id
         }
+
+        // Mirror the `createWorkspace` + groupID path: honor the
+        // `newWorkspacePlacement` setting when picking the slot in
+        // the target group's childOrder. `.endOfList` appends (nil),
+        // `.nearSelection` inserts right after the previously-active
+        // workspace's slot when it's in the same group. A freshly
+        // created group has an empty childOrder, so both modes land
+        // on append for the "new group" branch above.
+        let targetIndex: Int? = {
+            switch state.settings.newWorkspacePlacement {
+            case .endOfList:
+                return nil
+            case .nearSelection:
+                guard let previousActiveID,
+                      let idx = state.groups[id: targetGroupID]?.childOrder.firstIndex(of: previousActiveID)
+                else {
+                    return nil
+                }
+                return idx + 1
+            }
+        }()
 
         // Create the initial surface for the workspace, then move it
         // under the resolved group, then persist. Mirrors the
@@ -553,7 +578,7 @@ struct AppReducer {
             .send(.moveWorkspaceToGroup(
                 workspaceID: newWorkspaceID,
                 groupID: targetGroupID,
-                index: nil
+                index: targetIndex
             ))
         )
     }
@@ -755,17 +780,30 @@ struct AppReducer {
                 }
 
                 state.workspaces.append(workspace)
-                // Place into the target group if one was supplied and exists, adjacent to the
-                // previously-active workspace when that workspace is part of the same group.
-                // Fall back to top-level append when the group is missing (defensive).
+                // Place into the target group if one was supplied and exists.
+                // Placement within the group (or at top level when no group is
+                // supplied) follows the `newWorkspacePlacement` setting:
+                //   - `.endOfList` always appends.
+                //   - `.nearSelection` inserts after the previously-active
+                //     workspace's slot (its entry in the group's childOrder,
+                //     or its top-level sidebar anchor when ungrouped).
+                // Fall back to top-level append when the supplied group is
+                // missing (defensive).
+                let placement = state.settings.newWorkspacePlacement
                 if let groupID, state.groups[id: groupID] != nil {
                     let insertIndex: Int = {
-                        guard let previousActiveID,
-                              let idx = state.groups[id: groupID]?.childOrder.firstIndex(of: previousActiveID)
-                        else {
-                            return state.groups[id: groupID]?.childOrder.count ?? 0
+                        let count = state.groups[id: groupID]?.childOrder.count ?? 0
+                        switch placement {
+                        case .endOfList:
+                            return count
+                        case .nearSelection:
+                            guard let previousActiveID,
+                                  let idx = state.groups[id: groupID]?.childOrder.firstIndex(of: previousActiveID)
+                            else {
+                                return count
+                            }
+                            return idx + 1
                         }
-                        return idx + 1
                     }()
                     state.groups[id: groupID]?.childOrder.insert(workspace.id, at: insertIndex)
                     // Match the .setActiveWorkspace behavior: expand the parent
@@ -775,7 +813,17 @@ struct AppReducer {
                         state.groups[id: groupID]?.isCollapsed = false
                     }
                 } else {
-                    state.topLevelOrder.append(.workspace(workspace.id))
+                    switch placement {
+                    case .endOfList:
+                        state.topLevelOrder.append(.workspace(workspace.id))
+                    case .nearSelection:
+                        if let anchor = state.activeWorkspaceSidebarAnchor,
+                           let idx = state.topLevelOrder.firstIndex(of: anchor) {
+                            state.topLevelOrder.insert(.workspace(workspace.id), at: idx + 1)
+                        } else {
+                            state.topLevelOrder.append(.workspace(workspace.id))
+                        }
+                    }
                 }
                 state.activeWorkspaceID = workspace.id
                 state.isNewWorkspaceSheetPresented = false

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -2,14 +2,17 @@ import AppKit
 import ComposableArchitecture
 import Foundation
 
-/// Controls where a newly created workspace group is inserted in the sidebar.
-enum NewGroupPlacement: String, CaseIterable, Codable, Equatable {
-    /// Insert the new group after the active workspace's top-level entry
-    /// (or its parent group when nested). Falls back to appending if
-    /// there's no active workspace. This is the default.
+/// Controls where a newly created sidebar entry (group or workspace) is
+/// inserted. Used by both `newGroupPlacement` and `newWorkspacePlacement`.
+enum SidebarPlacement: String, CaseIterable, Codable, Equatable {
+    /// Insert near the active workspace: at the top level, after its
+    /// sidebar entry (or its parent group's entry when nested); inside a
+    /// group, after the active workspace's slot in that group's children.
+    /// Falls back to appending when there's no active workspace.
     case nearSelection = "near-selection"
 
-    /// Always append the new group to the end of the sidebar list.
+    /// Always append to the end of the list (or the end of the target
+    /// group's children). This is the default.
     case endOfList = "end-of-list"
 }
 
@@ -28,7 +31,8 @@ struct SettingsFeature {
         var autoDetectRepos: Bool = true
         var inheritGroupOnNewWorkspace: Bool = true
         var expandGroupOnWorkspaceDrop: Bool = true
-        var newGroupPlacement: NewGroupPlacement = .nearSelection
+        var newGroupPlacement: SidebarPlacement = .endOfList
+        var newWorkspacePlacement: SidebarPlacement = .endOfList
 
         /// The resolved absolute worktree base path. Expands ~ and substitutes
         /// the `<repo>` placeholder:
@@ -55,7 +59,8 @@ struct SettingsFeature {
         case setAutoDetectRepos(Bool)
         case setInheritGroupOnNewWorkspace(Bool)
         case setExpandGroupOnWorkspaceDrop(Bool)
-        case setNewGroupPlacement(NewGroupPlacement)
+        case setNewGroupPlacement(SidebarPlacement)
+        case setNewWorkspacePlacement(SidebarPlacement)
         case selectTheme(NexTheme?)
         case applyAppearance(opacity: Double, r: Double, g: Double, b: Double, theme: NexTheme?)
     }
@@ -73,6 +78,7 @@ struct SettingsFeature {
     static let defaultsKeyInheritGroupOnNewWorkspace = "settings.inheritGroupOnNewWorkspace"
     static let defaultsKeyExpandGroupOnWorkspaceDrop = "settings.expandGroupOnWorkspaceDrop"
     static let defaultsKeyNewGroupPlacement = "settings.newGroupPlacement"
+    static let defaultsKeyNewWorkspacePlacement = "settings.newWorkspacePlacement"
 
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.userDefaults) var userDefaults
@@ -97,8 +103,12 @@ struct SettingsFeature {
                     state.expandGroupOnWorkspaceDrop = userDefaults.boolForKey(Self.defaultsKeyExpandGroupOnWorkspaceDrop)
                 }
                 if let raw = userDefaults.stringForKey(Self.defaultsKeyNewGroupPlacement),
-                   let placement = NewGroupPlacement(rawValue: raw) {
+                   let placement = SidebarPlacement(rawValue: raw) {
                     state.newGroupPlacement = placement
+                }
+                if let raw = userDefaults.stringForKey(Self.defaultsKeyNewWorkspacePlacement),
+                   let placement = SidebarPlacement(rawValue: raw) {
+                    state.newWorkspacePlacement = placement
                 }
                 if userDefaults.boolForKey(Self.defaultsKeyHasCustomColor) {
                     state.backgroundColorR = userDefaults.doubleForKey(Self.defaultsKeyColorR)
@@ -172,6 +182,11 @@ struct SettingsFeature {
             case .setNewGroupPlacement(let placement):
                 state.newGroupPlacement = placement
                 userDefaults.setString(placement.rawValue, Self.defaultsKeyNewGroupPlacement)
+                return .none
+
+            case .setNewWorkspacePlacement(let placement):
+                state.newWorkspacePlacement = placement
+                userDefaults.setString(placement.rawValue, Self.defaultsKeyNewWorkspacePlacement)
                 return .none
 
             case .selectTheme(let theme):

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -2,6 +2,17 @@ import AppKit
 import ComposableArchitecture
 import Foundation
 
+/// Controls where a newly created workspace group is inserted in the sidebar.
+enum NewGroupPlacement: String, CaseIterable, Codable, Equatable {
+    /// Insert the new group after the active workspace's top-level entry
+    /// (or its parent group when nested). Falls back to appending if
+    /// there's no active workspace. This is the default.
+    case nearSelection = "near-selection"
+
+    /// Always append the new group to the end of the sidebar list.
+    case endOfList = "end-of-list"
+}
+
 @Reducer
 struct SettingsFeature {
     static let defaultWorktreeBasePath = "~/nex/worktrees/<repo>"
@@ -17,6 +28,7 @@ struct SettingsFeature {
         var autoDetectRepos: Bool = true
         var inheritGroupOnNewWorkspace: Bool = true
         var expandGroupOnWorkspaceDrop: Bool = true
+        var newGroupPlacement: NewGroupPlacement = .nearSelection
 
         /// The resolved absolute worktree base path. Expands ~ and substitutes
         /// the `<repo>` placeholder:
@@ -43,6 +55,7 @@ struct SettingsFeature {
         case setAutoDetectRepos(Bool)
         case setInheritGroupOnNewWorkspace(Bool)
         case setExpandGroupOnWorkspaceDrop(Bool)
+        case setNewGroupPlacement(NewGroupPlacement)
         case selectTheme(NexTheme?)
         case applyAppearance(opacity: Double, r: Double, g: Double, b: Double, theme: NexTheme?)
     }
@@ -59,6 +72,7 @@ struct SettingsFeature {
     static let defaultsKeyAutoDetectRepos = "settings.autoDetectRepos"
     static let defaultsKeyInheritGroupOnNewWorkspace = "settings.inheritGroupOnNewWorkspace"
     static let defaultsKeyExpandGroupOnWorkspaceDrop = "settings.expandGroupOnWorkspaceDrop"
+    static let defaultsKeyNewGroupPlacement = "settings.newGroupPlacement"
 
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.userDefaults) var userDefaults
@@ -81,6 +95,10 @@ struct SettingsFeature {
                 }
                 if userDefaults.hasKey(Self.defaultsKeyExpandGroupOnWorkspaceDrop) {
                     state.expandGroupOnWorkspaceDrop = userDefaults.boolForKey(Self.defaultsKeyExpandGroupOnWorkspaceDrop)
+                }
+                if let raw = userDefaults.stringForKey(Self.defaultsKeyNewGroupPlacement),
+                   let placement = NewGroupPlacement(rawValue: raw) {
+                    state.newGroupPlacement = placement
                 }
                 if userDefaults.boolForKey(Self.defaultsKeyHasCustomColor) {
                     state.backgroundColorR = userDefaults.doubleForKey(Self.defaultsKeyColorR)
@@ -149,6 +167,11 @@ struct SettingsFeature {
             case .setExpandGroupOnWorkspaceDrop(let enabled):
                 state.expandGroupOnWorkspaceDrop = enabled
                 userDefaults.setBool(enabled, Self.defaultsKeyExpandGroupOnWorkspaceDrop)
+                return .none
+
+            case .setNewGroupPlacement(let placement):
+                state.newGroupPlacement = placement
+                userDefaults.setString(placement.rawValue, Self.defaultsKeyNewGroupPlacement)
                 return .none
 
             case .selectTheme(let theme):

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -102,6 +102,17 @@ private struct GeneralSettingsView: View {
                     Text("When dragging a workspace into a collapsed group, expand the group on drop so the moved workspace is visible. Disable to keep the group collapsed and avoid disrupting the sidebar layout.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    Picker("New group placement", selection: Binding(
+                        get: { settingsStore.newGroupPlacement },
+                        set: { settingsStore.send(.setNewGroupPlacement($0)) }
+                    )) {
+                        Text("Next to selection").tag(NewGroupPlacement.nearSelection)
+                        Text("End of list").tag(NewGroupPlacement.endOfList)
+                    }
+                    Text("Where a newly created group is inserted in the sidebar. \"Next to selection\" places it after the active workspace (or its parent group when nested). \"End of list\" always appends it to the bottom.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 Section("Panes") {

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -103,12 +103,23 @@ private struct GeneralSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
+                    Picker("New workspace placement", selection: Binding(
+                        get: { settingsStore.newWorkspacePlacement },
+                        set: { settingsStore.send(.setNewWorkspacePlacement($0)) }
+                    )) {
+                        Text("Next to selection").tag(SidebarPlacement.nearSelection)
+                        Text("End of list").tag(SidebarPlacement.endOfList)
+                    }
+                    Text("Where a newly created workspace is inserted. \"Next to selection\" places it immediately after the active workspace's slot (within the target group when creating into one, falling back to append when the active workspace isn't in that group). \"End of list\" always appends to the bottom of the sidebar (or the end of the target group).")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
                     Picker("New group placement", selection: Binding(
                         get: { settingsStore.newGroupPlacement },
                         set: { settingsStore.send(.setNewGroupPlacement($0)) }
                     )) {
-                        Text("Next to selection").tag(NewGroupPlacement.nearSelection)
-                        Text("End of list").tag(NewGroupPlacement.endOfList)
+                        Text("Next to selection").tag(SidebarPlacement.nearSelection)
+                        Text("End of list").tag(SidebarPlacement.endOfList)
                     }
                     Text("Where a newly created group is inserted in the sidebar. \"Next to selection\" places it after the active workspace (or its parent group when nested). \"End of list\" always appends it to the bottom.")
                         .font(.caption)

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -106,10 +106,10 @@ struct AppReducerTests {
         }
     }
 
-    @Test func createWorkspaceWithGroupIDInsertsAdjacentToActive() async {
+    @Test func createWorkspaceWithGroupIDPlacesInGroupChildOrder() async {
         // Seed a group containing wsID1 (active). Creating a new workspace with
-        // that group's ID should place the new workspace right after wsID1 in
-        // the group's childOrder, NOT in topLevelOrder.
+        // that group's ID should add it to the group's childOrder (not to
+        // topLevelOrder). Default placement appends to the end of the group.
         let existing = Self.makeWorkspace(id: Self.wsID1, name: "Existing", paneID: Self.paneID1)
         let groupID = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000001")!
         let group = WorkspaceGroup(id: groupID, name: "Work", childOrder: [Self.wsID1])
@@ -139,6 +139,141 @@ struct AppReducerTests {
         #expect(store.state.groups[id: groupID]?.childOrder == [Self.wsID1, newID])
         #expect(store.state.topLevelOrder == [.group(groupID)])
         #expect(store.state.activeWorkspaceID == newID)
+    }
+
+    @Test func createWorkspaceTopLevelDefaultAppendsToEndOfList() async {
+        // Default (`newWorkspacePlacement == .endOfList`): a new top-level
+        // workspace is appended to the bottom of the sidebar regardless of
+        // which workspace is active.
+        let wsID3 = UUID(uuidString: "10000000-0000-0000-0000-000000000003")!
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A", paneID: Self.paneID1)
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B", paneID: Self.paneID2)
+        let ws3 = Self.makeWorkspace(id: wsID3, name: "C", paneID: UUID())
+        let store = makeStore(workspaces: [ws1, ws2, ws3], activeWorkspaceID: Self.wsID2)
+
+        await store.send(.createWorkspace(name: "New"))
+
+        let newID = store.state.workspaces.last!.id
+        #expect(store.state.topLevelOrder == [
+            .workspace(Self.wsID1),
+            .workspace(Self.wsID2),
+            .workspace(wsID3),
+            .workspace(newID)
+        ])
+    }
+
+    @Test func createWorkspaceTopLevelNearSelectionInsertsAfterActive() async {
+        // With `newWorkspacePlacement == .nearSelection`, a new top-level
+        // workspace slots in immediately after the active workspace's
+        // sidebar entry instead of appending to the bottom.
+        let wsID3 = UUID(uuidString: "10000000-0000-0000-0000-000000000003")!
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A", paneID: Self.paneID1)
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B", paneID: Self.paneID2)
+        let ws3 = Self.makeWorkspace(id: wsID3, name: "C", paneID: UUID())
+
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2, ws3]
+        appState.topLevelOrder = [
+            .workspace(Self.wsID1),
+            .workspace(Self.wsID2),
+            .workspace(wsID3)
+        ]
+        appState.activeWorkspaceID = Self.wsID2
+        appState.settings.newWorkspacePlacement = .nearSelection
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createWorkspace(name: "New"))
+
+        let newID = store.state.workspaces.last!.id
+        #expect(store.state.topLevelOrder == [
+            .workspace(Self.wsID1),
+            .workspace(Self.wsID2),
+            .workspace(newID),
+            .workspace(wsID3)
+        ])
+    }
+
+    @Test func createWorkspaceInGroupDefaultAppendsToGroupEnd() async {
+        // Default (`newWorkspacePlacement == .endOfList`): a new workspace
+        // created into a group is appended to the end of its childOrder
+        // regardless of which child is currently active.
+        let wsID3 = UUID(uuidString: "10000000-0000-0000-0000-000000000003")!
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A", paneID: Self.paneID1)
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B", paneID: Self.paneID2)
+        let ws3 = Self.makeWorkspace(id: wsID3, name: "C", paneID: UUID())
+        let groupID = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000003")!
+        let group = WorkspaceGroup(id: groupID, name: "Work", childOrder: [Self.wsID1, Self.wsID2, wsID3])
+
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2, ws3]
+        appState.groups = [group]
+        appState.topLevelOrder = [.group(groupID)]
+        // Active is the middle child; default placement should still append.
+        appState.activeWorkspaceID = Self.wsID2
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createWorkspace(name: "New", groupID: groupID))
+
+        let newID = store.state.workspaces.last!.id
+        #expect(store.state.groups[id: groupID]?.childOrder == [Self.wsID1, Self.wsID2, wsID3, newID])
+    }
+
+    @Test func createWorkspaceInGroupNearSelectionInsertsAfterActive() async {
+        // With `newWorkspacePlacement == .nearSelection`, a new in-group
+        // workspace is inserted directly after the active workspace's slot
+        // in that group's childOrder instead of appending to the end.
+        let wsID3 = UUID(uuidString: "10000000-0000-0000-0000-000000000003")!
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A", paneID: Self.paneID1)
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B", paneID: Self.paneID2)
+        let ws3 = Self.makeWorkspace(id: wsID3, name: "C", paneID: UUID())
+        let groupID = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000004")!
+        let group = WorkspaceGroup(id: groupID, name: "Work", childOrder: [Self.wsID1, Self.wsID2, wsID3])
+
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2, ws3]
+        appState.groups = [group]
+        appState.topLevelOrder = [.group(groupID)]
+        appState.activeWorkspaceID = Self.wsID2
+        appState.settings.newWorkspacePlacement = .nearSelection
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createWorkspace(name: "New", groupID: groupID))
+
+        let newID = store.state.workspaces.last!.id
+        #expect(store.state.groups[id: groupID]?.childOrder == [Self.wsID1, Self.wsID2, newID, wsID3])
     }
 
     @Test func createWorkspaceWithGroupIDExpandsCollapsedGroup() async {

--- a/NexTests/WorkspaceGroupCRUDTests.swift
+++ b/NexTests/WorkspaceGroupCRUDTests.swift
@@ -103,10 +103,10 @@ struct WorkspaceGroupCRUDTests {
         }
     }
 
-    @Test func createGroupDefaultPlacementFollowsActiveWorkspace() async {
-        // Default (`newGroupPlacement == .nearSelection`): an anchorless
-        // createGroup inserts the new group directly after the active
-        // workspace's sidebar entry rather than appending to the end.
+    @Test func createGroupDefaultPlacementAppendsToEndOfList() async {
+        // Default (`newGroupPlacement == .endOfList`): an anchorless
+        // createGroup appends to the bottom of the sidebar regardless of
+        // which workspace is active.
         let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
         let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")
         let ws3 = Self.makeWorkspace(id: Self.wsID3, name: "C")
@@ -122,24 +122,26 @@ struct WorkspaceGroupCRUDTests {
 
         await store.send(.createGroup(name: "Monitors")) { state in
             #expect(state.topLevelOrder.count == 4)
-            if case .workspace(let id) = state.topLevelOrder[0] { #expect(id == Self.wsID1) }
-            if case .workspace(let id) = state.topLevelOrder[1] { #expect(id == Self.wsID2) }
-            if case .group = state.topLevelOrder[2] {} else { Issue.record("expected group at index 2") }
-            if case .workspace(let id) = state.topLevelOrder[3] { #expect(id == Self.wsID3) }
+            #expect(state.topLevelOrder.last?.groupID == Self.groupA)
         }
     }
 
-    @Test func createGroupEndOfListPlacementAlwaysAppends() async {
-        // With `newGroupPlacement == .endOfList`, an anchorless createGroup
-        // ignores the active workspace and appends to the bottom of the
-        // sidebar (issue #58 opt-in behavior).
+    @Test func createGroupNearSelectionPlacementFollowsActiveWorkspace() async {
+        // With `newGroupPlacement == .nearSelection`, an anchorless
+        // createGroup inserts the new group directly after the active
+        // workspace's sidebar entry rather than appending to the end.
         let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
         let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")
+        let ws3 = Self.makeWorkspace(id: Self.wsID3, name: "C")
         var appState = AppReducer.State()
-        appState.workspaces = [ws1, ws2]
-        appState.topLevelOrder = [.workspace(Self.wsID1), .workspace(Self.wsID2)]
-        appState.activeWorkspaceID = Self.wsID1
-        appState.settings.newGroupPlacement = .endOfList
+        appState.workspaces = [ws1, ws2, ws3]
+        appState.topLevelOrder = [
+            .workspace(Self.wsID1),
+            .workspace(Self.wsID2),
+            .workspace(Self.wsID3)
+        ]
+        appState.activeWorkspaceID = Self.wsID2
+        appState.settings.newGroupPlacement = .nearSelection
 
         let store = TestStore(initialState: appState) {
             AppReducer()
@@ -154,8 +156,11 @@ struct WorkspaceGroupCRUDTests {
         store.exhaustivity = .off(showSkippedAssertions: false)
 
         await store.send(.createGroup(name: "Monitors")) { state in
-            #expect(state.topLevelOrder.count == 3)
-            #expect(state.topLevelOrder.last?.groupID == Self.groupA)
+            #expect(state.topLevelOrder.count == 4)
+            if case .workspace(let id) = state.topLevelOrder[0] { #expect(id == Self.wsID1) }
+            if case .workspace(let id) = state.topLevelOrder[1] { #expect(id == Self.wsID2) }
+            if case .group = state.topLevelOrder[2] {} else { Issue.record("expected group at index 2") }
+            if case .workspace(let id) = state.topLevelOrder[3] { #expect(id == Self.wsID3) }
         }
     }
 
@@ -180,6 +185,7 @@ struct WorkspaceGroupCRUDTests {
             .workspace(Self.wsID3)
         ]
         appState.activeWorkspaceID = Self.wsID2
+        appState.settings.newGroupPlacement = .nearSelection
 
         let store = TestStore(initialState: appState) {
             AppReducer()
@@ -220,6 +226,7 @@ struct WorkspaceGroupCRUDTests {
             .workspace(Self.wsID3)
         ]
         appState.activeWorkspaceID = Self.wsID2
+        appState.settings.newGroupPlacement = .nearSelection
 
         let store = TestStore(initialState: appState) {
             AppReducer()
@@ -265,6 +272,7 @@ struct WorkspaceGroupCRUDTests {
         ]
         // Active workspace is wsID1, but the user right-clicks wsID3.
         appState.activeWorkspaceID = Self.wsID1
+        appState.settings.newGroupPlacement = .nearSelection
 
         let store = TestStore(initialState: appState) {
             AppReducer()

--- a/NexTests/WorkspaceGroupCRUDTests.swift
+++ b/NexTests/WorkspaceGroupCRUDTests.swift
@@ -103,6 +103,105 @@ struct WorkspaceGroupCRUDTests {
         }
     }
 
+    @Test func createGroupDefaultPlacementFollowsActiveWorkspace() async {
+        // Default (`newGroupPlacement == .nearSelection`): an anchorless
+        // createGroup inserts the new group directly after the active
+        // workspace's sidebar entry rather than appending to the end.
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")
+        let ws3 = Self.makeWorkspace(id: Self.wsID3, name: "C")
+        let store = makeStore(
+            workspaces: [ws1, ws2, ws3],
+            topLevelOrder: [
+                .workspace(Self.wsID1),
+                .workspace(Self.wsID2),
+                .workspace(Self.wsID3)
+            ],
+            activeWorkspaceID: Self.wsID2
+        )
+
+        await store.send(.createGroup(name: "Monitors")) { state in
+            #expect(state.topLevelOrder.count == 4)
+            if case .workspace(let id) = state.topLevelOrder[0] { #expect(id == Self.wsID1) }
+            if case .workspace(let id) = state.topLevelOrder[1] { #expect(id == Self.wsID2) }
+            if case .group = state.topLevelOrder[2] {} else { Issue.record("expected group at index 2") }
+            if case .workspace(let id) = state.topLevelOrder[3] { #expect(id == Self.wsID3) }
+        }
+    }
+
+    @Test func createGroupEndOfListPlacementAlwaysAppends() async {
+        // With `newGroupPlacement == .endOfList`, an anchorless createGroup
+        // ignores the active workspace and appends to the bottom of the
+        // sidebar (issue #58 opt-in behavior).
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2]
+        appState.topLevelOrder = [.workspace(Self.wsID1), .workspace(Self.wsID2)]
+        appState.activeWorkspaceID = Self.wsID1
+        appState.settings.newGroupPlacement = .endOfList
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = UUIDGenerator { Self.groupA }
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createGroup(name: "Monitors")) { state in
+            #expect(state.topLevelOrder.count == 3)
+            #expect(state.topLevelOrder.last?.groupID == Self.groupA)
+        }
+    }
+
+    @Test func createGroupNearSelectionAnchorsToParentGroupWhenNested() async {
+        // When the active workspace lives inside a group, `.nearSelection`
+        // inserts the new group after the parent group's entry so the two
+        // groups are adjacent in the sidebar.
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")
+        let ws3 = Self.makeWorkspace(id: Self.wsID3, name: "C")
+        let parentGroup = WorkspaceGroup(
+            id: Self.groupB,
+            name: "Parent",
+            childOrder: [Self.wsID2]
+        )
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2, ws3]
+        appState.groups = [parentGroup]
+        appState.topLevelOrder = [
+            .workspace(Self.wsID1),
+            .group(Self.groupB),
+            .workspace(Self.wsID3)
+        ]
+        appState.activeWorkspaceID = Self.wsID2
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = UUIDGenerator { Self.groupA }
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createGroup(name: "Sibling")) { state in
+            #expect(state.topLevelOrder.count == 4)
+            if case .workspace(let id) = state.topLevelOrder[0] { #expect(id == Self.wsID1) }
+            if case .group(let id) = state.topLevelOrder[1] { #expect(id == Self.groupB) }
+            if case .group(let id) = state.topLevelOrder[2] { #expect(id == Self.groupA) }
+            if case .workspace(let id) = state.topLevelOrder[3] { #expect(id == Self.wsID3) }
+        }
+    }
+
     @Test func createGroupMovesInitialWorkspacesFromTopLevel() async {
         let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
         let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")

--- a/NexTests/WorkspaceGroupCRUDTests.swift
+++ b/NexTests/WorkspaceGroupCRUDTests.swift
@@ -202,6 +202,128 @@ struct WorkspaceGroupCRUDTests {
         }
     }
 
+    @Test func createGroupNearSelectionGroupingActiveTopLevelTakesItsSlot() async {
+        // Regression for the P1 bug: when the "New Group..." row-menu flow
+        // folds the active, top-level workspace into a new group
+        // (`initialWorkspaceIDs = [active]`), the new group must land in
+        // the slot that workspace occupied instead of falling through to
+        // `append`, because the anchor is removed before the insertion
+        // index lookup.
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")
+        let ws3 = Self.makeWorkspace(id: Self.wsID3, name: "C")
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2, ws3]
+        appState.topLevelOrder = [
+            .workspace(Self.wsID1),
+            .workspace(Self.wsID2),
+            .workspace(Self.wsID3)
+        ]
+        appState.activeWorkspaceID = Self.wsID2
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = UUIDGenerator { Self.groupA }
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createGroup(
+            name: "Bundle",
+            color: nil,
+            insertAfter: nil,
+            initialWorkspaceIDs: [Self.wsID2]
+        )) { state in
+            #expect(state.topLevelOrder.count == 3)
+            if case .workspace(let id) = state.topLevelOrder[0] { #expect(id == Self.wsID1) }
+            if case .group(let id) = state.topLevelOrder[1] { #expect(id == Self.groupA) }
+            if case .workspace(let id) = state.topLevelOrder[2] { #expect(id == Self.wsID3) }
+            #expect(state.groups[id: Self.groupA]?.childOrder == [Self.wsID2])
+        }
+    }
+
+    @Test func createGroupNearSelectionAnchorsToRowNotActiveWorkspace() async {
+        // Regression for the P2 bug: `.nearSelection` must anchor to the
+        // workspace being grouped (first initialWorkspaceIDs entry), not
+        // to the currently active workspace. The row-level "New Group..."
+        // on a non-active row previously placed the new group next to
+        // `activeWorkspaceID` instead.
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")
+        let ws3 = Self.makeWorkspace(id: Self.wsID3, name: "C")
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2, ws3]
+        appState.topLevelOrder = [
+            .workspace(Self.wsID1),
+            .workspace(Self.wsID2),
+            .workspace(Self.wsID3)
+        ]
+        // Active workspace is wsID1, but the user right-clicks wsID3.
+        appState.activeWorkspaceID = Self.wsID1
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = UUIDGenerator { Self.groupA }
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createGroup(
+            name: "Bundle",
+            color: nil,
+            insertAfter: nil,
+            initialWorkspaceIDs: [Self.wsID3]
+        )) { state in
+            // The new group takes wsID3's slot (end of list here), not a
+            // slot next to wsID1 (the active workspace).
+            #expect(state.topLevelOrder.count == 3)
+            if case .workspace(let id) = state.topLevelOrder[0] { #expect(id == Self.wsID1) }
+            if case .workspace(let id) = state.topLevelOrder[1] { #expect(id == Self.wsID2) }
+            if case .group(let id) = state.topLevelOrder[2] { #expect(id == Self.groupA) }
+            #expect(state.groups[id: Self.groupA]?.childOrder == [Self.wsID3])
+        }
+    }
+
+    @Test func createGroupExplicitInsertAfterStillHonoredAfterDetachment() async {
+        // When the caller supplies an explicit `insertAfter` that points at
+        // a workspace being folded into the new group, the new group must
+        // still land in that slot; an explicit anchor is authoritative and
+        // should survive the detachment step.
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")
+        let ws3 = Self.makeWorkspace(id: Self.wsID3, name: "C")
+        let store = makeStore(
+            workspaces: [ws1, ws2, ws3],
+            topLevelOrder: [
+                .workspace(Self.wsID1),
+                .workspace(Self.wsID2),
+                .workspace(Self.wsID3)
+            ]
+        )
+
+        await store.send(.createGroup(
+            name: "Bundle",
+            color: nil,
+            insertAfter: .workspace(Self.wsID2),
+            initialWorkspaceIDs: [Self.wsID2]
+        )) { state in
+            #expect(state.topLevelOrder.count == 3)
+            if case .workspace(let id) = state.topLevelOrder[0] { #expect(id == Self.wsID1) }
+            if case .group(let id) = state.topLevelOrder[1] { #expect(id == Self.groupA) }
+            if case .workspace(let id) = state.topLevelOrder[2] { #expect(id == Self.wsID3) }
+        }
+    }
+
     @Test func createGroupMovesInitialWorkspacesFromTopLevel() async {
         let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A")
         let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B")

--- a/NexTests/WorkspaceGroupSocketTests.swift
+++ b/NexTests/WorkspaceGroupSocketTests.swift
@@ -219,6 +219,104 @@ struct WorkspaceGroupSocketTests {
         }
     }
 
+    @Test func socketWorkspaceCreateWithExistingGroupNearSelectionInsertsAfterActive() async {
+        // `nex workspace create --group ...` must honor
+        // `newWorkspacePlacement`. With `.nearSelection` and an active
+        // workspace that already lives in the target group, the new
+        // workspace slots in right after that workspace's position
+        // rather than appending to the group's end.
+        let wsA = Self.makeWorkspace(id: Self.ws1ID, name: "A")
+        let wsB = Self.makeWorkspace(id: Self.ws2ID, name: "B")
+        let group = WorkspaceGroup(
+            id: Self.groupAID,
+            name: "Monitors",
+            childOrder: [Self.ws1ID, Self.ws2ID]
+        )
+        var appState = AppReducer.State()
+        appState.workspaces = [wsA, wsB]
+        appState.groups = [group]
+        appState.topLevelOrder = [.group(Self.groupAID)]
+        // Active workspace is the FIRST child — nearSelection should
+        // land the new workspace between ws1 and ws2.
+        appState.activeWorkspaceID = Self.ws1ID
+        appState.settings.newWorkspacePlacement = .nearSelection
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.socketMessage(.workspaceCreate(
+            name: "Alpha",
+            path: nil,
+            color: nil,
+            group: "Monitors"
+        ), reply: nil))
+        await store.receive(\.moveWorkspaceToGroup) { state in
+            let childOrder = state.groups[id: Self.groupAID]?.childOrder ?? []
+            #expect(childOrder.count == 3)
+            #expect(childOrder[0] == Self.ws1ID)
+            #expect(childOrder[2] == Self.ws2ID)
+            // Middle entry is the freshly created workspace.
+            let newID = state.workspaces.last?.id
+            #expect(childOrder[1] == newID)
+        }
+    }
+
+    @Test func socketWorkspaceCreateWithExistingGroupEndOfListAppends() async {
+        // Default `.endOfList`: even with an active workspace in the
+        // target group, the new workspace appends to the group's end
+        // rather than slotting in next to the active one.
+        let wsA = Self.makeWorkspace(id: Self.ws1ID, name: "A")
+        let wsB = Self.makeWorkspace(id: Self.ws2ID, name: "B")
+        let group = WorkspaceGroup(
+            id: Self.groupAID,
+            name: "Monitors",
+            childOrder: [Self.ws1ID, Self.ws2ID]
+        )
+        var appState = AppReducer.State()
+        appState.workspaces = [wsA, wsB]
+        appState.groups = [group]
+        appState.topLevelOrder = [.group(Self.groupAID)]
+        appState.activeWorkspaceID = Self.ws1ID
+        // Leave `newWorkspacePlacement` at its default (`.endOfList`).
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.socketMessage(.workspaceCreate(
+            name: "Alpha",
+            path: nil,
+            color: nil,
+            group: "Monitors"
+        ), reply: nil))
+        await store.receive(\.moveWorkspaceToGroup) { state in
+            let childOrder = state.groups[id: Self.groupAID]?.childOrder ?? []
+            #expect(childOrder.count == 3)
+            #expect(childOrder[0] == Self.ws1ID)
+            #expect(childOrder[1] == Self.ws2ID)
+            // New workspace appended at the end.
+            let newID = state.workspaces.last?.id
+            #expect(childOrder[2] == newID)
+        }
+    }
+
     @Test func socketWorkspaceCreateWithoutGroupStaysTopLevel() async {
         let store = makeStore()
 


### PR DESCRIPTION
## Summary

- New `NewGroupPlacement` setting: `.nearSelection` (default, preserves today's behavior) or `.endOfList`. Wired through `SettingsFeature` + a settings UI picker.
- Fixes two anchor-resolution bugs in `.createGroup` along the way:
  - **P1**: capture the anchor's index in `topLevelOrder` **before** detaching `initialWorkspaceIDs`. Previously the "Move to Group ▸ New Group" flow on the active workspace was falling back to `append` because the anchor had already been removed by the time `firstIndex(of:)` ran.
  - **P2**: derive the `.nearSelection` anchor from `initialWorkspaceIDs.first` when `insertAfter` is nil; fall back to active workspace only for the empty-group flow. Previously this flow anchored to the active row instead of the row the action was launched from.
- 3 new regression tests covering both placement modes and the anchor-detachment case.

Fixes #58.

## Test plan

- [ ] Default (`.nearSelection`): creating a new group inserts next to the selected/grouped workspace
- [ ] `.endOfList`: new group is appended at the bottom regardless of selection
- [ ] "Move to Group ▸ New Group" on the active workspace: new group takes the workspace's former slot (not bottom)
- [ ] "Move to Group ▸ New Group" on a non-active workspace: new group lands next to that workspace (not the previously-active one)
- [ ] `make check` green (511 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)