### PR TITLE
feat: right-click empty group to create workspace in it (#57)

### DIFF
--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -12,6 +12,7 @@ struct AppReducer {
         var activeWorkspaceID: UUID?
         var isSidebarVisible: Bool = true
         var isNewWorkspaceSheetPresented: Bool = false
+        var pendingSheetGroupID: UUID?
         var renamingWorkspaceID: UUID?
         var renamingPaneID: UUID?
         var renamingGroupID: UUID?
@@ -274,7 +275,7 @@ struct AppReducer {
         case switchToNextWorkspace
         case switchToPreviousWorkspace
         case toggleSidebar
-        case showNewWorkspaceSheet
+        case showNewWorkspaceSheet(groupID: UUID? = nil)
         case dismissNewWorkspaceSheet
         case beginRenameActiveWorkspace
         case setRenamingWorkspaceID(UUID?)
@@ -976,6 +977,7 @@ struct AppReducer {
                 }
                 state.activeWorkspaceID = workspace.id
                 state.isNewWorkspaceSheetPresented = false
+                state.pendingSheetGroupID = nil
 
                 // Create the initial surface for the default pane
                 let paneID = workspace.panes.first!.id
@@ -1150,12 +1152,14 @@ struct AppReducer {
                 state.isSidebarVisible.toggle()
                 return .none
 
-            case .showNewWorkspaceSheet:
+            case .showNewWorkspaceSheet(let groupID):
                 state.isNewWorkspaceSheetPresented = true
+                state.pendingSheetGroupID = groupID
                 return .none
 
             case .dismissNewWorkspaceSheet:
                 state.isNewWorkspaceSheetPresented = false
+                state.pendingSheetGroupID = nil
                 return .none
 
             case .beginRenameActiveWorkspace:

--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -9,7 +9,7 @@ struct NexCommands: Commands {
         // Replace the default "New Window" (⌘N) with "New Workspace"
         CommandGroup(replacing: .newItem) {
             menuButton("New Workspace", action: .newWorkspace) {
-                store.send(.showNewWorkspaceSheet)
+                store.send(.showNewWorkspaceSheet())
             }
 
             menuButton("New Group", action: .newGroup) {

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -125,7 +125,7 @@ struct ContentView: View {
                         Text("No workspace selected")
                             .foregroundStyle(.secondary)
                         Button("Create Workspace") {
-                            store.send(.showNewWorkspaceSheet)
+                            store.send(.showNewWorkspaceSheet())
                         }
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Nex/Features/Workspace/GroupHeaderRow.swift
+++ b/Nex/Features/Workspace/GroupHeaderRow.swift
@@ -166,5 +166,9 @@ struct GroupEmptyRow: View {
         }
         .padding(.vertical, 6)
         .padding(.horizontal, 16)
+        // Right-click anywhere on the row should open the empty-group
+        // context menu — without an explicit hit shape only the Text's
+        // glyph area would respond.
+        .contentShape(Rectangle())
     }
 }

--- a/Nex/Features/Workspace/NewWorkspaceSheet.swift
+++ b/Nex/Features/Workspace/NewWorkspaceSheet.swift
@@ -29,10 +29,13 @@ struct NewWorkspaceSheet: View {
     init(store: StoreOf<AppReducer>) {
         self.store = store
         _color = State(initialValue: store.workspaces.nextRandomColor())
-        // Preselect the active workspace's group when inheritance is enabled,
-        // so the sheet opens pointing at the group the user is likely to want.
-        // They can always flip to "No group" or pick a different one.
+        // When the sheet was opened scoped to a specific group (e.g. from the
+        // empty-group context menu), honour that first. Otherwise fall back to
+        // preselecting the active workspace's group when inheritance is
+        // enabled. Either way the user can still flip to "No group" or pick a
+        // different one.
         let defaultGroupID: UUID? = {
+            if let pending = store.pendingSheetGroupID { return pending }
             guard store.settings.inheritGroupOnNewWorkspace,
                   let activeID = store.activeWorkspaceID else { return nil }
             return store.state.groupID(forWorkspace: activeID)

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -148,7 +148,7 @@ struct WorkspaceListView: View {
                             }
                             .contextMenu {
                                 Button("New Workspace") {
-                                    store.send(.showNewWorkspaceSheet)
+                                    store.send(.showNewWorkspaceSheet())
                                 }
                                 Button("New Group") {
                                     let placeholder = defaultGroupName(existing: store.groups)
@@ -193,7 +193,7 @@ struct WorkspaceListView: View {
             }
             .safeAreaInset(edge: .bottom) {
                 Menu {
-                    Button("New Workspace") { store.send(.showNewWorkspaceSheet) }
+                    Button("New Workspace") { store.send(.showNewWorkspaceSheet()) }
                     Button("New Group") {
                         let placeholder = defaultGroupName(existing: store.groups)
                         store.send(.createGroup(name: placeholder, autoRename: true))
@@ -202,7 +202,7 @@ struct WorkspaceListView: View {
                     Label("New Workspace", systemImage: "plus")
                         .frame(maxWidth: .infinity)
                 } primaryAction: {
-                    store.send(.showNewWorkspaceSheet)
+                    store.send(.showNewWorkspaceSheet())
                 }
                 .menuStyle(.borderlessButton)
                 .padding(12)
@@ -350,6 +350,15 @@ struct WorkspaceListView: View {
                     .spring(response: 0.35, dampingFraction: 0.8),
                     value: sidebarLayoutKey
                 )
+                .contextMenu {
+                    Button("New Workspace") {
+                        store.send(.showNewWorkspaceSheet(groupID: groupID))
+                    }
+                    if let group = store.groups[id: groupID] {
+                        Divider()
+                        groupContextMenu(groupID: groupID, group: group)
+                    }
+                }
         }
     }
 

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -528,14 +528,26 @@ struct AppReducerTests {
     @Test func showNewWorkspaceSheet() async {
         let store = makeStore()
 
-        await store.send(.showNewWorkspaceSheet) { state in
-            #expect(state.isNewWorkspaceSheetPresented == true)
+        await store.send(.showNewWorkspaceSheet()) { state in
+            state.isNewWorkspaceSheetPresented = true
+        }
+    }
+
+    @Test func showNewWorkspaceSheetScopedToGroup() async {
+        let groupID = UUID(uuidString: "20000000-0000-0000-0000-000000000001")!
+        let store = makeStore()
+
+        await store.send(.showNewWorkspaceSheet(groupID: groupID)) { state in
+            state.isNewWorkspaceSheetPresented = true
+            state.pendingSheetGroupID = groupID
         }
     }
 
     @Test func dismissNewWorkspaceSheet() async {
+        let groupID = UUID(uuidString: "20000000-0000-0000-0000-000000000002")!
         var appState = AppReducer.State()
         appState.isNewWorkspaceSheetPresented = true
+        appState.pendingSheetGroupID = groupID
 
         let store = TestStore(initialState: appState) {
             AppReducer()
@@ -549,8 +561,39 @@ struct AppReducerTests {
         store.exhaustivity = .off(showSkippedAssertions: false)
 
         await store.send(.dismissNewWorkspaceSheet) { state in
-            #expect(state.isNewWorkspaceSheetPresented == false)
+            state.isNewWorkspaceSheetPresented = false
+            state.pendingSheetGroupID = nil
         }
+    }
+
+    @Test func createWorkspaceClearsPendingSheetGroupID() async {
+        // When the sheet is open scoped to a group and the user submits, the
+        // pending preselection hint should be cleared alongside the sheet flag
+        // so a subsequent generic open doesn't remember the previous group.
+        let groupID = UUID(uuidString: "20000000-0000-0000-0000-000000000003")!
+        let group = WorkspaceGroup(id: groupID, name: "G", color: nil, icon: nil)
+        var appState = AppReducer.State()
+        appState.groups = [group]
+        appState.topLevelOrder = [.group(groupID)]
+        appState.isNewWorkspaceSheetPresented = true
+        appState.pendingSheetGroupID = groupID
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createWorkspace(name: "New", groupID: groupID))
+
+        #expect(store.state.isNewWorkspaceSheetPresented == false)
+        #expect(store.state.pendingSheetGroupID == nil)
     }
 
     // MARK: - beginRenameActiveWorkspace / setRenamingWorkspaceID


### PR DESCRIPTION
Closes #57.

## Summary
- Right-clicking the "No workspaces" placeholder inside an expanded empty group now opens a context menu with "New Workspace" preselected to that group, plus the same group-level actions (Rename, Color, Change Icon, Expand/Collapse, Delete) as the group header.
- Threads a transient `pendingSheetGroupID` through `AppReducer.State`; `NewWorkspaceSheet.init` honours it ahead of the inherit-from-active-workspace default. Cleared on dismiss and on successful create so subsequent generic opens don't remember the previous group.
- Adds `.contentShape(Rectangle())` to `GroupEmptyRow` so the whole row is right-clickable, not just the text glyphs.

## Test plan
- [x] `xcodebuild build` clean
- [x] `xcodebuild test` 546/546 pass, including 3 new reducer tests (scoped open, dismiss clears pending, create clears pending)
- [x] `make check` clean (format + lint + build + test)
- [x] Manually verified in-app