### PR TITLE
feat: cmd+= / cmd+- adjust markdown preview font size

### DIFF
--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -232,6 +232,12 @@ final class PaneShortcutMonitor {
         case .toggleMarkdownEdit:
             return handleToggleMarkdownEdit(activeWorkspaceID: id)
 
+        case .increaseMarkdownFontSize:
+            return handleMarkdownFontSize(activeWorkspaceID: id, increase: true)
+
+        case .decreaseMarkdownFontSize:
+            return handleMarkdownFontSize(activeWorkspaceID: id, increase: false)
+
         case .toggleZoom:
             store.send(.workspaces(.element(id: id, action: .toggleZoomPane)))
             return true
@@ -304,6 +310,21 @@ final class PaneShortcutMonitor {
         else { return false }
 
         store.send(.workspaces(.element(id: id, action: .toggleMarkdownEdit(focusedID))))
+        return true
+    }
+
+    private func handleMarkdownFontSize(activeWorkspaceID id: UUID, increase: Bool) -> Bool {
+        guard let workspace = store.workspaces[id: id],
+              let focusedID = workspace.focusedPaneID,
+              let pane = workspace.panes[id: focusedID],
+              pane.type == .markdown,
+              !pane.isEditing
+        else { return false }
+
+        let action: WorkspaceFeature.Action = increase
+            ? .increaseMarkdownFontSize(focusedID)
+            : .decreaseMarkdownFontSize(focusedID)
+        store.send(.workspaces(.element(id: id, action: action)))
         return true
     }
 

--- a/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
+++ b/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
@@ -162,14 +162,20 @@ enum MarkdownRenderer {
     static func renderToHTML(
         _ markdown: String,
         backgroundColor: NSColor = .windowBackgroundColor,
-        backgroundOpacity: Double = 1.0
+        backgroundOpacity: Double = 1.0,
+        baseFontSize: Double = 14
     ) -> String {
         let document = Document(parsing: markdown)
         var visitor = MarkdownHTMLRenderer()
         let bodyHTML = visitor.visit(document)
         let bgCSS = cssBackground(color: backgroundColor, opacity: backgroundOpacity)
         let isDark = isDarkBackground(color: backgroundColor)
-        return wrapInHTMLDocument(bodyHTML, backgroundCSS: bgCSS, isDark: isDark)
+        return wrapInHTMLDocument(
+            bodyHTML,
+            backgroundCSS: bgCSS,
+            isDark: isDark,
+            baseFontSize: baseFontSize
+        )
     }
 
     private static func isDarkBackground(color: NSColor) -> Bool {
@@ -186,7 +192,12 @@ enum MarkdownRenderer {
         return "background-color: rgba(\(r), \(g), \(b), \(opacity));"
     }
 
-    private static func wrapInHTMLDocument(_ body: String, backgroundCSS: String, isDark: Bool) -> String {
+    private static func wrapInHTMLDocument(
+        _ body: String,
+        backgroundCSS: String,
+        isDark: Bool,
+        baseFontSize: Double
+    ) -> String {
         """
         <!DOCTYPE html>
         <html class="\(isDark ? "dark" : "light")">
@@ -194,7 +205,7 @@ enum MarkdownRenderer {
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <style>
-        \(css(backgroundCSS: backgroundCSS))
+        \(css(backgroundCSS: backgroundCSS, baseFontSize: baseFontSize))
         </style>
         </head>
         <body>
@@ -208,11 +219,12 @@ enum MarkdownRenderer {
 
     // MARK: - Stylesheet
 
-    private static func css(backgroundCSS: String) -> String {
-        """
+    private static func css(backgroundCSS: String, baseFontSize: Double) -> String {
+        let codeFontSize = max(baseFontSize - 1, 6)
+        return """
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
-            font-size: 14px;
+            font-size: \(baseFontSize)px;
             line-height: 1.6;
             padding: 20px 28px;
             margin: 0;
@@ -238,7 +250,7 @@ enum MarkdownRenderer {
             padding: 16px;
             border-radius: 6px;
             overflow-x: auto;
-            font-size: 13px;
+            font-size: \(codeFontSize)px;
             line-height: 1.45;
         }
         .dark pre { background: #161b22; }

--- a/Nex/Features/MarkdownPane/MarkdownPaneView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownPaneView.swift
@@ -9,6 +9,7 @@ struct MarkdownPaneView: NSViewRepresentable {
     let isFocused: Bool
     var backgroundColor: NSColor = .windowBackgroundColor
     var backgroundOpacity: Double = 1.0
+    var fontSize: Double = 14
     @Environment(\.sidebarTextEditingActive) private var sidebarTextEditingActive
 
     func makeCoordinator() -> Coordinator {
@@ -44,6 +45,7 @@ struct MarkdownPaneView: NSViewRepresentable {
         context.coordinator.filePath = filePath
         context.coordinator.backgroundColor = backgroundColor
         context.coordinator.backgroundOpacity = backgroundOpacity
+        context.coordinator.fontSize = fontSize
         context.coordinator.loadFile()
         context.coordinator.startWatching()
 
@@ -60,8 +62,12 @@ struct MarkdownPaneView: NSViewRepresentable {
         if context.coordinator.filePath != filePath {
             context.coordinator.stopWatching()
             context.coordinator.filePath = filePath
+            context.coordinator.fontSize = fontSize
             context.coordinator.loadFile()
             context.coordinator.startWatching()
+        } else if context.coordinator.fontSize != fontSize {
+            context.coordinator.fontSize = fontSize
+            context.coordinator.renderCurrentContent()
         }
         // Only claim on a real false→true transition so re-renders caused
         // by unrelated state changes (e.g., the user typing in the command
@@ -95,8 +101,13 @@ struct MarkdownPaneView: NSViewRepresentable {
         var filePath: String = ""
         var backgroundColor: NSColor = .windowBackgroundColor
         var backgroundOpacity: Double = 1.0
+        var fontSize: Double = 14
         var lastIsFocused: Bool = false
         private var currentContent: String = ""
+        /// Monotonic token: incremented before each render, checked after
+        /// the async `window.scrollY` round-trip to drop stale reloads when
+        /// the user holds Cmd+= / Cmd+- and multiple renders are in flight.
+        private var renderToken: UInt64 = 0
         var pendingScrollFraction: CGFloat?
         nonisolated(unsafe) var fileWatcher: DispatchSourceFileSystemObject?
         nonisolated(unsafe) var fileDescriptor: Int32 = -1
@@ -113,21 +124,38 @@ struct MarkdownPaneView: NSViewRepresentable {
 
             guard content != currentContent else { return }
             currentContent = content
+            renderAndReload(content: content)
+        }
 
+        /// Re-render the currently loaded content (e.g. after a font-size change)
+        /// without touching disk.
+        func renderCurrentContent() {
+            guard !currentContent.isEmpty else { return }
+            renderAndReload(content: currentContent)
+        }
+
+        private func renderAndReload(content: String) {
+            renderToken &+= 1
+            let token = renderToken
             let html = MarkdownRenderer.renderToHTML(
                 content,
                 backgroundColor: backgroundColor,
-                backgroundOpacity: backgroundOpacity
+                backgroundOpacity: backgroundOpacity,
+                baseFontSize: fontSize
             )
             let baseURL = URL(fileURLWithPath: filePath).deletingLastPathComponent()
 
-            // Save scroll position, reload, then restore
+            // Save scroll position, reload, then restore. Drop the load if a
+            // newer render has been requested in the meantime — otherwise a
+            // stale callback from rapid Cmd+=/Cmd+- key repeat can overwrite
+            // the current render.
             webView?.evaluateJavaScript("window.scrollY") { [weak self] result, _ in
+                guard let self, token == renderToken else { return }
                 let scrollY = result as? Double ?? 0
-                self?.webView?.loadHTMLString(html, baseURL: baseURL)
+                webView?.loadHTMLString(html, baseURL: baseURL)
                 if scrollY > 0 {
-                    self?.pendingScrollFraction = nil
-                    self?.webView?.evaluateJavaScript("window.scrollTo(0, \(scrollY))")
+                    pendingScrollFraction = nil
+                    webView?.evaluateJavaScript("window.scrollTo(0, \(scrollY))")
                 }
             }
         }

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -174,7 +174,8 @@ struct PaneGridView: View {
                         filePath: pane.filePath ?? "",
                         isFocused: pane.id == focusedPaneID,
                         backgroundColor: ghosttyConfig.backgroundColor,
-                        backgroundOpacity: ghosttyConfig.backgroundOpacity
+                        backgroundOpacity: ghosttyConfig.backgroundOpacity,
+                        fontSize: pane.markdownFontSize
                     )
                 }
             case .scratchpad:

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -8,6 +8,7 @@ struct ClosedPaneSnapshot: Equatable {
     var filePath: String?
     var scratchpadContent: String?
     var claudeSessionID: String?
+    var markdownFontSize: Double = 14
 }
 
 @Reducer
@@ -113,6 +114,8 @@ struct WorkspaceFeature {
         case paneBranchChanged(paneID: UUID, branch: String?)
         case openMarkdownFile(filePath: String)
         case toggleMarkdownEdit(UUID)
+        case increaseMarkdownFontSize(UUID)
+        case decreaseMarkdownFontSize(UUID)
         case createScratchpad
         case scratchpadContentChanged(paneID: UUID, content: String)
         case addRepoAssociation(RepoAssociation)
@@ -332,7 +335,8 @@ struct WorkspaceFeature {
                             type: pane.type,
                             filePath: pane.filePath,
                             scratchpadContent: pane.scratchpadContent,
-                            claudeSessionID: pane.claudeSessionID
+                            claudeSessionID: pane.claudeSessionID,
+                            markdownFontSize: pane.markdownFontSize
                         )
                     )
                     if state.recentlyClosedPanes.count > 10 {
@@ -495,6 +499,24 @@ struct WorkspaceFeature {
 
                 state.panes[id: paneID]?.isEditing = true
                 state.panes[id: paneID]?.externalEditorCommand = nil
+                return .none
+
+            case .increaseMarkdownFontSize(let paneID):
+                guard let pane = state.panes[id: paneID],
+                      pane.type == .markdown,
+                      !pane.isEditing
+                else { return .none }
+                let next = min(pane.markdownFontSize + 1, 32)
+                state.panes[id: paneID]?.markdownFontSize = next
+                return .none
+
+            case .decreaseMarkdownFontSize(let paneID):
+                guard let pane = state.panes[id: paneID],
+                      pane.type == .markdown,
+                      !pane.isEditing
+                else { return .none }
+                let next = max(pane.markdownFontSize - 1, 8)
+                state.panes[id: paneID]?.markdownFontSize = next
                 return .none
 
             case .addRepoAssociation(let assoc):
@@ -675,7 +697,8 @@ struct WorkspaceFeature {
                     workingDirectory: snapshot.workingDirectory,
                     filePath: snapshot.filePath,
                     isEditing: snapshot.type == .scratchpad,
-                    scratchpadContent: snapshot.scratchpadContent
+                    scratchpadContent: snapshot.scratchpadContent,
+                    markdownFontSize: snapshot.markdownFontSize
                 )
 
                 let (newLayout, _) = state.layout.splitting(

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -231,6 +231,8 @@ enum NexAction: String, CaseIterable {
     case previousWorkspace = "previous_workspace"
     case renameWorkspace = "rename_workspace"
     case toggleMarkdownEdit = "toggle_markdown_edit"
+    case increaseMarkdownFontSize = "increase_markdown_font_size"
+    case decreaseMarkdownFontSize = "decrease_markdown_font_size"
     case toggleZoom = "toggle_zoom"
     case reopenClosedPane = "reopen_closed_pane"
     case toggleSearch = "toggle_search"
@@ -285,6 +287,8 @@ enum NexAction: String, CaseIterable {
         case .previousWorkspace: "Previous Workspace"
         case .renameWorkspace: "Rename Workspace"
         case .toggleMarkdownEdit: "Toggle Markdown Edit"
+        case .increaseMarkdownFontSize: "Increase Markdown Font Size"
+        case .decreaseMarkdownFontSize: "Decrease Markdown Font Size"
         case .toggleZoom: "Toggle Zoom"
         case .reopenClosedPane: "Reopen Closed Pane"
         case .toggleSearch: "Toggle Search"
@@ -316,7 +320,7 @@ enum NexAction: String, CaseIterable {
             "Workspaces"
         case .toggleSidebar, .toggleInspector:
             "View"
-        case .openFile, .toggleMarkdownEdit:
+        case .openFile, .toggleMarkdownEdit, .increaseMarkdownFontSize, .decreaseMarkdownFontSize:
             "Files"
         case .toggleSearch, .closeSearch:
             "Search"
@@ -474,6 +478,8 @@ struct KeyBindingMap: Equatable {
         bindings[KeyTrigger(keyCode: 126, modifiers: [.command, .option])] = .previousWorkspace // ⌘⌥↑
         bindings[KeyTrigger(keyCode: 15, modifiers: [.command, .shift])] = .renameWorkspace // ⌘⇧R
         bindings[KeyTrigger(keyCode: 14, modifiers: .command)] = .toggleMarkdownEdit // ⌘E
+        bindings[KeyTrigger(keyCode: 24, modifiers: .command)] = .increaseMarkdownFontSize // ⌘=
+        bindings[KeyTrigger(keyCode: 27, modifiers: .command)] = .decreaseMarkdownFontSize // ⌘-
         bindings[KeyTrigger(keyCode: 36, modifiers: [.command, .shift])] = .toggleZoom // ⌘⇧Return
         bindings[KeyTrigger(keyCode: 17, modifiers: [.command, .shift])] = .reopenClosedPane // ⌘⇧T
         bindings[KeyTrigger(keyCode: 3, modifiers: .command)] = .toggleSearch // ⌘F

--- a/Nex/Models/Pane.swift
+++ b/Nex/Models/Pane.swift
@@ -25,6 +25,9 @@ struct Pane: Identifiable, Equatable {
     /// but never written to a file on disk.
     var scratchpadContent: String?
     var claudeSessionID: String?
+    /// Rendered body font size (px) for markdown preview panes. Per-pane,
+    /// in-memory only; adjusted via Cmd+= / Cmd+-.
+    var markdownFontSize: Double
 
     /// Convenience accessor for rendering logic.
     var isUsingExternalEditor: Bool { externalEditorCommand != nil }
@@ -44,6 +47,7 @@ struct Pane: Identifiable, Equatable {
         scratchpadContent: String? = nil,
         status: PaneStatus = .idle,
         claudeSessionID: String? = nil,
+        markdownFontSize: Double = 14,
         createdAt: Date = Date(),
         lastActivityAt: Date = Date()
     ) {
@@ -59,6 +63,7 @@ struct Pane: Identifiable, Equatable {
         self.scratchpadContent = scratchpadContent
         self.status = status
         self.claudeSessionID = claudeSessionID
+        self.markdownFontSize = markdownFontSize
         self.createdAt = createdAt
         self.lastActivityAt = lastActivityAt
     }


### PR DESCRIPTION
## Summary
- Adds `⌘=` / `⌘-` shortcuts to increase/decrease font size in markdown preview panes, matching the terminal-pane UX provided by libghostty.
- Per-pane, in-memory only (resets on app relaunch); clamped to `[8, 32]`; preserved across pane reopen.
- Preview only — editor mode and terminal panes are unaffected (keybinding falls through for non-markdown or editing panes).

## Design
- `Pane.markdownFontSize: Double = 14` — per-pane ephemeral state.
- New `NexAction` cases `increase_markdown_font_size` / `decrease_markdown_font_size` with default bindings `⌘=` / `⌘-`.
- `PaneShortcutMonitor.handleMarkdownFontSize` mirrors `handleToggleMarkdownEdit` — returns `false` unless the focused pane is `.markdown` and not `isEditing`, so the event propagates cleanly in every other context.
- `MarkdownHTMLRenderer.renderToHTML(..., baseFontSize:)` parameterized; code block size derives as `baseFontSize - 1` (inline code and headings are em-based and scale automatically).
- `MarkdownPaneView.Coordinator` refactored: `loadFile()` delegates to `renderAndReload(content:)`; new `renderCurrentContent()` re-renders without disk I/O when only font size changed. A monotonic `renderToken` guards against stale HTML winning when `⌘=` is held down and multiple async reloads are in flight.
- `ClosedPaneSnapshot` now carries `markdownFontSize` so close + `reopen_closed_pane` restores the resized preview.

## Test plan
- [x] `make check` green (546 tests, swiftformat, swiftlint, build)
- [x] Manual: open a `.md` via ⌘O; `⌘=` grows body + code; `⌘-` shrinks; clamps at 8 and 32; scroll position preserved across re-render
- [x] Manual: focus a terminal pane — `⌘=` still increases ghostty font size (unchanged)
- [x] Manual: toggle to editor with ⌘E — editor font stays fixed (preview-only scope)
- [x] Manual: close a resized markdown pane + ⌘⇧T — font size preserved

## Reviewer notes
- Implementation audited by a codex agent before push; three findings addressed in this PR (stale-render race → render token; reducer defense-in-depth `!isEditing` guard; reopen snapshot field).
- No persistence changes. No schema changes. `Pane` init gained an additional defaulted parameter; no positional callers.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)