### PR TITLE
feat: render markdown front-matter as a styled table (#73)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ make check
 ### Markdown panes
 - **Entry points**: ⌘O (file picker filtered to `.md`) or drag-and-drop a `.md` file onto the window. Both route through `AppReducer.openFileAtPath` → `WorkspaceFeature.openMarkdownFile`.
 - **View mode** (`MarkdownPaneView`): `WKWebView` with `drawsBackground=false`. File content is parsed via swift-markdown → `MarkdownHTMLRenderer` → full HTML document with CSS (light/dark). Live file watching via `DispatchSource` detects writes, renames, and deletes (vim-style save). Scroll position is preserved across reloads.
+- **Front-matter**: if a file begins with a `---`-fenced YAML block, `FrontMatterExtractor` pulls it out before swift-markdown parsing and `FrontMatterRenderer` emits a styled two-column table at the top of the preview. Parsing uses Yams; malformed YAML falls back to a styled raw block, and blocks larger than 64 KiB are skipped (rendered as plain markdown) to guard against pathological input.
 - **Edit mode** (`MarkdownEditorView`): `NSTextView` (plain text, monospace 13pt) in an `NSScrollView`. Auto-saves to disk with 500ms debounce.
 - **Toggle**: ⌘E switches between view and edit mode (only when a markdown pane is focused). Header button also toggles.
 - **Background**: both views receive `ghosttyConfig.backgroundColor` / `backgroundOpacity` so they match terminal panes. The pane container also has a matching background fill for any gaps.

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -42,8 +42,10 @@
 		550563B9BEDE841D3B7CE6B8 /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221A3B0170CFD708F3B03A84 /* Repo.swift */; };
 		5883FFD10BE73F44EA8F4A5C /* PaneSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE917FD003D3FFD196DBF77 /* PaneSearchOverlay.swift */; };
 		58B6A951A34B2ED1516194C4 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08D39F8F87D7505CD32D25D /* WebKit.framework */; };
+		59239C7AD0D26E390C647C46 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 98CF017F4F26916F63300A33 /* Yams */; };
 		5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */; };
 		64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A24C1FEC6EA31096603326 /* SurfaceManager.swift */; };
+		696312BB96D35569F48B7CAE /* MarkdownFrontMatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43F769C33118440222BF5FA /* MarkdownFrontMatter.swift */; };
 		6ACFF31A3875EBE87E78C587 /* RepoAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A1CB3D7653911EF93F8F5 /* RepoAssociation.swift */; };
 		6C50041FBB0F31598067D4FA /* LineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */; };
 		6CF210BA0C7BFE62B90844F7 /* KeybindingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439174A029FAFE2C252A1B8B /* KeybindingsSettingsView.swift */; };
@@ -238,6 +240,7 @@
 		F173122691292BD9062F356E /* CheckForUpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUpdatesView.swift; sourceTree = "<group>"; };
 		F1A8D5B3446F6056F443CDB8 /* Nex.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Nex.entitlements; sourceTree = "<group>"; };
 		F228193206574DB257C8B3FB /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		F43F769C33118440222BF5FA /* MarkdownFrontMatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFrontMatter.swift; sourceTree = "<group>"; };
 		F5CE8D708EEECA4A82BE0AC1 /* PaneCloseReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneCloseReplyTests.swift; sourceTree = "<group>"; };
 		F7F9C43CA9B19E7281082913 /* WorkspaceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceListView.swift; sourceTree = "<group>"; };
 		F90FF9C2E7F0BC50E51C47DE /* RepoRegistryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoRegistryView.swift; sourceTree = "<group>"; };
@@ -255,6 +258,7 @@
 				811C87C669F7A920EE05E8DA /* GRDB in Frameworks */,
 				52D4477AF5CCF1724D609119 /* Sparkle in Frameworks */,
 				A15BBD1CFDB5E52E44B7ED59 /* Markdown in Frameworks */,
+				59239C7AD0D26E390C647C46 /* Yams in Frameworks */,
 				2364A5458060B16493954543 /* Metal.framework in Frameworks */,
 				58B6A951A34B2ED1516194C4 /* WebKit.framework in Frameworks */,
 				14C1E964B19A8C277D5EA5E4 /* QuartzCore.framework in Frameworks */,
@@ -499,6 +503,7 @@
 			children = (
 				852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */,
 				7ED3289901F70616FC36F80B /* MarkdownEditorView.swift */,
+				F43F769C33118440222BF5FA /* MarkdownFrontMatter.swift */,
 				1E7D450881FC7318F58CB78F /* MarkdownHTMLRenderer.swift */,
 				B02A888F436610636F5A4D55 /* MarkdownPaneView.swift */,
 			);
@@ -571,6 +576,7 @@
 				3A812A87D56E4976C8BF532E /* GRDB */,
 				EFC4D8E9A152683486EC7F29 /* Sparkle */,
 				A7AC116A099F0911E230E51F /* Markdown */,
+				98CF017F4F26916F63300A33 /* Yams */,
 			);
 			productName = Nex;
 			productReference = E5859C5B2E1850D1262AFE4B /* Nex.app */;
@@ -606,6 +612,7 @@
 				6E173FC7EE2E93830E33275D /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
 				74E1DDA9D84597B0F162BA1C /* XCRemoteSwiftPackageReference "GRDB.swift" */,
 				A90C5D38F552F217B7D089E9 /* XCRemoteSwiftPackageReference "Sparkle" */,
+				BDC72AE7CC087295CCC0D1B0 /* XCRemoteSwiftPackageReference "Yams" */,
 				9F09C051CE1194C74915BD2E /* XCRemoteSwiftPackageReference "swift-markdown" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -719,6 +726,7 @@
 				6CF210BA0C7BFE62B90844F7 /* KeybindingsSettingsView.swift in Sources */,
 				6C50041FBB0F31598067D4FA /* LineNumberRulerView.swift in Sources */,
 				291A22061671351813971551 /* MarkdownEditorView.swift in Sources */,
+				696312BB96D35569F48B7CAE /* MarkdownFrontMatter.swift in Sources */,
 				AC234A5AAADE90A7EC7BB5F8 /* MarkdownHTMLRenderer.swift in Sources */,
 				E56B0EC49D7AC553B5CDC2CC /* MarkdownPaneView.swift in Sources */,
 				F232D23668E3159B6EA5FC37 /* NewGroupSheet.swift in Sources */,
@@ -1093,6 +1101,14 @@
 				minimumVersion = 2.6.0;
 			};
 		};
+		BDC72AE7CC087295CCC0D1B0 /* XCRemoteSwiftPackageReference "Yams" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jpsim/Yams";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1105,6 +1121,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6E173FC7EE2E93830E33275D /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
 			productName = ComposableArchitecture;
+		};
+		98CF017F4F26916F63300A33 /* Yams */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BDC72AE7CC087295CCC0D1B0 /* XCRemoteSwiftPackageReference "Yams" */;
+			productName = Yams;
 		};
 		A7AC116A099F0911E230E51F /* Markdown */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Nex/Features/MarkdownPane/MarkdownFrontMatter.swift
+++ b/Nex/Features/MarkdownPane/MarkdownFrontMatter.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Yams
+
+/// Maximum size of a YAML front-matter block we'll try to parse. Files with a
+/// larger block fall through as "no front-matter" to guard against
+/// pathological / YAML-bomb inputs.
+private let frontMatterSizeCapBytes = 64 * 1024
+
+enum FrontMatterExtractor {
+    /// Returns `(yaml, body)`. `yaml` is nil when the markdown does not begin
+    /// with a well-formed `---\n...\n---\n` block (or the block exceeds the
+    /// size cap). `body` is the markdown with the front-matter block removed.
+    static func extract(_ markdown: String) -> (yaml: String?, body: String) {
+        var input = markdown
+        // Strip a single leading BOM.
+        if input.first == "\u{FEFF}" {
+            input.removeFirst()
+        }
+
+        // In Swift, "\r\n" is one extended grapheme cluster — a single Character
+        // — so we match any of \n, \r\n, or \r as a line terminator.
+        let isLineEnd: (Character) -> Bool = { $0 == "\n" || $0 == "\r\n" || $0 == "\r" }
+
+        // A fence line is `---` or `...` at column 0, optionally followed by
+        // spaces/tabs, and nothing else. Leading whitespace disqualifies — we
+        // don't want an indented `---` inside body prose to be interpreted as
+        // a fence.
+        let isFence: (Substring, String) -> Bool = { line, marker in
+            guard line.hasPrefix(marker) else { return false }
+            let rest = line.dropFirst(marker.count)
+            return rest.allSatisfy { $0 == " " || $0 == "\t" }
+        }
+
+        // Opening fence: the very first line must be `---` (+ trailing ws).
+        guard let firstNewline = input.firstIndex(where: isLineEnd) else {
+            return (nil, markdown)
+        }
+        let firstLine = input[input.startIndex ..< firstNewline]
+        guard isFence(firstLine, "---") else {
+            return (nil, markdown)
+        }
+
+        // Scan subsequent lines for a closing fence of `---` or `...`, tracking
+        // UTF-8 bytes so we bail on pathological input before materializing the
+        // YAML substring.
+        var cursor = input.index(after: firstNewline)
+        var bytesScanned = 0
+        while cursor < input.endIndex {
+            let lineEnd = input[cursor...].firstIndex(where: isLineEnd) ?? input.endIndex
+            let line = input[cursor ..< lineEnd]
+            if isFence(line, "---") || isFence(line, "...") {
+                let yamlStart = input.index(after: firstNewline)
+                let yamlEnd = cursor
+                // Drop the trailing newline between last YAML line and fence.
+                let yaml = String(input[yamlStart ..< yamlEnd]).trimmingTrailingNewline()
+
+                // Body = everything after the closing fence's newline.
+                let afterFence: String.Index = if lineEnd < input.endIndex {
+                    input.index(after: lineEnd)
+                } else {
+                    input.endIndex
+                }
+                let body = String(input[afterFence...])
+                return (yaml, body)
+            }
+            // +1 accounts for the newline that ended this line (not present
+            // only when we hit end-of-input, in which case we'll break below).
+            bytesScanned += line.utf8.count + 1
+            if bytesScanned > frontMatterSizeCapBytes {
+                return (nil, markdown)
+            }
+            if lineEnd == input.endIndex { break }
+            cursor = input.index(after: lineEnd)
+        }
+
+        return (nil, markdown)
+    }
+}
+
+enum FrontMatterRenderer {
+    /// Renders a YAML front-matter block as HTML. Returns `""` when the block
+    /// is empty or produces an empty mapping.
+    ///
+    /// - Well-formed mapping → styled `<table class="frontmatter">`.
+    /// - Malformed YAML or non-mapping root → `<pre class="frontmatter-raw">`
+    ///   with the raw (escaped) YAML.
+    static func render(_ yaml: String) -> String {
+        let trimmed = yaml.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return "" }
+
+        let node: Node?
+        do {
+            node = try Yams.compose(yaml: yaml)
+        } catch {
+            return rawFallback(yaml)
+        }
+        guard let node, let mapping = node.mapping else {
+            return rawFallback(yaml)
+        }
+        if mapping.isEmpty { return "" }
+
+        var rows = ""
+        for (keyNode, valueNode) in mapping {
+            let keyText = keyNode.scalar?.string ?? String(describing: keyNode)
+            let key = escapeHTML(keyText)
+            let value = renderValue(valueNode)
+            rows += "<tr><th scope=\"row\">\(key)</th><td>\(value)</td></tr>\n"
+        }
+        return "<table class=\"frontmatter\">\n<tbody>\n\(rows)</tbody>\n</table>\n"
+    }
+
+    private static func renderValue(_ node: Node) -> String {
+        switch node {
+        case let .scalar(scalar):
+            // Multi-line scalars (block `|`, folded `>`, or any value that
+            // contains a newline) would otherwise collapse in a <td>; route
+            // them to a pre so line breaks survive.
+            if scalar.string.contains("\n") {
+                return nestedPre(node)
+            }
+            return escapeHTML(scalar.string)
+        case let .sequence(seq):
+            // Only comma-join if every child is a SINGLE-LINE scalar; a
+            // multiline block scalar inside the sequence would otherwise
+            // collapse inside the <td>.
+            let allSingleLineScalars = seq.allSatisfy {
+                if let s = $0.scalar?.string { return !s.contains("\n") }
+                return false
+            }
+            if allSingleLineScalars {
+                let parts = seq.map { escapeHTML($0.scalar?.string ?? "") }
+                return parts.joined(separator: ", ")
+            }
+            return nestedPre(node)
+        case .mapping:
+            return nestedPre(node)
+        case let .alias(alias):
+            // Show the YAML alias source form (`*name`) rather than a bare
+            // identifier that would look like an orphaned word.
+            return escapeHTML("*\(alias.anchor.rawValue)")
+        }
+    }
+
+    private static func nestedPre(_ node: Node) -> String {
+        let serialized = (try? Yams.serialize(node: node)) ?? ""
+        let cleaned = serialized.trimmingCharacters(in: .whitespacesAndNewlines)
+        return "<pre class=\"frontmatter-nested\">\(escapeHTML(cleaned))</pre>"
+    }
+
+    private static func rawFallback(_ yaml: String) -> String {
+        "<pre class=\"frontmatter-raw\">\(escapeHTML(yaml))</pre>\n"
+    }
+
+    private static func escapeHTML(_ text: String) -> String {
+        text.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}
+
+private extension String {
+    /// Drops a single trailing newline grapheme (`\n`, `\r\n`, or `\r`) so the
+    /// YAML text doesn't carry the newline that precedes the closing fence.
+    /// Swift treats `\r\n` as a single extended grapheme cluster, hence one
+    /// `dropLast()` call covers all three forms.
+    func trimmingTrailingNewline() -> String {
+        if let last, last == "\n" || last == "\r\n" || last == "\r" {
+            return String(dropLast())
+        }
+        return self
+    }
+}

--- a/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
+++ b/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
@@ -165,13 +165,15 @@ enum MarkdownRenderer {
         backgroundOpacity: Double = 1.0,
         baseFontSize: Double = 14
     ) -> String {
-        let document = Document(parsing: markdown)
+        let (yaml, body) = FrontMatterExtractor.extract(markdown)
+        let document = Document(parsing: body)
         var visitor = MarkdownHTMLRenderer()
         let bodyHTML = visitor.visit(document)
+        let fmHTML = yaml.map(FrontMatterRenderer.render) ?? ""
         let bgCSS = cssBackground(color: backgroundColor, opacity: backgroundOpacity)
         let isDark = isDarkBackground(color: backgroundColor)
         return wrapInHTMLDocument(
-            bodyHTML,
+            fmHTML + bodyHTML,
             backgroundCSS: bgCSS,
             isDark: isDark,
             baseFontSize: baseFontSize
@@ -296,6 +298,59 @@ enum MarkdownRenderer {
         img { max-width: 100%; border-radius: 4px; }
         del { color: #656d76; }
         .dark del { color: #9198a1; }
+        table.frontmatter {
+            margin: 0 0 1.5em;
+            border: 1px solid #d1d9e0;
+            border-radius: 6px;
+            border-collapse: separate;
+            border-spacing: 0;
+            width: auto;
+            min-width: 40%;
+            max-width: 100%;
+            font-size: 0.9em;
+            overflow: hidden;
+        }
+        .dark table.frontmatter { border-color: #3d444d; }
+        table.frontmatter th,
+        table.frontmatter td {
+            border: none;
+            border-bottom: 1px solid #d1d9e0;
+            padding: 6px 12px;
+            text-align: start;
+            vertical-align: top;
+        }
+        .dark table.frontmatter th,
+        .dark table.frontmatter td { border-bottom-color: #3d444d; }
+        table.frontmatter tr:last-child th,
+        table.frontmatter tr:last-child td { border-bottom: none; }
+        table.frontmatter th {
+            font-weight: 600;
+            color: #656d76;
+            background: #f6f8fa;
+            white-space: nowrap;
+            width: 1%;
+        }
+        .dark table.frontmatter th { background: #161b22; color: #9198a1; }
+        table.frontmatter td {
+            font-family: 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+            font-size: 0.95em;
+            word-break: break-word;
+        }
+        pre.frontmatter-raw,
+        pre.frontmatter-nested {
+            margin: 0;
+            padding: 8px 10px;
+            background: transparent;
+            border: none;
+            font-size: 0.85em;
+            white-space: pre-wrap;
+        }
+        pre.frontmatter-raw {
+            border-left: 3px solid #d1d9e0;
+            padding-left: 10px;
+            margin: 0 0 1.5em;
+        }
+        .dark pre.frontmatter-raw { border-left-color: #3d444d; }
         """
     }
 }

--- a/NexTests/MarkdownHTMLRendererTests.swift
+++ b/NexTests/MarkdownHTMLRendererTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 @testable import Nex
 import Testing
@@ -35,5 +36,238 @@ struct MarkdownHTMLRendererTests {
     @Test func paragraphRendered() {
         let html = MarkdownRenderer.renderToHTML("Hello world")
         #expect(html.contains("<p>Hello world</p>"))
+    }
+
+    // MARK: - Front matter
+
+    @Test func frontMatterBasicRendersAsTable() {
+        let html = MarkdownRenderer.renderToHTML("---\ntitle: Hello\n---\n# Body")
+        #expect(html.contains("<table class=\"frontmatter\">"))
+        #expect(html.contains("<th scope=\"row\">title</th>"))
+        #expect(html.contains("<td>Hello</td>"))
+        #expect(html.contains("<h1>Body</h1>"))
+    }
+
+    @Test func frontMatterStrippedFromBody() {
+        let html = MarkdownRenderer.renderToHTML("---\ntitle: Hello\n---\nAfter")
+        // The literal "title: Hello" must not appear as body text.
+        #expect(!html.contains("<p>title: Hello</p>"))
+        #expect(html.contains("<p>After</p>"))
+    }
+
+    @Test func frontMatterInlineArrayBecomesCommaList() {
+        let html = MarkdownRenderer.renderToHTML("---\ntags: [a, b, c]\n---\n")
+        #expect(html.contains("<td>a, b, c</td>"))
+    }
+
+    @Test func frontMatterBlockListBecomesCommaList() {
+        let yaml = "---\ntags:\n  - a\n  - b\n---\n"
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(html.contains("<td>a, b</td>"))
+    }
+
+    @Test func frontMatterBoolAndNumberRendered() {
+        let html = MarkdownRenderer.renderToHTML("---\ndraft: true\ncount: 42\n---\n")
+        #expect(html.contains("<td>true</td>"))
+        #expect(html.contains("<td>42</td>"))
+    }
+
+    @Test func frontMatterQuotedStringPreservesColon() {
+        let html = MarkdownRenderer.renderToHTML("---\ntitle: \"Hello: world\"\n---\n")
+        #expect(html.contains("<td>Hello: world</td>"))
+    }
+
+    @Test func frontMatterKeyOrderPreserved() {
+        let html = MarkdownRenderer.renderToHTML("---\na: 1\nb: 2\nc: 3\n---\n")
+        guard let aRange = html.range(of: ">a</th>"),
+              let bRange = html.range(of: ">b</th>"),
+              let cRange = html.range(of: ">c</th>") else {
+            Issue.record("expected all three keys in output")
+            return
+        }
+        #expect(aRange.lowerBound < bRange.lowerBound)
+        #expect(bRange.lowerBound < cRange.lowerBound)
+    }
+
+    @Test func frontMatterNestedMappingUsesNestedPre() {
+        let yaml = "---\nauthor:\n  name: Jane\n  email: j@e.com\n---\n"
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(html.contains("<pre class=\"frontmatter-nested\">"))
+        #expect(html.contains("name: Jane"))
+        #expect(html.contains("email: j@e.com"))
+    }
+
+    @Test func frontMatterNonStringKeyCoerced() {
+        let html = MarkdownRenderer.renderToHTML("---\n1: one\n2: two\n---\n")
+        #expect(html.contains("<th scope=\"row\">1</th>"))
+        #expect(html.contains("<th scope=\"row\">2</th>"))
+    }
+
+    @Test func frontMatterCRLFLineEndings() {
+        let html = MarkdownRenderer.renderToHTML("---\r\ntitle: x\r\n---\r\n# Body")
+        #expect(html.contains("<table class=\"frontmatter\">"))
+        #expect(html.contains("<td>x</td>"))
+        #expect(html.contains("<h1>Body</h1>"))
+    }
+
+    @Test func frontMatterLeadingBOMTolerated() {
+        let html = MarkdownRenderer.renderToHTML("\u{FEFF}---\ntitle: x\n---\n# Body")
+        #expect(html.contains("<table class=\"frontmatter\">"))
+        #expect(html.contains("<td>x</td>"))
+    }
+
+    @Test func frontMatterAbsentDoesNotRenderTable() {
+        let html = MarkdownRenderer.renderToHTML("# Just a heading\n\nA paragraph.")
+        #expect(!html.contains("class=\"frontmatter\""))
+    }
+
+    @Test func frontMatterMissingClosingFenceIsRegularMarkdown() {
+        // Without a closing ---, swift-markdown should see the opening --- as
+        // a thematic break (hr) followed by body content.
+        let html = MarkdownRenderer.renderToHTML("---\ntitle: x\n# Heading")
+        #expect(!html.contains("class=\"frontmatter\""))
+        #expect(html.contains("<hr>"))
+    }
+
+    @Test func frontMatterEmptyMappingEmitsNothing() {
+        let html = MarkdownRenderer.renderToHTML("---\n---\n# Body")
+        #expect(!html.contains("class=\"frontmatter\""))
+        #expect(html.contains("<h1>Body</h1>"))
+    }
+
+    @Test func frontMatterExceedingSizeCapTreatedAsAbsent() {
+        // Build a front-matter block > 64 KiB. Each line is ~72 bytes, so 1000
+        // lines ≈ 72 KiB — comfortably over the cap.
+        let padding = String(repeating: "x", count: 64)
+        var yaml = "---\n"
+        for i in 0 ..< 1000 {
+            yaml += "k\(i): \(padding)\n"
+        }
+        yaml += "---\n# Body"
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(!html.contains("class=\"frontmatter\""))
+    }
+
+    @Test func frontMatterMalformedYAMLFallsBackEscaped() {
+        // Malformed YAML with an embedded <script>; should show raw-fallback
+        // pre AND the script tag must be escaped.
+        let yaml = "---\ntitle: [unclosed <script>alert(1)</script>\n---\n# Body"
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(html.contains("<pre class=\"frontmatter-raw\">"))
+        #expect(!html.contains("<script>alert(1)</script>"))
+        #expect(html.contains("&lt;script&gt;"))
+    }
+
+    @Test func frontMatterInjectionInValueEscaped() {
+        let yaml = "---\ntitle: \"<script>alert(1)</script>\"\n---\n"
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(!html.contains("<script>alert(1)</script>"))
+        #expect(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"))
+    }
+
+    @Test func frontMatterInjectionInKeyEscaped() {
+        // A key containing HTML must be escaped inside <th>.
+        let yaml = "---\n\"<b>evil</b>\": x\n---\n"
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(!html.contains("<th scope=\"row\"><b>evil</b></th>"))
+        #expect(html.contains("&lt;b&gt;evil&lt;/b&gt;"))
+    }
+
+    @Test func frontMatterDarkThemeCSSPresent() {
+        let html = MarkdownRenderer.renderToHTML(
+            "---\ntitle: x\n---\n",
+            backgroundColor: .black
+        )
+        #expect(html.contains("<html class=\"dark\">"))
+        #expect(html.contains(".dark table.frontmatter"))
+    }
+
+    @Test func frontMatterOpeningFenceRejectsLeadingWhitespace() {
+        // An indented `---` must NOT be treated as an opening fence.
+        let html = MarkdownRenderer.renderToHTML("  ---\ntitle: x\n---\n# Body")
+        #expect(!html.contains("class=\"frontmatter\""))
+    }
+
+    @Test func frontMatterClosingFenceRejectsLeadingWhitespace() {
+        // An indented `---` must NOT be treated as a closing fence.
+        let html = MarkdownRenderer.renderToHTML("---\ntitle: x\n  ---\n# Body")
+        #expect(!html.contains("class=\"frontmatter\""))
+    }
+
+    @Test func frontMatterClosingFenceAllowsTrailingWhitespace() {
+        let html = MarkdownRenderer.renderToHTML("---\ntitle: x\n---  \n# Body")
+        #expect(html.contains("<table class=\"frontmatter\">"))
+        #expect(html.contains("<td>x</td>"))
+    }
+
+    @Test func frontMatterDotDotDotClosingFence() {
+        let html = MarkdownRenderer.renderToHTML("---\ntitle: x\n...\n# Body")
+        #expect(html.contains("<table class=\"frontmatter\">"))
+        #expect(html.contains("<td>x</td>"))
+    }
+
+    @Test func frontMatterBlockScalarPreservesNewlines() {
+        // A `|` literal scalar must survive in a pre, not get flattened.
+        let yaml = "---\ndescription: |\n  Line 1\n  Line 2\n---\n"
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(html.contains("<pre class=\"frontmatter-nested\">"))
+        #expect(html.contains("Line 1"))
+        #expect(html.contains("Line 2"))
+    }
+
+    @Test func frontMatterNullValuedKey() {
+        let html = MarkdownRenderer.renderToHTML("---\nkey:\n---\n# Body")
+        // The table is emitted with the key row (value is empty or "null").
+        #expect(html.contains("<table class=\"frontmatter\">"))
+        #expect(html.contains("<th scope=\"row\">key</th>"))
+        #expect(html.contains("<h1>Body</h1>"))
+    }
+
+    @Test func frontMatterSizeCapBailsMidScan() {
+        // No closing fence; block is huge. The scanner must bail while
+        // scanning, not after. We don't measure time here — this is a
+        // correctness guard that the "no-fm" path is taken.
+        let padding = String(repeating: "x", count: 64)
+        var yaml = "---\n"
+        for i in 0 ..< 2000 {
+            yaml += "k\(i): \(padding)\n"
+        }
+        // Intentionally no closing ---; just body text that looks YAML-like.
+        yaml += "# Body"
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(!html.contains("class=\"frontmatter\""))
+    }
+
+    @Test func frontMatterMultilineScalarInSequenceGoesToPre() {
+        // A sequence where one element is a multiline block scalar must NOT
+        // comma-collapse — newlines would disappear.
+        let yaml = """
+        ---
+        items:
+          - one
+          - |
+            two line one
+            two line two
+        ---
+        """
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(html.contains("<pre class=\"frontmatter-nested\">"))
+        #expect(html.contains("two line one"))
+        #expect(html.contains("two line two"))
+    }
+
+    @Test func frontMatterAliasResolvedByYamsCompose() {
+        // Yams.compose resolves aliases to their anchored value, so an alias
+        // reference surfaces as the target's content. Both cells should render
+        // as "hello"; a bare "b" identifier must never appear alone.
+        let yaml = """
+        ---
+        base: &b hello
+        other: *b
+        ---
+        """
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(html.contains("<td>hello</td>"))
+        #expect(!html.contains("<td>b</td>"))
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -38,6 +38,9 @@ packages:
   swift-markdown:
     url: https://github.com/swiftlang/swift-markdown
     from: "0.5.0"
+  Yams:
+    url: https://github.com/jpsim/Yams
+    from: "5.1.0"
 
 targets:
   Nex:
@@ -86,6 +89,7 @@ targets:
       - package: Sparkle
       - package: swift-markdown
         product: Markdown
+      - package: Yams
       - sdk: Metal.framework
       - sdk: WebKit.framework
       - sdk: QuartzCore.framework


### PR DESCRIPTION
## Summary

- Detect YAML front-matter (the `---`-fenced block at the top of a markdown file) and render it as a two-column key/value table in the preview instead of the `<hr>` + prose fallback that swift-markdown produces by default.
- Parse with [Yams](https://github.com/jpsim/Yams) (new SPM dep). Scalars, single-line arrays, nested mappings, block scalars, and aliases all render sensibly; malformed YAML falls back to a styled raw block.
- A 64 KiB scan cap (tracked during line scanning, not after) guards against pathological input.
- CSS is scoped to `.frontmatter*` selectors so existing GFM tables and code blocks in the body are unaffected.

Closes #73.

## Files

- **New**: `Nex/Features/MarkdownPane/MarkdownFrontMatter.swift` — `FrontMatterExtractor` (fence parsing, BOM, CRLF, `---` / `...` close, size cap) + `FrontMatterRenderer` (Yams → HTML table / nested `<pre>` / raw fallback).
- `Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift` — call the extractor, prepend the rendered table to the body, extend the stylesheet.
- `NexTests/MarkdownHTMLRendererTests.swift` — 28 new `@Test` cases covering basic rendering, key/value/sequence/mapping shapes, CRLF, BOM, `...` close, empty mapping, size cap, HTML-injection escaping in keys/values/raw fallback, multiline block scalars, alias resolution, dark-theme CSS.
- `project.yml`, `Nex.xcodeproj/project.pbxproj` — Yams SPM dep.
- `CLAUDE.md` — one-line note under the Markdown panes section.

## Test plan

- [x] `xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation build` — clean
- [x] `xcodebuild ... test` — **589 tests pass** (34 in `MarkdownHTMLRendererTests`)
- [x] `swiftformat --lint` + `swiftlint lint` — 0 violations on the changed files
- [x] Manual: open a `.md` file with front-matter, confirm table appears at the top and body renders below; theme (light/dark) tracks the terminal.
- [x] Manual: edit front-matter in edit mode, save, flip back to preview — table reflects new keys/values.
- [x] Manual: drop an intentionally malformed file (`---\ntitle: [unclosed\n---`) — styled raw block shows, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)