### PR TITLE
feat: nex open --here (reuse the originating pane, restore on close)

### DIFF
--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -1767,6 +1767,20 @@ struct AppReducer {
                     scheduleAutoUnlink(workspaceID: wsID, in: state)
                 )
 
+            case .workspaces(.element(id: let wsID, action: .openMarkdownFile(_, .some))):
+                // `--here` reuse removed a pane — mirror closePane's
+                // parent-level cleanup so renamingPaneID isn't left
+                // dangling and auto-detected repo associations are
+                // reconciled against the new working directory set.
+                if let renamingPaneID = state.renamingPaneID,
+                   !state.workspaces.contains(where: { $0.panes[id: renamingPaneID] != nil }) {
+                    state.renamingPaneID = nil
+                }
+                return .merge(
+                    .send(.persistState),
+                    scheduleAutoUnlink(workspaceID: wsID, in: state)
+                )
+
             case .workspaces(.element(id: let wsID, action: .paneProcessTerminated)):
                 if let renamingPaneID = state.renamingPaneID,
                    !state.workspaces.contains(where: { $0.panes[id: renamingPaneID] != nil }) {
@@ -2360,19 +2374,19 @@ struct AppReducer {
 
                 // MARK: File commands
 
-                case .openFile(let path, let paneID):
+                case .openFile(let path, let paneID, let reuse):
                     if let paneID,
                        let workspace = state.workspaces.first(where: { $0.panes[id: paneID] != nil }) {
                         state.workspaces[id: workspace.id]?.focusedPaneID = paneID
                         return .send(.workspaces(.element(
                             id: workspace.id,
-                            action: .openMarkdownFile(filePath: path)
+                            action: .openMarkdownFile(filePath: path, reusePaneID: reuse ? paneID : nil)
                         )))
                     }
                     guard let activeID = state.activeWorkspaceID else { return .none }
                     return .send(.workspaces(.element(
                         id: activeID,
-                        action: .openMarkdownFile(filePath: path)
+                        action: .openMarkdownFile(filePath: path, reusePaneID: nil)
                     )))
 
                 // MARK: Layout commands

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -196,6 +196,18 @@ struct AppReducer {
             return matches.count == 1 ? matches.first : nil
         }
 
+        /// Locate the workspace owning a pane, checking both the
+        /// visible layout and the parked lane. Used by surface/agent
+        /// lifecycle routing so events on shells parked by
+        /// `nex open --here` aren't dropped. User-command routing
+        /// (pane send, split, close, etc.) intentionally searches
+        /// only `panes` — parked panes are not user-addressable.
+        func workspaceContainingPane(_ paneID: UUID) -> WorkspaceFeature.State? {
+            workspaces.first(where: {
+                $0.panes[id: paneID] != nil || $0.parkedPanes[id: paneID] != nil
+            })
+        }
+
         func workspaces(inGroup groupID: UUID) -> [WorkspaceFeature.State] {
             guard let group = groups[id: groupID] else { return [] }
             return group.childOrder.compactMap { workspaces[id: $0] }
@@ -993,6 +1005,7 @@ struct AppReducer {
             case .deleteWorkspace(let id):
                 guard let workspace = state.workspaces[id: id] else { return .none }
                 let paneIDs = workspace.layout.allPaneIDs
+                    + workspace.parkedPanes.map(\.id)
                 state.workspaces.remove(id: id)
                 state.topLevelOrder.removeAll { $0 == .workspace(id) }
                 for groupID in state.groups.ids {
@@ -1237,6 +1250,7 @@ struct AppReducer {
                 for id in ids {
                     guard let workspace = state.workspaces[id: id] else { continue }
                     panesToDestroy.append(contentsOf: workspace.layout.allPaneIDs)
+                    panesToDestroy.append(contentsOf: workspace.parkedPanes.map(\.id))
                     state.workspaces.remove(id: id)
                 }
                 let removedSet = Set(ids)
@@ -1440,6 +1454,7 @@ struct AppReducer {
                     for wsID in childIDs {
                         guard let workspace = state.workspaces[id: wsID] else { continue }
                         paneIDs.append(contentsOf: workspace.layout.allPaneIDs)
+                        paneIDs.append(contentsOf: workspace.parkedPanes.map(\.id))
                         state.workspaces.remove(id: wsID)
                     }
                     let removedSet = Set(childIDs)
@@ -1767,19 +1782,17 @@ struct AppReducer {
                     scheduleAutoUnlink(workspaceID: wsID, in: state)
                 )
 
-            case .workspaces(.element(id: let wsID, action: .openMarkdownFile(_, .some))):
-                // `--here` reuse removed a pane — mirror closePane's
-                // parent-level cleanup so renamingPaneID isn't left
-                // dangling and auto-detected repo associations are
-                // reconciled against the new working directory set.
-                if let renamingPaneID = state.renamingPaneID,
-                   !state.workspaces.contains(where: { $0.panes[id: renamingPaneID] != nil }) {
+            case .workspaces(.element(_, action: .openMarkdownFile(_, .some(let reusePaneID)))):
+                // `--here` reuse parks (doesn't remove) the source
+                // pane. Only clear renamingPaneID if it targeted the
+                // source — the overlay can't continue into a parked
+                // pane that's no longer visible. No auto-unlink pass
+                // is needed because the source still owns its working
+                // directory, just off-layout.
+                if state.renamingPaneID == reusePaneID {
                     state.renamingPaneID = nil
                 }
-                return .merge(
-                    .send(.persistState),
-                    scheduleAutoUnlink(workspaceID: wsID, in: state)
-                )
+                return .send(.persistState)
 
             case .workspaces(.element(id: let wsID, action: .paneProcessTerminated)):
                 if let renamingPaneID = state.renamingPaneID,
@@ -2103,14 +2116,16 @@ struct AppReducer {
                 // MARK: Agent lifecycle
 
                 case .agentStarted(let paneID):
-                    guard let workspace = state.workspaces.first(where: { $0.panes[id: paneID] != nil })
+                    guard let workspace = state.workspaceContainingPane(paneID)
                     else { return .none }
 
                     // If we get a "start" while already running, the previous "stop"
                     // was missed (e.g. user interrupted Claude). Reset to idle first
                     // so the status lifecycle stays clean.
-                    if workspace.panes[id: paneID]?.status == .running {
-                        state.workspaces[id: workspace.id]?.panes[id: paneID]?.status = .idle
+                    if workspace.pane(id: paneID)?.status == .running {
+                        state.workspaces[id: workspace.id]?.mutatePane(id: paneID) {
+                            $0.status = .idle
+                        }
                     }
 
                     return .merge(
@@ -2119,7 +2134,7 @@ struct AppReducer {
                     )
 
                 case .agentStopped(let paneID):
-                    guard let workspace = state.workspaces.first(where: { $0.panes[id: paneID] != nil })
+                    guard let workspace = state.workspaceContainingPane(paneID)
                     else { return .none }
 
                     let isFocused = state.activeWorkspaceID == workspace.id && workspace.focusedPaneID == paneID
@@ -2128,7 +2143,7 @@ struct AppReducer {
                     let isAppActive = MainActor.assumeIsolated { NSApp.isActive }
                     let shouldNotify = !isFocused || !isAppActive
                     let shouldBounce = !isAppActive
-                    let title = workspace.panes[id: paneID]?.title ?? workspace.name
+                    let title = workspace.pane(id: paneID)?.title ?? workspace.name
 
                     return .merge(
                         .send(.workspaces(.element(id: workspace.id, action: .agentStopped(paneID: paneID)))),
@@ -2151,7 +2166,7 @@ struct AppReducer {
                     )
 
                 case .agentError(let paneID, let message):
-                    guard let workspace = state.workspaces.first(where: { $0.panes[id: paneID] != nil })
+                    guard let workspace = state.workspaceContainingPane(paneID)
                     else { return .none }
 
                     let notifService = notificationService
@@ -2171,7 +2186,7 @@ struct AppReducer {
                     )
 
                 case .notification(let paneID, let title, let body):
-                    guard let workspace = state.workspaces.first(where: { $0.panes[id: paneID] != nil })
+                    guard let workspace = state.workspaceContainingPane(paneID)
                     else { return .none }
 
                     let isFocused = state.activeWorkspaceID == workspace.id && workspace.focusedPaneID == paneID
@@ -2191,7 +2206,7 @@ struct AppReducer {
                     return .merge(effects)
 
                 case .sessionStarted(let paneID, let sessionID):
-                    guard let workspace = state.workspaces.first(where: { $0.panes[id: paneID] != nil })
+                    guard let workspace = state.workspaceContainingPane(paneID)
                     else { return .none }
 
                     return .merge(
@@ -2418,27 +2433,24 @@ struct AppReducer {
             // MARK: - Cross-Workspace Surface Notifications
 
             case .surfaceTitleChanged(let paneID, let title):
-                guard let workspace = state.workspaces.first(where: { ws in
-                    ws.panes[id: paneID] != nil
-                }) else { return .none }
+                guard let workspace = state.workspaceContainingPane(paneID)
+                else { return .none }
                 return .send(.workspaces(.element(
                     id: workspace.id,
                     action: .paneTitleChanged(paneID: paneID, title: title)
                 )))
 
             case .surfaceDirectoryChanged(let paneID, let directory):
-                guard let workspace = state.workspaces.first(where: { ws in
-                    ws.panes[id: paneID] != nil
-                }) else { return .none }
+                guard let workspace = state.workspaceContainingPane(paneID)
+                else { return .none }
                 return .send(.workspaces(.element(
                     id: workspace.id,
                     action: .paneDirectoryChanged(paneID: paneID, directory: directory)
                 )))
 
             case .surfaceProcessExited(let paneID):
-                guard let workspace = state.workspaces.first(where: { ws in
-                    ws.panes[id: paneID] != nil
-                }) else { return .none }
+                guard let workspace = state.workspaceContainingPane(paneID)
+                else { return .none }
                 return .send(.workspaces(.element(
                     id: workspace.id,
                     action: .paneProcessTerminated(paneID: paneID)
@@ -2448,7 +2460,7 @@ struct AppReducer {
 
             case .desktopNotification(let paneID, let title, let body):
                 // Suppress if this pane is focused and app is active
-                if let workspace = state.workspaces.first(where: { $0.panes[id: paneID] != nil }),
+                if let workspace = state.workspaceContainingPane(paneID),
                    state.activeWorkspaceID == workspace.id,
                    workspace.focusedPaneID == paneID,
                    MainActor.assumeIsolated({ NSApp.isActive }) {
@@ -2692,6 +2704,7 @@ struct AppReducer {
                 guard !candidateIDs.isEmpty else { return .none }
 
                 let panePaths = workspace.panes.map(\.workingDirectory)
+                    + workspace.parkedPanes.map(\.workingDirectory)
 
                 func isPathInside(_ path: String, _ root: String) -> Bool {
                     let p = (path as NSString).standardizingPath

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -112,7 +112,7 @@ struct WorkspaceFeature {
         case sessionStarted(paneID: UUID, sessionID: String)
         case clearPaneStatus(UUID)
         case paneBranchChanged(paneID: UUID, branch: String?)
-        case openMarkdownFile(filePath: String)
+        case openMarkdownFile(filePath: String, reusePaneID: UUID? = nil)
         case toggleMarkdownEdit(UUID)
         case increaseMarkdownFontSize(UUID)
         case decreaseMarkdownFontSize(UUID)
@@ -239,7 +239,7 @@ struct WorkspaceFeature {
                     )
                 }
 
-            case .openMarkdownFile(let filePath):
+            case .openMarkdownFile(let filePath, let reusePaneID):
                 let newPaneID = uuid()
                 let dir = (filePath as NSString).deletingLastPathComponent
                 let fileName = (filePath as NSString).lastPathComponent
@@ -254,6 +254,59 @@ struct WorkspaceFeature {
                     lastActivityAt: now
                 )
 
+                let branchEffect: Effect<Action> = .run { send in
+                    let branch = try? await gitService.getCurrentBranch(dir)
+                    await send(.paneBranchChanged(paneID: newPaneID, branch: branch))
+                }
+
+                if let reusePaneID, let oldPane = state.panes[id: reusePaneID] {
+                    // `--here`: replace the originating pane in place.
+                    // Mirrors closePane's cleanup so the two paths stay in
+                    // lockstep (search, zoom, recently-closed, surface
+                    // teardown).
+                    if state.searchingPaneID == reusePaneID {
+                        state.searchingPaneID = nil
+                        state.searchNeedle = ""
+                        state.searchTotal = nil
+                        state.searchSelected = nil
+                    }
+                    if let saved = state.savedLayout {
+                        state.layout = saved
+                        state.zoomedPaneID = nil
+                        state.savedLayout = nil
+                    }
+                    let hasBackingSurface = oldPane.type == .shell
+                        || (oldPane.type == .markdown && oldPane.isUsingExternalEditor)
+                    state.recentlyClosedPanes.append(
+                        ClosedPaneSnapshot(
+                            workingDirectory: oldPane.workingDirectory,
+                            label: oldPane.label,
+                            type: oldPane.type,
+                            filePath: oldPane.filePath,
+                            scratchpadContent: oldPane.scratchpadContent,
+                            claudeSessionID: oldPane.claudeSessionID,
+                            markdownFontSize: oldPane.markdownFontSize
+                        )
+                    )
+                    if state.recentlyClosedPanes.count > 10 {
+                        state.recentlyClosedPanes.removeFirst()
+                    }
+                    state.layout = state.layout.replacing(paneID: reusePaneID, with: .leaf(newPaneID))
+                    state.panes.remove(id: reusePaneID)
+                    state.panes.append(newPane)
+                    state.focusedPaneID = newPaneID
+                    state.currentLayoutIndex = nil
+                    if hasBackingSurface {
+                        return .merge(
+                            .run { _ in
+                                await surfaceManager.destroySurface(paneID: reusePaneID)
+                            },
+                            branchEffect
+                        )
+                    }
+                    return branchEffect
+                }
+
                 if let sourceID = state.focusedPaneID {
                     let (newLayout, _) = state.layout.splitting(
                         paneID: sourceID,
@@ -267,10 +320,7 @@ struct WorkspaceFeature {
                 state.panes.append(newPane)
                 state.focusedPaneID = newPaneID
                 state.currentLayoutIndex = nil
-                return .run { send in
-                    let branch = try? await gitService.getCurrentBranch(dir)
-                    await send(.paneBranchChanged(paneID: newPaneID, branch: branch))
-                }
+                return branchEffect
 
             case .createScratchpad:
                 let newPaneID = uuid()

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -24,6 +24,12 @@ struct WorkspaceFeature {
         var focusedPaneID: UUID?
         var repoAssociations: IdentifiedArrayOf<RepoAssociation> = []
         var recentlyClosedPanes: [ClosedPaneSnapshot] = []
+        /// Panes that are off-layout but whose ghostty surfaces/PTYs must
+        /// stay alive (currently: sources parked by `nex open --here`).
+        /// Not persisted — surfaces can't be restored across app
+        /// restarts. A `Pane` lives in exactly one of `panes` or
+        /// `parkedPanes` at any time.
+        var parkedPanes: IdentifiedArrayOf<Pane> = []
         var zoomedPaneID: UUID?
         var savedLayout: PaneLayout?
         var searchingPaneID: UUID?
@@ -77,6 +83,27 @@ struct WorkspaceFeature {
             self.repoAssociations = repoAssociations
             self.createdAt = createdAt
             self.lastAccessedAt = lastAccessedAt
+        }
+
+        /// Read a pane wherever it lives — visible layout or the
+        /// parked lane (sources hidden by `nex open --here`). Surface
+        /// and agent lifecycle events can target parked panes; user
+        /// commands (send/split/close) intentionally only look at
+        /// `panes`.
+        func pane(id paneID: UUID) -> Pane? {
+            panes[id: paneID] ?? parkedPanes[id: paneID]
+        }
+
+        /// Mutate a pane wherever it lives (visible or parked). If the
+        /// pane isn't found the closure is not invoked.
+        mutating func mutatePane(id paneID: UUID, _ body: (inout Pane) -> Void) {
+            if var pane = panes[id: paneID] {
+                body(&pane)
+                panes[id: paneID] = pane
+            } else if var pane = parkedPanes[id: paneID] {
+                body(&pane)
+                parkedPanes[id: paneID] = pane
+            }
         }
 
         /// Generate a filesystem-safe slug from a display name.
@@ -260,10 +287,10 @@ struct WorkspaceFeature {
                 }
 
                 if let reusePaneID, let oldPane = state.panes[id: reusePaneID] {
-                    // `--here`: replace the originating pane in place.
-                    // Mirrors closePane's cleanup so the two paths stay in
-                    // lockstep (search, zoom, recently-closed, surface
-                    // teardown).
+                    // `--here`: park the originating pane so its PTY
+                    // stays alive off-layout. Closing the new markdown
+                    // pane will unpark it and restore the terminal.
+                    // Mirrors closePane's search/zoom cleanup.
                     if state.searchingPaneID == reusePaneID {
                         state.searchingPaneID = nil
                         state.searchNeedle = ""
@@ -275,35 +302,14 @@ struct WorkspaceFeature {
                         state.zoomedPaneID = nil
                         state.savedLayout = nil
                     }
-                    let hasBackingSurface = oldPane.type == .shell
-                        || (oldPane.type == .markdown && oldPane.isUsingExternalEditor)
-                    state.recentlyClosedPanes.append(
-                        ClosedPaneSnapshot(
-                            workingDirectory: oldPane.workingDirectory,
-                            label: oldPane.label,
-                            type: oldPane.type,
-                            filePath: oldPane.filePath,
-                            scratchpadContent: oldPane.scratchpadContent,
-                            claudeSessionID: oldPane.claudeSessionID,
-                            markdownFontSize: oldPane.markdownFontSize
-                        )
-                    )
-                    if state.recentlyClosedPanes.count > 10 {
-                        state.recentlyClosedPanes.removeFirst()
-                    }
+                    var linkedPane = newPane
+                    linkedPane.parkedSourcePaneID = reusePaneID
                     state.layout = state.layout.replacing(paneID: reusePaneID, with: .leaf(newPaneID))
                     state.panes.remove(id: reusePaneID)
-                    state.panes.append(newPane)
+                    state.parkedPanes.append(oldPane)
+                    state.panes.append(linkedPane)
                     state.focusedPaneID = newPaneID
                     state.currentLayoutIndex = nil
-                    if hasBackingSurface {
-                        return .merge(
-                            .run { _ in
-                                await surfaceManager.destroySurface(paneID: reusePaneID)
-                            },
-                            branchEffect
-                        )
-                    }
                     return branchEffect
                 }
 
@@ -370,6 +376,33 @@ struct WorkspaceFeature {
                     state.zoomedPaneID = nil
                     state.savedLayout = nil
                 }
+
+                // Unpark: if the closing pane was created via `nex open
+                // --here` and its source is still parked, restore the
+                // source terminal instead of closing. The markdown
+                // pane's own surface (if it entered external-editor
+                // mode) still needs torn down.
+                if let closingPane = state.panes[id: paneID],
+                   let sourceID = closingPane.parkedSourcePaneID,
+                   let parkedPane = state.parkedPanes[id: sourceID] {
+                    let markdownHasSurface = closingPane.type == .markdown
+                        && closingPane.isUsingExternalEditor
+                    state.parkedPanes.remove(id: sourceID)
+                    state.panes.remove(id: paneID)
+                    state.panes.append(parkedPane)
+                    state.layout = state.layout.replacing(
+                        paneID: paneID, with: .leaf(sourceID)
+                    )
+                    state.focusedPaneID = sourceID
+                    state.currentLayoutIndex = nil
+                    if markdownHasSurface {
+                        return .run { _ in
+                            await surfaceManager.destroySurface(paneID: paneID)
+                        }
+                    }
+                    return .none
+                }
+
                 let paneType = state.panes[id: paneID]?.type ?? .shell
                 // A markdown pane hosts a ghostty surface only while editing
                 // via an external editor. We must destroy that surface on
@@ -435,19 +468,39 @@ struct WorkspaceFeature {
                 return .none
 
             case .paneTitleChanged(let paneID, let title):
-                state.panes[id: paneID]?.title = title
-                state.panes[id: paneID]?.lastActivityAt = now
+                let timestamp = now
+                state.mutatePane(id: paneID) {
+                    $0.title = title
+                    $0.lastActivityAt = timestamp
+                }
                 return .none
 
             case .paneDirectoryChanged(let paneID, let directory):
-                state.panes[id: paneID]?.workingDirectory = directory
-                state.panes[id: paneID]?.lastActivityAt = now
+                let timestamp = now
+                state.mutatePane(id: paneID) {
+                    $0.workingDirectory = directory
+                    $0.lastActivityAt = timestamp
+                }
                 return .run { send in
                     let branch = try? await gitService.getCurrentBranch(directory)
                     await send(.paneBranchChanged(paneID: paneID, branch: branch))
                 }
 
             case .paneProcessTerminated(let paneID):
+                // If a parked pane's process died (SIGHUP, etc.), evict
+                // it from the parked lane and clear references from
+                // any markdown panes that were going to restore it.
+                // The standard closePane path would be a no-op here
+                // (parked panes aren't in state.panes or state.layout).
+                if state.parkedPanes[id: paneID] != nil {
+                    state.parkedPanes.remove(id: paneID)
+                    for pane in state.panes where pane.parkedSourcePaneID == paneID {
+                        state.panes[id: pane.id]?.parkedSourcePaneID = nil
+                    }
+                    return .run { _ in
+                        await surfaceManager.destroySurface(paneID: paneID)
+                    }
+                }
                 // If this was a markdown pane whose external editor just exited,
                 // flip back to view mode instead of closing the pane. The
                 // MarkdownPaneView file watcher will reload any on-disk changes.
@@ -484,31 +537,31 @@ struct WorkspaceFeature {
                 return .none
 
             case .agentStarted(let paneID):
-                state.panes[id: paneID]?.status = .running
+                state.mutatePane(id: paneID) { $0.status = .running }
                 return .none
 
             case .agentStopped(let paneID):
-                state.panes[id: paneID]?.status = .waitingForInput
+                state.mutatePane(id: paneID) { $0.status = .waitingForInput }
                 return .none
 
             case .agentError(let paneID):
-                state.panes[id: paneID]?.status = .waitingForInput
+                state.mutatePane(id: paneID) { $0.status = .waitingForInput }
                 return .none
 
             case .sessionStarted(let paneID, let sessionID):
-                state.panes[id: paneID]?.claudeSessionID = sessionID
+                state.mutatePane(id: paneID) { $0.claudeSessionID = sessionID }
                 return .none
 
             case .clearPaneStatus(let paneID):
                 // Only clear waitingForInput — don't clobber .running if the agent
                 // already started again before the 600ms focus timer fired.
-                if state.panes[id: paneID]?.status == .waitingForInput {
-                    state.panes[id: paneID]?.status = .idle
+                if state.pane(id: paneID)?.status == .waitingForInput {
+                    state.mutatePane(id: paneID) { $0.status = .idle }
                 }
                 return .none
 
             case .paneBranchChanged(let paneID, let branch):
-                state.panes[id: paneID]?.gitBranch = branch
+                state.mutatePane(id: paneID) { $0.gitBranch = branch }
                 return .none
 
             case .toggleMarkdownEdit(let paneID):

--- a/Nex/Models/Pane.swift
+++ b/Nex/Models/Pane.swift
@@ -28,6 +28,11 @@ struct Pane: Identifiable, Equatable {
     /// Rendered body font size (px) for markdown preview panes. Per-pane,
     /// in-memory only; adjusted via Cmd+= / Cmd+-.
     var markdownFontSize: Double
+    /// When set on a markdown pane created via `nex open --here`, points
+    /// at the parked source pane in the workspace's `parkedPanes` lane.
+    /// Closing this pane restores the source instead of taking the
+    /// normal close path. In-memory only; not persisted.
+    var parkedSourcePaneID: UUID?
 
     /// Convenience accessor for rendering logic.
     var isUsingExternalEditor: Bool { externalEditorCommand != nil }
@@ -48,6 +53,7 @@ struct Pane: Identifiable, Equatable {
         status: PaneStatus = .idle,
         claudeSessionID: String? = nil,
         markdownFontSize: Double = 14,
+        parkedSourcePaneID: UUID? = nil,
         createdAt: Date = Date(),
         lastActivityAt: Date = Date()
     ) {
@@ -64,6 +70,7 @@ struct Pane: Identifiable, Equatable {
         self.status = status
         self.claudeSessionID = claudeSessionID
         self.markdownFontSize = markdownFontSize
+        self.parkedSourcePaneID = parkedSourcePaneID
         self.createdAt = createdAt
         self.lastActivityAt = lastActivityAt
     }

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -35,8 +35,9 @@ enum SocketMessage: Equatable {
     case groupCreate(name: String, color: WorkspaceColor?)
     case groupRename(nameOrID: String, newName: String)
     case groupDelete(nameOrID: String, cascade: Bool)
-    /// File commands
-    case openFile(path: String, paneID: UUID?)
+    /// File commands. `reuse` = replace the originating pane in place
+    /// (`nex open --here`) instead of splitting off it.
+    case openFile(path: String, paneID: UUID?, reuse: Bool)
     /// Layout commands
     case layoutCycle(paneID: UUID)
     case layoutSelect(paneID: UUID, name: String)
@@ -431,6 +432,8 @@ final class SocketServer: Sendable {
         // Request/response — `pane-list` filters
         var workspace: String?
         var scope: String?
+        /// `nex open --here` → replace originating pane in place.
+        var reuse: Bool?
 
         enum CodingKeys: String, CodingKey {
             case command
@@ -441,6 +444,7 @@ final class SocketServer: Sendable {
             case newName = "new_name"
             case cascade, index, group
             case workspace, scope
+            case reuse
         }
     }
 
@@ -491,7 +495,7 @@ final class SocketServer: Sendable {
         if wire.command == "open" {
             guard let path = wire.path, !path.isEmpty else { return nil }
             let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
-            return (.openFile(path: path, paneID: paneID), wire)
+            return (.openFile(path: path, paneID: paneID, reuse: wire.reuse ?? false), wire)
         }
 
         if wire.command == "pane-close" {

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -1714,4 +1714,142 @@ struct AppReducerTests {
             action: .openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: nil)
         )))
     }
+
+    // MARK: - Parked panes + workspace deletion
+
+    /// Deleting a workspace must tear down surfaces for *parked* panes
+    /// too. They're not in `layout.allPaneIDs`, so the original loop
+    /// (pre-parked-panes) would have leaked their PTYs.
+    @Test func deleteWorkspaceDestroysParkedPaneSurfaces() async {
+        let visibleID = UUID(uuidString: "00000000-0000-0000-0000-000000100001")!
+        let parkedID = UUID(uuidString: "00000000-0000-0000-0000-000000100002")!
+
+        var ws = Self.makeWorkspace(id: Self.wsID1, name: "W", paneID: visibleID)
+        ws.parkedPanes = [Pane(id: parkedID, type: .shell)]
+
+        let surfaceManager = SurfaceManager()
+        surfaceManager.createSurface(paneID: visibleID, workingDirectory: "/tmp")
+        surfaceManager.createSurface(paneID: parkedID, workingDirectory: "/tmp")
+        #expect(surfaceManager.activeSurfaceCount == 2)
+
+        var appState = AppReducer.State()
+        appState.workspaces = [ws]
+        appState.activeWorkspaceID = Self.wsID1
+        appState.topLevelOrder = [.workspace(Self.wsID1)]
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = surfaceManager
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.deleteWorkspace(Self.wsID1))
+        await store.finish()
+
+        #expect(surfaceManager.activeSurfaceCount == 0)
+    }
+
+    /// End-to-end: a parked pane's PTY can exit on its own (SIGHUP,
+    /// background job, etc.). The surface callback fires
+    /// `.surfaceProcessExited`. AppReducer must route this to the
+    /// workspace (which lives in the `parkedPanes` lane, not `panes`)
+    /// so the parked-eviction branch in `WorkspaceFeature` runs.
+    /// Before this fix the event was dropped and the parked entry
+    /// leaked.
+    @Test func parkedShellSurfaceExitReachesWorkspaceAndEvicts() async {
+        let visibleID = UUID(uuidString: "00000000-0000-0000-0000-0000BA5EBA11")!
+        let parkedID = UUID(uuidString: "00000000-0000-0000-0000-0000DEADBEEF")!
+        let markdownID = UUID(uuidString: "00000000-0000-0000-0000-000012345678")!
+
+        var ws = Self.makeWorkspace(id: Self.wsID1, name: "W", paneID: visibleID)
+        // Simulate a `--here` overlay: shell parked, markdown linked.
+        var markdownPane = Pane(id: markdownID, type: .markdown, filePath: "/tmp/x.md")
+        markdownPane.parkedSourcePaneID = parkedID
+        ws.panes.append(markdownPane)
+        ws.parkedPanes = [Pane(id: parkedID, type: .shell)]
+
+        let surfaceManager = SurfaceManager()
+        surfaceManager.createSurface(paneID: visibleID, workingDirectory: "/tmp")
+        surfaceManager.createSurface(paneID: parkedID, workingDirectory: "/tmp")
+        #expect(surfaceManager.activeSurfaceCount == 2)
+
+        var appState = AppReducer.State()
+        appState.workspaces = [ws]
+        appState.activeWorkspaceID = Self.wsID1
+        appState.topLevelOrder = [.workspace(Self.wsID1)]
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = surfaceManager
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.surfaceProcessExited(paneID: parkedID))
+        await store.receive(.workspaces(.element(
+            id: Self.wsID1,
+            action: .paneProcessTerminated(paneID: parkedID)
+        )))
+        await store.finish()
+
+        let wsState = store.state.workspaces[id: Self.wsID1]
+        #expect(wsState?.parkedPanes[id: parkedID] == nil)
+        // Markdown pane's link cleared so its close takes the normal path.
+        #expect(wsState?.panes[id: markdownID]?.parkedSourcePaneID == nil)
+        #expect(surfaceManager.surface(for: parkedID) == nil)
+        #expect(surfaceManager.surface(for: visibleID) != nil)
+    }
+
+    /// Agent lifecycle events (e.g. claude exits in a parked shell)
+    /// must also reach the workspace so the parked pane's status
+    /// tracking stays consistent. When we unpark later, the restored
+    /// terminal's badge should reflect reality.
+    @Test func parkedAgentStoppedUpdatesParkedPaneStatus() async {
+        let visibleID = UUID(uuidString: "00000000-0000-0000-0000-000022222222")!
+        let parkedID = UUID(uuidString: "00000000-0000-0000-0000-000033333333")!
+
+        var parkedPane = Pane(id: parkedID, type: .shell)
+        parkedPane.status = .running
+        var ws = Self.makeWorkspace(id: Self.wsID1, name: "W", paneID: visibleID)
+        ws.parkedPanes = [parkedPane]
+
+        var appState = AppReducer.State()
+        appState.workspaces = [ws]
+        appState.activeWorkspaceID = Self.wsID1
+        appState.topLevelOrder = [.workspace(Self.wsID1)]
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+            $0.notificationService = .testValue
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.socketMessage(.agentStopped(paneID: parkedID), reply: nil))
+        await store.receive(.workspaces(.element(
+            id: Self.wsID1,
+            action: .agentStopped(paneID: parkedID)
+        )))
+        await store.finish()
+
+        let parked = store.state.workspaces[id: Self.wsID1]?.parkedPanes[id: parkedID]
+        #expect(parked?.status == .waitingForInput)
+    }
 }

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -1679,4 +1679,39 @@ struct AppReducerTests {
             #expect(state.workspaces[id: Self.wsID1]?.focusedPaneID == nil)
         }
     }
+
+    // MARK: - openFile socket handoff
+
+    /// `--here` (reuse=true) with a resolvable source pane must hand
+    /// off a non-nil `reusePaneID` to the workspace action — a bug
+    /// that always passed `nil` here would silently fall back to the
+    /// split behaviour and would not be caught by the wire-parsing
+    /// or workspace-feature tests in isolation.
+    @Test func openFileWithReusePassesReusePaneID() async {
+        let ws = Self.makeWorkspace(id: Self.wsID1, name: "W", paneID: Self.paneID1)
+        let store = makeStore(workspaces: [ws], activeWorkspaceID: Self.wsID1)
+
+        await store.send(.socketMessage(
+            .openFile(path: "/tmp/plan.md", paneID: Self.paneID1, reuse: true),
+            reply: nil
+        ))
+        await store.receive(.workspaces(.element(
+            id: Self.wsID1,
+            action: .openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: Self.paneID1)
+        )))
+    }
+
+    @Test func openFileWithoutReuseSendsNilReusePaneID() async {
+        let ws = Self.makeWorkspace(id: Self.wsID1, name: "W", paneID: Self.paneID1)
+        let store = makeStore(workspaces: [ws], activeWorkspaceID: Self.wsID1)
+
+        await store.send(.socketMessage(
+            .openFile(path: "/tmp/plan.md", paneID: Self.paneID1, reuse: false),
+            reply: nil
+        ))
+        await store.receive(.workspaces(.element(
+            id: Self.wsID1,
+            action: .openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: nil)
+        )))
+    }
 }

--- a/NexTests/SocketParsingTests.swift
+++ b/NexTests/SocketParsingTests.swift
@@ -383,7 +383,7 @@ struct SocketParsingTests {
         """)
         let result = SocketServer.parseWireMessage(data)
         #expect(result != nil)
-        #expect(result?.0 == .openFile(path: "/tmp/plan.md", paneID: Self.paneUUID))
+        #expect(result?.0 == .openFile(path: "/tmp/plan.md", paneID: Self.paneUUID, reuse: false))
     }
 
     @Test func parseOpenCommandNoPaneID() {
@@ -392,7 +392,7 @@ struct SocketParsingTests {
         """)
         let result = SocketServer.parseWireMessage(data)
         #expect(result != nil)
-        #expect(result?.0 == .openFile(path: "/tmp/plan.md", paneID: nil))
+        #expect(result?.0 == .openFile(path: "/tmp/plan.md", paneID: nil, reuse: false))
     }
 
     @Test func parseOpenCommandMissingPath() {
@@ -409,6 +409,24 @@ struct SocketParsingTests {
         """)
         let result = SocketServer.parseWireMessage(data)
         #expect(result == nil)
+    }
+
+    @Test func parseOpenCommandWithReuse() {
+        let data = jsonData("""
+        {"command":"open","path":"/tmp/plan.md","pane_id":"\(Self.paneIDString)","reuse":true}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result != nil)
+        #expect(result?.0 == .openFile(path: "/tmp/plan.md", paneID: Self.paneUUID, reuse: true))
+    }
+
+    @Test func parseOpenCommandReuseFalseExplicit() {
+        let data = jsonData("""
+        {"command":"open","path":"/tmp/plan.md","pane_id":"\(Self.paneIDString)","reuse":false}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result != nil)
+        #expect(result?.0 == .openFile(path: "/tmp/plan.md", paneID: Self.paneUUID, reuse: false))
     }
 
     // MARK: - parseWireMessage — Error cases

--- a/NexTests/WorkspaceFeatureTests.swift
+++ b/NexTests/WorkspaceFeatureTests.swift
@@ -1299,11 +1299,17 @@ struct WorkspaceFeatureTests {
         store.exhaustivity = .off(showSkippedAssertions: false)
 
         await store.send(.openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: sourceID)) { state in
+            // Source moved to parked lane (alive but off-layout), not removed.
             #expect(state.panes[id: sourceID] == nil)
+            #expect(state.parkedPanes[id: sourceID] != nil)
+            #expect(state.parkedPanes[id: sourceID]?.workingDirectory == sourceCwd)
             let created = state.panes[id: newPaneID]
             #expect(created?.type == .markdown)
             #expect(created?.filePath == "/tmp/plan.md")
             #expect(created?.label == "plan.md")
+            // New markdown pane links back to the parked source so close
+            // knows to restore it.
+            #expect(created?.parkedSourcePaneID == sourceID)
             #expect(state.focusedPaneID == newPaneID)
             #expect(state.currentLayoutIndex == nil)
             // Layout: sibling is preserved, source leaf swapped for newPaneID.
@@ -1315,10 +1321,8 @@ struct WorkspaceFeatureTests {
             } else {
                 Issue.record("Expected horizontal split with source leaf replaced by new pane")
             }
-            // Snapshot of the replaced pane is queued for Undo.
-            #expect(state.recentlyClosedPanes.count == 1)
-            #expect(state.recentlyClosedPanes.first?.type == .shell)
-            #expect(state.recentlyClosedPanes.first?.workingDirectory == sourceCwd)
+            // Park is a dismiss-not-close: no recentlyClosedPanes snapshot.
+            #expect(state.recentlyClosedPanes.isEmpty)
         }
     }
 
@@ -1343,14 +1347,19 @@ struct WorkspaceFeatureTests {
         await store.send(.openMarkdownFile(filePath: "/tmp/notes.md", reusePaneID: sourceID)) { state in
             #expect(state.panes[id: sourceID] == nil)
             #expect(state.panes.count == 1)
+            #expect(state.parkedPanes.count == 1)
+            #expect(state.parkedPanes[id: sourceID] != nil)
+            #expect(state.panes[id: newPaneID]?.parkedSourcePaneID == sourceID)
             #expect(state.layout == .leaf(newPaneID))
             #expect(state.focusedPaneID == newPaneID)
         }
     }
 
-    @Test func openMarkdownFileReuseDestroysBackingSurfaceForShell() async {
-        // Regression guard: reusing a shell pane in place must tear down
-        // the backing ghostty surface, not leak it.
+    @Test func openMarkdownFileReusePreservesBackingSurfaceForShell() async {
+        // Correctness claim: reusing a shell pane must NOT tear down
+        // its backing ghostty surface. The PTY stays alive while the
+        // pane is parked, ready for closePane to unpark it back into
+        // the layout with all state (scrollback, prompt, jobs) intact.
         var workspace = WorkspaceFeature.State(name: "Test")
         let sourceID = workspace.panes.first!.id
         let siblingID = UUID()
@@ -1366,6 +1375,7 @@ struct WorkspaceFeatureTests {
         let surfaceManager = SurfaceManager()
         surfaceManager.createSurface(paneID: sourceID, workingDirectory: "/tmp")
         #expect(surfaceManager.activeSurfaceCount == 1)
+        let originalSurface = surfaceManager.surface(for: sourceID)
 
         let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000333333")!
 
@@ -1382,8 +1392,11 @@ struct WorkspaceFeatureTests {
         await store.send(.openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: sourceID))
         await store.finish()
 
+        // Source is parked (still alive), surface untouched.
         #expect(store.state.panes[id: sourceID] == nil)
-        #expect(surfaceManager.activeSurfaceCount == 0)
+        #expect(store.state.parkedPanes[id: sourceID] != nil)
+        #expect(surfaceManager.activeSurfaceCount == 1)
+        #expect(surfaceManager.surface(for: sourceID) === originalSurface)
     }
 
     @Test func openMarkdownFileReuseClearsZoomAndSearchState() async {
@@ -1434,6 +1447,218 @@ struct WorkspaceFeatureTests {
             #expect(state.searchTotal == nil)
             #expect(state.searchSelected == nil)
             #expect(state.focusedPaneID == newPaneID)
+            // Source parked for later restore.
+            #expect(state.parkedPanes[id: sourceID] != nil)
         }
+    }
+
+    // MARK: - Close markdown pane → unpark source (--here round-trip)
+
+    @Test func closeMarkdownUnparksSource() async {
+        // Round-trip: shell → `--here` markdown → close markdown.
+        // The shell's surface (PTY) must be the SAME object before and
+        // after — that's the whole point of the feature.
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let shellID = workspace.panes.first!.id
+        let siblingID = UUID()
+        workspace.panes.append(Pane(id: siblingID, type: .shell))
+        workspace.layout = .split(
+            .horizontal,
+            ratio: 0.5,
+            first: .leaf(shellID),
+            second: .leaf(siblingID)
+        )
+        workspace.focusedPaneID = shellID
+
+        let surfaceManager = SurfaceManager()
+        surfaceManager.createSurface(paneID: shellID, workingDirectory: "/tmp")
+        let originalSurface = surfaceManager.surface(for: shellID)
+        #expect(originalSurface != nil)
+
+        let markdownID = UUID(uuidString: "00000000-0000-0000-0000-0000000FFFFF")!
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = surfaceManager
+            $0.date = .constant(Date(timeIntervalSince1970: 5000))
+            $0.uuid = .constant(markdownID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: shellID))
+        await store.finish()
+        #expect(store.state.parkedPanes[id: shellID] != nil)
+
+        await store.send(.closePane(markdownID))
+        await store.finish()
+
+        // Shell back in the visible pane set; markdown gone; layout
+        // restored to shell + sibling; focus on shell.
+        #expect(store.state.panes[id: shellID] != nil)
+        #expect(store.state.panes[id: markdownID] == nil)
+        #expect(store.state.parkedPanes[id: shellID] == nil)
+        #expect(store.state.focusedPaneID == shellID)
+        if case .split(_, _, .leaf(let first), .leaf(let second)) = store.state.layout {
+            #expect(first == shellID)
+            #expect(second == siblingID)
+        } else {
+            Issue.record("Expected layout restored with shell + sibling split")
+        }
+        // Surface identity: same SurfaceView instance, PTY untouched.
+        #expect(surfaceManager.surface(for: shellID) === originalSurface)
+        #expect(surfaceManager.activeSurfaceCount == 1)
+    }
+
+    @Test func closeMarkdownWithExternalEditorTearsDownOnlyOwnSurface() async {
+        // While the source is parked, the markdown pane itself can
+        // have entered external-editor mode (its own PTY). On close
+        // we tear down the markdown's surface but leave the parked
+        // shell's surface alone.
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let shellID = workspace.panes.first!.id
+        workspace.layout = .leaf(shellID)
+        workspace.focusedPaneID = shellID
+
+        let surfaceManager = SurfaceManager()
+        surfaceManager.createSurface(paneID: shellID, workingDirectory: "/tmp")
+        let shellSurface = surfaceManager.surface(for: shellID)
+
+        let markdownID = UUID(uuidString: "00000000-0000-0000-0000-00000000EEEE")!
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = surfaceManager
+            $0.date = .constant(Date(timeIntervalSince1970: 5000))
+            $0.uuid = .constant(markdownID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+            // Resolvable editor so toggleMarkdownEdit flips to
+            // external-editor mode and createSurface(paneID: markdownID)
+            // runs through the real path.
+            $0.editorService.buildCommand = { path in "nvim \(path)" }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        // 1. --here parks shell, creates markdown pane.
+        await store.send(.openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: shellID))
+        await store.finish()
+
+        // 2. Markdown enters external editor mode → second surface.
+        await store.send(.toggleMarkdownEdit(markdownID))
+        await store.finish()
+        #expect(store.state.panes[id: markdownID]?.isUsingExternalEditor == true)
+        #expect(surfaceManager.activeSurfaceCount == 2)
+
+        // 3. Close markdown. Unpark branch runs; markdown's own
+        // surface is destroyed but shell's stays alive.
+        await store.send(.closePane(markdownID))
+        await store.finish()
+
+        #expect(surfaceManager.surface(for: markdownID) == nil)
+        #expect(surfaceManager.surface(for: shellID) === shellSurface)
+        #expect(surfaceManager.activeSurfaceCount == 1)
+        #expect(store.state.panes[id: shellID] != nil)
+        #expect(store.state.parkedPanes[id: shellID] == nil)
+    }
+
+    @Test func chainedReuseUnwindsOneLevel() async {
+        // shell → --here → mdA; from mdA → --here → mdB.
+        // Close mdB: mdA comes back (still linked to shell).
+        // Close mdA: shell comes back.
+        var workspace = WorkspaceFeature.State(name: "Chain")
+        let shellID = workspace.panes.first!.id
+        workspace.layout = .leaf(shellID)
+        workspace.focusedPaneID = shellID
+
+        let surfaceManager = SurfaceManager()
+        surfaceManager.createSurface(paneID: shellID, workingDirectory: "/tmp")
+        let shellSurface = surfaceManager.surface(for: shellID)
+
+        let mdAID = UUID(uuidString: "00000000-0000-0000-0000-000000AAAAAA")!
+        let mdBID = UUID(uuidString: "00000000-0000-0000-0000-000000BBBBBB")!
+
+        // First `--here`: shellID → mdAID
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = surfaceManager
+            $0.date = .constant(Date(timeIntervalSince1970: 5000))
+            $0.uuid = .constant(mdAID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openMarkdownFile(filePath: "/tmp/A.md", reusePaneID: shellID))
+        await store.finish()
+        #expect(store.state.parkedPanes[id: shellID] != nil)
+        #expect(store.state.panes[id: mdAID]?.parkedSourcePaneID == shellID)
+
+        // Second `--here`: mdAID → mdBID. Swap the uuid dep.
+        store.dependencies.uuid = .constant(mdBID)
+        await store.send(.openMarkdownFile(filePath: "/tmp/B.md", reusePaneID: mdAID))
+        await store.finish()
+        // shell still parked (deeper); mdA parked on top.
+        #expect(store.state.parkedPanes[id: shellID] != nil)
+        #expect(store.state.parkedPanes[id: mdAID] != nil)
+        #expect(store.state.panes[id: mdBID]?.parkedSourcePaneID == mdAID)
+        // Critical chain invariant: parked mdA keeps its link to shell.
+        #expect(store.state.parkedPanes[id: mdAID]?.parkedSourcePaneID == shellID)
+
+        // Close B → mdA restored, still linked to shell.
+        await store.send(.closePane(mdBID))
+        await store.finish()
+        #expect(store.state.panes[id: mdAID] != nil)
+        #expect(store.state.panes[id: mdAID]?.parkedSourcePaneID == shellID)
+        #expect(store.state.parkedPanes[id: mdAID] == nil)
+        #expect(store.state.parkedPanes[id: shellID] != nil)
+        #expect(store.state.focusedPaneID == mdAID)
+
+        // Close A → shell restored.
+        await store.send(.closePane(mdAID))
+        await store.finish()
+        #expect(store.state.panes[id: shellID] != nil)
+        #expect(store.state.parkedPanes.isEmpty)
+        #expect(store.state.focusedPaneID == shellID)
+
+        // Shell's surface is the same all the way through.
+        #expect(surfaceManager.surface(for: shellID) === shellSurface)
+    }
+
+    @Test func parkedShellTerminationEvictsAndUnlinks() async {
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let shellID = workspace.panes.first!.id
+        workspace.layout = .leaf(shellID)
+        workspace.focusedPaneID = shellID
+
+        let surfaceManager = SurfaceManager()
+        surfaceManager.createSurface(paneID: shellID, workingDirectory: "/tmp")
+
+        let markdownID = UUID(uuidString: "00000000-0000-0000-0000-00000000CCCC")!
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = surfaceManager
+            $0.date = .constant(Date(timeIntervalSince1970: 5000))
+            $0.uuid = .constant(markdownID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: shellID))
+        await store.finish()
+        #expect(store.state.parkedPanes[id: shellID] != nil)
+
+        // Parked shell's process dies unexpectedly.
+        await store.send(.paneProcessTerminated(paneID: shellID))
+        await store.finish()
+
+        // Parked lane emptied; markdown's link cleared so a subsequent
+        // close takes the normal path.
+        #expect(store.state.parkedPanes[id: shellID] == nil)
+        #expect(store.state.panes[id: markdownID]?.parkedSourcePaneID == nil)
+        #expect(surfaceManager.activeSurfaceCount == 0)
     }
 }

--- a/NexTests/WorkspaceFeatureTests.swift
+++ b/NexTests/WorkspaceFeatureTests.swift
@@ -1268,4 +1268,172 @@ struct WorkspaceFeatureTests {
             state.currentLayoutIndex = 0
         }
     }
+
+    // MARK: - openMarkdownFile --here (reuse)
+
+    @Test func openMarkdownFileReusesPaneInPlace() async {
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let sourceID = workspace.panes.first!.id
+        let siblingID = UUID()
+        workspace.panes.append(Pane(id: siblingID))
+        workspace.layout = .split(
+            .horizontal,
+            ratio: 0.5,
+            first: .leaf(sourceID),
+            second: .leaf(siblingID)
+        )
+        workspace.focusedPaneID = sourceID
+        let sourceCwd = workspace.panes[id: sourceID]!.workingDirectory
+
+        let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000ABCDEF")!
+        let fixedNow = Date(timeIntervalSince1970: 1000)
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(fixedNow)
+            $0.uuid = .constant(newPaneID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: sourceID)) { state in
+            #expect(state.panes[id: sourceID] == nil)
+            let created = state.panes[id: newPaneID]
+            #expect(created?.type == .markdown)
+            #expect(created?.filePath == "/tmp/plan.md")
+            #expect(created?.label == "plan.md")
+            #expect(state.focusedPaneID == newPaneID)
+            #expect(state.currentLayoutIndex == nil)
+            // Layout: sibling is preserved, source leaf swapped for newPaneID.
+            if case .split(let dir, let ratio, .leaf(let first), .leaf(let second)) = state.layout {
+                #expect(dir == .horizontal)
+                #expect(ratio == 0.5)
+                #expect(first == newPaneID)
+                #expect(second == siblingID)
+            } else {
+                Issue.record("Expected horizontal split with source leaf replaced by new pane")
+            }
+            // Snapshot of the replaced pane is queued for Undo.
+            #expect(state.recentlyClosedPanes.count == 1)
+            #expect(state.recentlyClosedPanes.first?.type == .shell)
+            #expect(state.recentlyClosedPanes.first?.workingDirectory == sourceCwd)
+        }
+    }
+
+    @Test func openMarkdownFileReuseWhenOnlyPane() async {
+        var workspace = WorkspaceFeature.State(name: "Solo")
+        let sourceID = workspace.panes.first!.id
+        workspace.layout = .leaf(sourceID)
+        workspace.focusedPaneID = sourceID
+
+        let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000111111")!
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(Date(timeIntervalSince1970: 2000))
+            $0.uuid = .constant(newPaneID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openMarkdownFile(filePath: "/tmp/notes.md", reusePaneID: sourceID)) { state in
+            #expect(state.panes[id: sourceID] == nil)
+            #expect(state.panes.count == 1)
+            #expect(state.layout == .leaf(newPaneID))
+            #expect(state.focusedPaneID == newPaneID)
+        }
+    }
+
+    @Test func openMarkdownFileReuseDestroysBackingSurfaceForShell() async {
+        // Regression guard: reusing a shell pane in place must tear down
+        // the backing ghostty surface, not leak it.
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let sourceID = workspace.panes.first!.id
+        let siblingID = UUID()
+        workspace.panes.append(Pane(id: siblingID, type: .shell))
+        workspace.layout = .split(
+            .horizontal,
+            ratio: 0.5,
+            first: .leaf(sourceID),
+            second: .leaf(siblingID)
+        )
+        workspace.focusedPaneID = sourceID
+
+        let surfaceManager = SurfaceManager()
+        surfaceManager.createSurface(paneID: sourceID, workingDirectory: "/tmp")
+        #expect(surfaceManager.activeSurfaceCount == 1)
+
+        let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000333333")!
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = surfaceManager
+            $0.date = .constant(Date(timeIntervalSince1970: 4000))
+            $0.uuid = .constant(newPaneID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openMarkdownFile(filePath: "/tmp/plan.md", reusePaneID: sourceID))
+        await store.finish()
+
+        #expect(store.state.panes[id: sourceID] == nil)
+        #expect(surfaceManager.activeSurfaceCount == 0)
+    }
+
+    @Test func openMarkdownFileReuseClearsZoomAndSearchState() async {
+        var workspace = WorkspaceFeature.State(name: "Zoomed")
+        let sourceID = workspace.panes.first!.id
+        let siblingID = UUID()
+        workspace.panes.append(Pane(id: siblingID))
+        let fullLayout: PaneLayout = .split(
+            .horizontal,
+            ratio: 0.5,
+            first: .leaf(sourceID),
+            second: .leaf(siblingID)
+        )
+        workspace.layout = .leaf(sourceID) // zoomed layout
+        workspace.savedLayout = fullLayout
+        workspace.zoomedPaneID = sourceID
+        workspace.focusedPaneID = sourceID
+        workspace.searchingPaneID = sourceID
+        workspace.searchNeedle = "foo"
+        workspace.searchTotal = 3
+        workspace.searchSelected = 1
+
+        let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000222222")!
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(Date(timeIntervalSince1970: 3000))
+            $0.uuid = .constant(newPaneID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openMarkdownFile(filePath: "/tmp/x.md", reusePaneID: sourceID)) { state in
+            // Zoom restored to full layout, then source swapped for new pane.
+            #expect(state.savedLayout == nil)
+            #expect(state.zoomedPaneID == nil)
+            if case .split(_, _, .leaf(let first), .leaf(let second)) = state.layout {
+                #expect(first == newPaneID)
+                #expect(second == siblingID)
+            } else {
+                Issue.record("Expected restored layout with source leaf replaced")
+            }
+            // Search state cleared because source was the searching pane.
+            #expect(state.searchingPaneID == nil)
+            #expect(state.searchNeedle == "")
+            #expect(state.searchTotal == nil)
+            #expect(state.searchSelected == nil)
+            #expect(state.focusedPaneID == newPaneID)
+        }
+    }
 }

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -21,7 +21,7 @@
 //   nex group delete <name-or-id> [--cascade]
 //   nex layout cycle
 //   nex layout select <name>
-//   nex open <filepath>
+//   nex open [--here] <filepath>
 //
 // Reads NEX_PANE_ID from the environment (injected by Nex when the PTY was created).
 // Reads NEX_SOCKET from the environment to select transport:
@@ -91,7 +91,7 @@ func printUsage() {
       nex group delete <name-or-id> [--cascade]
       nex layout cycle
       nex layout select <name>
-      nex open <filepath>
+      nex open [--here] <filepath>
     \n
     """, stderr)
 }
@@ -824,14 +824,15 @@ func handleLayout(_ args: inout ArraySlice<String>) {
 }
 
 func handleOpen(_ args: inout ArraySlice<String>) {
+    let reuse = popSwitch("--here", from: &args)
     guard let filePath = args.popFirst() else {
-        fputs("Usage: nex open <filepath>\n", stderr)
+        fputs("Usage: nex open [--here] <filepath>\n", stderr)
         exit(1)
     }
 
     let absolutePath = URL(fileURLWithPath: filePath).standardizedFileURL.path
 
-    var payload: [String: String] = [
+    var payload: [String: Any] = [
         "command": "open",
         "path": absolutePath
     ]
@@ -840,7 +841,11 @@ func handleOpen(_ args: inout ArraySlice<String>) {
         payload["pane_id"] = paneID
     }
 
-    sendJSON(payload)
+    if reuse {
+        payload["reuse"] = true
+    }
+
+    sendJSONAny(payload)
 }
 
 // MARK: - Main


### PR DESCRIPTION
## Summary

Adds a `--here` flag to `nex open <file>` (closes #63) so the markdown pane replaces the originating terminal in place instead of splitting off it. Closes the round-trip by parking the source terminal off-layout rather than destroying it — closing the markdown pane drops back to the exact same shell (PTY, scrollback, prompt, background jobs intact). Chains cleanly across multiple `--here` overlays.

Two commits:
- `5e1a485` — CLI flag, wire protocol, workspace reducer branch that replaces the originating leaf with a fresh markdown pane.
- `27b107b` — park/unpark lane: source stays alive off-layout until the markdown pane closes. Surface and agent lifecycle events (process exit, agent status, title/cwd, OSC notifications) route through both visible and parked lanes so parked PTYs evict cleanly on exit and status tracking stays accurate. User commands (`pane send`/`split`/`close`) intentionally stay visible-only — parked panes are not user-addressable.

## What users see

- `nex open README.md --here` from inside a pane: markdown appears in place, shell is gone from view.
- Close the markdown pane (⌘W): the same shell returns, with the same prompt, scrollback, and any `sleep 300 &` still in `jobs`.
- Chain: from the restored shell, `nex open NOTES.md --here`, then from that pane `nex open ANOTHER.md --here`. Close twice, shell is back. No zombies in `ps`.

## Implementation notes

- New transient state: `Pane.parkedSourcePaneID`, `WorkspaceFeature.State.parkedPanes`. Both in-memory only — parked PTYs don't survive app restart, so persisting would leave zombie references.
- Surface teardown matches `closePane` semantics: the markdown pane's own external-editor PTY (if any) is torn down on close; the parked shell's surface is preserved.
- Workspace/group deletion extends its surface-destroy pass to include `parkedPanes` (previously would have leaked).
- `autoUnlinkUnusedRepos` now considers parked pane cwd so parking the last shell in a worktree doesn't trigger spurious auto-unlink/relink churn.

## Test plan

- [x] `xcodebuild test` — 561 tests passing (added 13 for this feature)
- [x] `swiftlint lint` + `swiftformat --lint .` clean
- [x] Manual: `nex open README.md --here` from a shell, close, confirm same PTY (pid unchanged, scrollback intact)
- [x] Manual: `seq 1 500` before `--here`, verify scrollback after close round-trip
- [x] Manual: `sleep 300 &` before `--here`, verify `jobs` after round-trip
- [x] Manual: external-editor-during-overlay — `--here` → ⌘E → close; verify editor PTY torn down, shell restored
- [x] Manual: workspace deletion with parked shell present — verify no orphan ghostty procs in `ps`
- [x] Manual: agent-in-parked-shell — start a claude session, `--here`, trigger `nex event stop` targeting the parked shell's paneID; status badge updates correctly on restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)