### PR TITLE
chore: bump version to 0.21.0

### DIFF
--- a/Nex/Info.plist
+++ b/Nex/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.2</string>
+	<string>0.21.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.20.2</string>
+	<string>0.21.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSMainStoryboardFile</key>


### PR DESCRIPTION
## Summary
- Bump `CFBundleShortVersionString` and `CFBundleVersion` to `0.21.0`.

## Test plan
- [x] Info.plist updated
- [ ] Merge and tag `v0.21.0` to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)