### PR TITLE
fix: trim trailing whitespace from cmd+click paths (#72)

### DIFF
--- a/Nex/Ghostty/GhosttyApp.swift
+++ b/Nex/Ghostty/GhosttyApp.swift
@@ -201,7 +201,12 @@ final class GhosttyApp {
         case GHOSTTY_ACTION_OPEN_URL:
             let openUrl = action.action.open_url
             guard let urlPtr = openUrl.url else { return false }
-            var urlString = String(cString: urlPtr)
+            // Ghostty's URL regex includes trailing spaces that run to end-of-line
+            // (see ghostty/src/config/url.zig `trailing_spaces_at_eol`), so a path
+            // matched at the end of a terminal line arrives padded with spaces.
+            // Trim before the .md suffix check or we'd silently fall through to
+            // ghostty's default opener and `open(1)` would fail.
+            var urlString = String(cString: urlPtr).trimmingCharacters(in: .whitespacesAndNewlines)
             while urlString.hasSuffix(".") {
                 urlString.removeLast()
             }


### PR DESCRIPTION
## Summary
- Cmd+clicking a markdown filename in a terminal pane was opening reliably mid-line but silently failing when the path landed at end-of-line.
- Root cause: ghostty's URL regex includes trailing spaces that run to end-of-line (`trailing_spaces_at_eol` in `ghostty/src/config/url.zig`). The padded path failed the `.md` suffix check in `GhosttyApp.swift`, the apprt returned false, and ghostty fell back to its default opener — which `open(1)` then rejected.
- Fix: trim whitespace before the suffix check in `Nex/Ghostty/GhosttyApp.swift:204`.

Fixes #72.

## Test plan
- [x] Build: `xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation build`
- [x] Open a pane in a directory with `.md` files. Run a command whose output puts a `.md` filename at end-of-line (e.g. a `find` or `ls` of long names that wrap).
- [x] Cmd+click the path that lands at end-of-line — should open the markdown pane.
- [x] Cmd+click a path that lands mid-line (followed by other text) — should still open.
- [x] Repeat across panes/workspaces; should be 100% reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)