### PR TITLE
feat: diff pane with sticky file headers and inspector stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,13 +69,20 @@ make check
 - **Background**: both views receive `ghosttyConfig.backgroundColor` / `backgroundOpacity` so they match terminal panes. The pane container also has a matching background fill for any gaps.
 - **Git branch**: detected at open time via `gitService.getCurrentBranch` on the file's parent directory.
 
+### Diff panes
+- **Entry points**: `nex diff [<path>]` from the CLI, the bindable `open_diff` action (default unbound), or the "plusminus" button next to a repo association in the workspace inspector. All route through `AppReducer.openDiffPath` → `WorkspaceFeature.openDiffPane`.
+- **Renderer** (`DiffHTMLRenderer`): pure-Swift line-by-line classifier — emits `<div class="line line-{add|del|hunk|context|file-header}">` with GitHub-style colors and the same dark-mode detection as `MarkdownHTMLRenderer`. Each `diff --git` opens a `<details class="file" open>` block with a sticky `<summary>` (the file path); clicking the summary toggles collapse, and `position: sticky` keeps the current file's header pinned while scrolling through its hunks. Empty diff → "No changes" placeholder.
+- **View** (`DiffPaneView`): `WKWebView` mirroring `MarkdownPaneView` minus edit mode and file watching. Refreshes when the pane regains focus and when the header refresh button (`arrow.clockwise`) bumps a per-pane `refreshToken` tracked in `PaneGridView`.
+- **Inputs**: `pane.workingDirectory` is the repo path; `pane.filePath` is the optional file/dir scope passed to `git diff -- <path>`. No `--staged` / ref-range support yet.
+- **Git invocation**: new `gitService.getDiff(repoPath:targetPath:)` shells out via the existing `runGit` helper. Errors render as a placeholder line in the pane.
+
 ### Persistence — GRDB
 - `DatabaseService` — manages SQLite via GRDB's `DatabasePool` (prod) or `DatabaseQueue` (tests, in-memory).
 - `PersistenceService` — debounced (500ms) full-state serialization. Clears and re-inserts all records on each save. Tables: `WorkspaceRecord`, `PaneRecord`, `RepoRecord`, `RepoAssociationRecord`, `AppStateRecord`.
 - DB location: `~/Library/Application Support/Nex/nex.db`
 
 ### Agent monitoring & CLI
-- `SocketServer` — Unix domain socket at `/tmp/nex.sock` + optional TCP listener on `127.0.0.1:<port>`. Receives newline-delimited JSON from the `nex` CLI. Messages use `"command"` key. Commands: `start`, `stop`, `error`, `notification`, `session-start`, `pane-split`, `pane-create`, `pane-close`, `pane-name`, `pane-send`, `pane-move`, `pane-move-to-workspace`, `pane-list`, `workspace-create`, `workspace-move`, `group-create`, `group-rename`, `group-delete`, `layout-cycle`, `layout-select`, `open`. Group icon management is deliberately UI-only (context menu); there is no `group-set-icon` wire command.
+- `SocketServer` — Unix domain socket at `/tmp/nex.sock` + optional TCP listener on `127.0.0.1:<port>`. Receives newline-delimited JSON from the `nex` CLI. Messages use `"command"` key. Commands: `start`, `stop`, `error`, `notification`, `session-start`, `pane-split`, `pane-create`, `pane-close`, `pane-name`, `pane-send`, `pane-move`, `pane-move-to-workspace`, `pane-list`, `workspace-create`, `workspace-move`, `group-create`, `group-rename`, `group-delete`, `layout-cycle`, `layout-select`, `open`, `diff`. Group icon management is deliberately UI-only (context menu); there is no `group-set-icon` wire command.
 - **Request/response framing**: most commands are fire-and-forget (server reads, acts, drops the FD). Commands in `replyCommandAllowlist` (currently `pane-list`, `pane-close`) return structured JSON — the server allocates a `SocketServer.ReplyHandle`, the reducer writes a single newline-terminated JSON line via `reply.send(...)`, then `reply.close()` cancels the client's dispatch source (EOF on the CLI side). Success payloads are `{"ok":true, ...}`; failures are `{"ok":false,"error":"<message>"}` and the CLI exits non-zero. Reply handlers must gracefully accept `reply: nil` for the legacy fire-and-forget path.
 - **TCP transport**: enabled via `tcp-port = <port>` in `~/.config/nex/config`. Binds to `127.0.0.1` only (no auth needed — SSH tunnels handle remote security). Use cases: dev containers connect via `host.docker.internal:<port>`, remote agents connect via SSH reverse tunnel (`ssh -R <port>:localhost:<port> remote`).
 - `SocketMessage` — enum representing all wire messages (agent lifecycle + pane commands + workspace + group commands).
@@ -93,6 +100,7 @@ make check
   - `nex group delete <name-or-id> [--cascade]` — without `--cascade`, children promote to top level
   - `nex layout cycle|select <name>`
   - `nex open <filepath>`
+  - `nex diff [<path>]` — opens a diff pane for the CLI's current working directory (or scoped to `<path>`). The diff pane refreshes on focus and via the header refresh button.
 - **CLI transport selection**: `NEX_SOCKET` env var selects transport. Absent = Unix socket (`/tmp/nex.sock`). `tcp:<host>:<port>` = TCP (e.g., `NEX_SOCKET=tcp:host.docker.internal:19400`).
 - `StatusBarController` — menu bar icon + popover showing running/waiting agents across workspaces.
 - `NotificationService` — desktop notifications with "Open"/"Dismiss" actions.

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0D7D8E5C230B6C98E7693D66 /* PaneListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */; };
 		0EAFF0FDB683293F95D8AB47 /* RenameWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */; };
 		0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B822ABF12B071E574E089BB4 /* GroupIconTests.swift */; };
+		149E80DD671127055EF67F7F /* DiffHTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */; };
 		14C1E964B19A8C277D5EA5E4 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE56BB11F5C7C34821411297 /* QuartzCore.framework */; };
 		1569F35B72EC7C133643190E /* PaneType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377C07C6C4B00D0699682EA3 /* PaneType.swift */; };
 		1E6354C9BBDF122BF0FB255F /* WorktreeOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CBC99B6D8094F73CDFBD80 /* WorktreeOperationTests.swift */; };
@@ -44,6 +45,7 @@
 		58B6A951A34B2ED1516194C4 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08D39F8F87D7505CD32D25D /* WebKit.framework */; };
 		59239C7AD0D26E390C647C46 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 98CF017F4F26916F63300A33 /* Yams */; };
 		5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */; };
+		62564D224FD57BC3C02100EA /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191E820170ADF2ADB58B8079 /* GitServiceTests.swift */; };
 		64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A24C1FEC6EA31096603326 /* SurfaceManager.swift */; };
 		696312BB96D35569F48B7CAE /* MarkdownFrontMatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43F769C33118440222BF5FA /* MarkdownFrontMatter.swift */; };
 		6ACFF31A3875EBE87E78C587 /* RepoAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A1CB3D7653911EF93F8F5 /* RepoAssociation.swift */; };
@@ -54,6 +56,8 @@
 		75BECE7D63EF981C344D4902 /* SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */; };
 		77C780C65EFA8114C681638B /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 8B14B7BF7BD4FCD61EBB97A9 /* ComposableArchitecture */; };
 		77CF808E3AF2C06BD12D11C0 /* SplitDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DED98594372C8E34542A5C2 /* SplitDividerView.swift */; };
+		77FB1142F26F5C33539E3F23 /* DiffHTMLRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E85EE83A315989753EADF1 /* DiffHTMLRenderer.swift */; };
+		7B54AB73465C0926D5259580 /* DiffPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB2BCC7EBF45A4E50F314F2 /* DiffPaneView.swift */; };
 		7C49755ABEC49B51EC1333FB /* WorkspaceGroupCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF88062F290789D98B545AC6 /* WorkspaceGroupCRUDTests.swift */; };
 		7C78EA65C2D22749546715A0 /* GhosttySurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD03468B083223FF50F68E0 /* GhosttySurface.swift */; };
 		7D1EEEBEE302F17F8CA2852D /* SocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309D0F6F13F12FDC350DE875 /* SocketServer.swift */; };
@@ -146,9 +150,11 @@
 		11CBC99B6D8094F73CDFBD80 /* WorktreeOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeOperationTests.swift; sourceTree = "<group>"; };
 		1870562A61E6F66FFE03A8BA /* CommandPaletteItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteItem.swift; sourceTree = "<group>"; };
 		191592BF0EBCEC22DF9F5745 /* RenamePaneSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenamePaneSheet.swift; sourceTree = "<group>"; };
+		191E820170ADF2ADB58B8079 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
 		1A198A2F5EA992907A3031ED /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		1BA6AA9E98405375983902BD /* WorkspaceFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFeature.swift; sourceTree = "<group>"; };
 		1C625959E287CE9896D5BA4D /* RepoRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoRegistryTests.swift; sourceTree = "<group>"; };
+		1CB2BCC7EBF45A4E50F314F2 /* DiffPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneView.swift; sourceTree = "<group>"; };
 		1E7D450881FC7318F58CB78F /* MarkdownHTMLRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownHTMLRenderer.swift; sourceTree = "<group>"; };
 		1F71D541343DA67CDCADA821 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
 		200EB2588E40ABB7C51E24E6 /* MarkdownHTMLRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownHTMLRendererTests.swift; sourceTree = "<group>"; };
@@ -165,6 +171,7 @@
 		3714AA1F15C85762BF36B1FE /* NexApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NexApp.swift; sourceTree = "<group>"; };
 		377C07C6C4B00D0699682EA3 /* PaneType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneType.swift; sourceTree = "<group>"; };
 		3879BA745F8737CA5872F80D /* DatabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseService.swift; sourceTree = "<group>"; };
+		396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffHTMLRendererTests.swift; sourceTree = "<group>"; };
 		3B2687F4D886D153C83D8A60 /* WorkspaceGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroup.swift; sourceTree = "<group>"; };
 		42A24C1FEC6EA31096603326 /* SurfaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceManager.swift; sourceTree = "<group>"; };
 		439174A029FAFE2C252A1B8B /* KeybindingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingsSettingsView.swift; sourceTree = "<group>"; };
@@ -191,6 +198,7 @@
 		852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineNumberRulerView.swift; sourceTree = "<group>"; };
 		89FC5F004277851CEA0CFF3F /* CommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteTests.swift; sourceTree = "<group>"; };
 		8C693AF419763177AE1CEA0F /* UserDefaultsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsClient.swift; sourceTree = "<group>"; };
+		92E85EE83A315989753EADF1 /* DiffHTMLRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffHTMLRenderer.swift; sourceTree = "<group>"; };
 		933D5B5E664E30B2E88EE3C7 /* WorkspaceGroupPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupPersistenceTests.swift; sourceTree = "<group>"; };
 		93D45D65A66C475B0CEEC53C /* KeybindingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingService.swift; sourceTree = "<group>"; };
 		94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceView.swift; sourceTree = "<group>"; };
@@ -338,7 +346,9 @@
 				89FC5F004277851CEA0CFF3F /* CommandPaletteTests.swift */,
 				309F641591BB580429299666 /* ConfigParserTests.swift */,
 				21064C4AB47888B6A02CCD73 /* DatabaseMigrationTests.swift */,
+				396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */,
 				77FDA3FB200AA7846BCDC7A7 /* EditorServiceTests.swift */,
+				191E820170ADF2ADB58B8079 /* GitServiceTests.swift */,
 				B822ABF12B071E574E089BB4 /* GroupIconTests.swift */,
 				EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */,
 				5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */,
@@ -424,6 +434,7 @@
 			children = (
 				61D6AE6635332105A3C18A03 /* VibrancyView.swift */,
 				F09BE06FAA330721302E5EE2 /* CommandPalette */,
+				88A51E308F0A25C93CF584F1 /* DiffPane */,
 				DF5C0A1272DF055BCEA24B8E /* Help */,
 				B83E9D548B12F0748394A98C /* MarkdownPane */,
 				575CB385F691D30D4A449F9C /* PaneGrid */,
@@ -472,6 +483,15 @@
 				C58BE92A0878D9CCC786A657 /* WorkspaceRowView.swift */,
 			);
 			path = Workspace;
+			sourceTree = "<group>";
+		};
+		88A51E308F0A25C93CF584F1 /* DiffPane */ = {
+			isa = PBXGroup;
+			children = (
+				92E85EE83A315989753EADF1 /* DiffHTMLRenderer.swift */,
+				1CB2BCC7EBF45A4E50F314F2 /* DiffPaneView.swift */,
+			);
+			path = DiffPane;
 			sourceTree = "<group>";
 		};
 		A05FDE83E479F0CC46756554 /* Frameworks */ = {
@@ -670,7 +690,9 @@
 				FD494AFC9E74F4C5D7E125B8 /* CommandPaletteTests.swift in Sources */,
 				A1937931A23F2D0EB8472737 /* ConfigParserTests.swift in Sources */,
 				B652FDDE5CE91C5CA1DAC8E2 /* DatabaseMigrationTests.swift in Sources */,
+				149E80DD671127055EF67F7F /* DiffHTMLRendererTests.swift in Sources */,
 				F9EF0D090461E0518C6EB23F /* EditorServiceTests.swift in Sources */,
+				62564D224FD57BC3C02100EA /* GitServiceTests.swift in Sources */,
 				0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */,
 				EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */,
 				B701F36FA68D43170D591F40 /* KeyBindingTests.swift in Sources */,
@@ -708,6 +730,8 @@
 				2D8754E0B3E9AD185D7EB6B0 /* ConfigParser.swift in Sources */,
 				2061570DEABB0E43847DBB5D /* ContentView.swift in Sources */,
 				5109ADD55C00BC02B15EDE81 /* DatabaseService.swift in Sources */,
+				77FB1142F26F5C33539E3F23 /* DiffHTMLRenderer.swift in Sources */,
+				7B54AB73465C0926D5259580 /* DiffPaneView.swift in Sources */,
 				A3B349AFCABD43FDC2F97A2A /* EditorService.swift in Sources */,
 				9D8356F03AF69469528218D5 /* FocusNotifyingTextView.swift in Sources */,
 				2BD04AF1F25BBC3516E5F706 /* GhosttyApp.swift in Sources */,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -129,6 +129,7 @@ struct AppReducer {
                     case .shell: "terminal"
                     case .markdown: "doc.text"
                     case .scratchpad: "note.text"
+                    case .diff: "plusminus"
                     }
                     items.append(CommandPaletteItem(
                         id: "pane:\(paneID)",
@@ -370,6 +371,7 @@ struct AppReducer {
         // File Opening
         case openFile
         case openFileAtPath(String, fromPaneID: UUID?)
+        case openDiffPath(repoPath: String, targetPath: String?, fromPaneID: UUID?)
 
         // Inspector + Git Status
         case toggleInspector
@@ -2109,6 +2111,36 @@ struct AppReducer {
                     action: .openMarkdownFile(filePath: resolvedPath)
                 )))
 
+            case .openDiffPath(let repoPath, let targetPath, let fromPaneID):
+                guard let activeID = state.activeWorkspaceID else { return .none }
+                let workspace = state.workspaces[id: activeID]
+                let resolvedTarget: String? = {
+                    guard let targetPath, !targetPath.isEmpty else { return nil }
+                    if targetPath.hasPrefix("/") { return targetPath }
+                    let cwd: String? = {
+                        if let fromPaneID, let pane = workspace?.panes.first(where: { $0.id == fromPaneID }) {
+                            return pane.workingDirectory
+                        }
+                        if let focusedID = workspace?.focusedPaneID,
+                           let pane = workspace?.panes.first(where: { $0.id == focusedID }) {
+                            return pane.workingDirectory
+                        }
+                        return nil
+                    }()
+                    if let cwd, !cwd.isEmpty {
+                        return (cwd as NSString).appendingPathComponent(targetPath)
+                    }
+                    return targetPath
+                }()
+                return .send(.workspaces(.element(
+                    id: activeID,
+                    action: .openDiffPane(
+                        repoPath: repoPath,
+                        targetPath: resolvedTarget,
+                        reusePaneID: nil
+                    )
+                )))
+
             // MARK: - Socket Messages
 
             case .socketMessage(let message, let reply):
@@ -2402,6 +2434,29 @@ struct AppReducer {
                     return .send(.workspaces(.element(
                         id: activeID,
                         action: .openMarkdownFile(filePath: path, reusePaneID: nil)
+                    )))
+
+                case .openDiff(let repoPath, let targetPath, let paneID):
+                    if let paneID,
+                       let workspace = state.workspaces.first(where: { $0.panes[id: paneID] != nil }) {
+                        state.workspaces[id: workspace.id]?.focusedPaneID = paneID
+                        return .send(.workspaces(.element(
+                            id: workspace.id,
+                            action: .openDiffPane(
+                                repoPath: repoPath,
+                                targetPath: targetPath,
+                                reusePaneID: nil
+                            )
+                        )))
+                    }
+                    guard let activeID = state.activeWorkspaceID else { return .none }
+                    return .send(.workspaces(.element(
+                        id: activeID,
+                        action: .openDiffPane(
+                            repoPath: repoPath,
+                            targetPath: targetPath,
+                            reusePaneID: nil
+                        )
                     )))
 
                 // MARK: Layout commands

--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -281,6 +281,9 @@ final class PaneShortcutMonitor {
             store.send(.beginRenameActiveWorkspace)
             return true
 
+        case .openDiff:
+            return handleOpenDiff(activeWorkspaceID: id)
+
         default:
             return false
         }
@@ -325,6 +328,19 @@ final class PaneShortcutMonitor {
             ? .increaseMarkdownFontSize(focusedID)
             : .decreaseMarkdownFontSize(focusedID)
         store.send(.workspaces(.element(id: id, action: action)))
+        return true
+    }
+
+    private func handleOpenDiff(activeWorkspaceID id: UUID) -> Bool {
+        guard let workspace = store.workspaces[id: id],
+              let focusedID = workspace.focusedPaneID,
+              let pane = workspace.panes[id: focusedID]
+        else { return false }
+        store.send(.openDiffPath(
+            repoPath: pane.workingDirectory,
+            targetPath: nil,
+            fromPaneID: focusedID
+        ))
         return true
     }
 

--- a/Nex/Features/DiffPane/DiffHTMLRenderer.swift
+++ b/Nex/Features/DiffPane/DiffHTMLRenderer.swift
@@ -1,0 +1,423 @@
+import AppKit
+import Foundation
+
+/// Renders raw `git diff` output into a styled HTML document. Mirrors the
+/// background-color and dark-mode pattern used by `MarkdownHTMLRenderer`
+/// so diff panes blend with surrounding terminal panes.
+enum DiffHTMLRenderer {
+    static func renderToHTML(
+        diffText: String,
+        backgroundColor: NSColor = .windowBackgroundColor,
+        backgroundOpacity: Double = 1.0,
+        baseFontSize: Double = 13
+    ) -> String {
+        let bgCSS = cssBackground(color: backgroundColor, opacity: backgroundOpacity)
+        let isDark = isDarkBackground(color: backgroundColor)
+        let body: String = if diffText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            "<div class=\"empty\">No changes</div>"
+        } else {
+            renderLines(diffText)
+        }
+        return wrapInHTMLDocument(
+            body,
+            backgroundCSS: bgCSS,
+            isDark: isDark,
+            baseFontSize: baseFontSize
+        )
+    }
+
+    // MARK: - Line classification
+
+    private static func renderLines(_ diff: String) -> String {
+        let chunks = splitIntoFileChunks(diff)
+        var html = "<div class=\"diff\">"
+        for chunk in chunks {
+            html += renderChunk(chunk)
+        }
+        html += "</div>"
+        return html
+    }
+
+    /// A run of lines belonging to a single file (or the leading preamble
+    /// before any `diff --git` line). `headerLine` is `nil` for the preamble.
+    private struct FileChunk {
+        var headerLine: String?
+        var lines: [String]
+    }
+
+    private static func splitIntoFileChunks(_ diff: String) -> [FileChunk] {
+        var chunks: [FileChunk] = []
+        var current = FileChunk(headerLine: nil, lines: [])
+        for rawLine in diff.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            if line.hasPrefix("diff --git ") {
+                if !current.lines.isEmpty || current.headerLine != nil {
+                    chunks.append(current)
+                }
+                current = FileChunk(headerLine: line, lines: [line])
+            } else {
+                current.lines.append(line)
+            }
+        }
+        if !current.lines.isEmpty || current.headerLine != nil {
+            chunks.append(current)
+        }
+        return chunks
+    }
+
+    private static func renderChunk(_ chunk: FileChunk) -> String {
+        // No `diff --git` header: render lines loose (no <details>).
+        guard chunk.headerLine != nil else {
+            return chunk.lines
+                .map { "<div class=\"line line-\(classify($0))\">\(escape($0))</div>" }
+                .joined()
+        }
+
+        let status = detectStatus(chunk)
+        let counts = countChanges(chunk)
+        let path = displayPath(for: chunk, status: status)
+
+        var html = "<details class=\"file\" open>"
+        html += "<summary class=\"file-summary\">"
+        html += "<span class=\"caret\"></span>"
+        html += "<span class=\"file-path\">\(escape(path))</span>"
+        html += "<span class=\"file-status status-\(status.cssClass)\">\(status.label)</span>"
+        if counts.additions > 0 || counts.deletions > 0 {
+            html += "<span class=\"diff-stats\">"
+            html += "<span class=\"stat-add\">+\(counts.additions)</span>"
+            html += "<span class=\"stat-del\">-\(counts.deletions)</span>"
+            html += "</span>"
+        }
+        html += "</summary>"
+        // Per-file horizontal scroll: `.hunks` clips, `.hunks-inner` sizes to
+        // widest line so backgrounds extend across the full diff width while
+        // the outer summary stays pinned at viewport width.
+        html += "<div class=\"hunks\"><div class=\"hunks-inner\">"
+        for line in chunk.lines {
+            html += "<div class=\"line line-\(classify(line))\">\(escape(line))</div>"
+        }
+        html += "</div></div>"
+        html += "</details>"
+        return html
+    }
+
+    // MARK: - Per-file derivation
+
+    private enum FileStatus {
+        case added
+        case deleted
+        case modified
+        case renamed(from: String)
+        case binary
+        case modeChange
+
+        var label: String {
+            switch self {
+            case .added: "added"
+            case .deleted: "deleted"
+            case .modified: "modified"
+            case .renamed: "renamed"
+            case .binary: "binary"
+            case .modeChange: "mode"
+            }
+        }
+
+        var cssClass: String {
+            switch self {
+            case .added: "added"
+            case .deleted: "deleted"
+            case .modified: "modified"
+            case .renamed: "renamed"
+            case .binary: "binary"
+            case .modeChange: "mode"
+            }
+        }
+    }
+
+    private static func detectStatus(_ chunk: FileChunk) -> FileStatus {
+        var hasNewFileMode = false
+        var hasDeletedFileMode = false
+        var renameFrom: String?
+        var hasRenameTo = false
+        var hasBinary = false
+        var hasContentChange = false
+        var hasModeChange = false
+
+        for line in chunk.lines {
+            if line.hasPrefix("new file mode") { hasNewFileMode = true }
+            if line.hasPrefix("deleted file mode") { hasDeletedFileMode = true }
+            if line.hasPrefix("rename from ") {
+                renameFrom = String(line.dropFirst("rename from ".count))
+            }
+            if line.hasPrefix("rename to ") { hasRenameTo = true }
+            if line.hasPrefix("Binary files") { hasBinary = true }
+            if line.hasPrefix("old mode") || line.hasPrefix("new mode") { hasModeChange = true }
+            if line.hasPrefix("@@") { hasContentChange = true }
+        }
+
+        // Content change wins over mode-only changes, so a chmod+edit shows as modified.
+        if hasNewFileMode { return .added }
+        if hasDeletedFileMode { return .deleted }
+        if let from = renameFrom, hasRenameTo { return .renamed(from: from) }
+        if hasBinary { return .binary }
+        if hasModeChange, !hasContentChange { return .modeChange }
+        return .modified
+    }
+
+    private static func countChanges(_ chunk: FileChunk) -> (additions: Int, deletions: Int) {
+        var add = 0
+        var del = 0
+        for line in chunk.lines {
+            if line.hasPrefix("+++") || line.hasPrefix("---") { continue }
+            if line.hasPrefix("+") { add += 1 }
+            if line.hasPrefix("-") { del += 1 }
+        }
+        return (add, del)
+    }
+
+    private static func displayPath(for chunk: FileChunk, status: FileStatus) -> String {
+        let dest = extractFilePath(from: chunk.headerLine ?? "")
+        if case .renamed(let from) = status {
+            return "\(from) → \(dest)"
+        }
+        return dest
+    }
+
+    /// Extract the destination path from a `diff --git a/<path> b/<path>` line.
+    /// Uses the last " b/" occurrence so paths with spaces or unusual prefixes
+    /// still work for the common case.
+    private static func extractFilePath(from diffGitLine: String) -> String {
+        if let bRange = diffGitLine.range(of: " b/", options: .backwards) {
+            return String(diffGitLine[bRange.upperBound...])
+        }
+        return diffGitLine
+    }
+
+    private static func classify(_ line: String) -> String {
+        // File-header markers must be checked before +/- because of +++/---.
+        if line.hasPrefix("diff --git ") ||
+            line.hasPrefix("index ") ||
+            line.hasPrefix("--- ") ||
+            line.hasPrefix("+++ ") ||
+            line.hasPrefix("new file mode") ||
+            line.hasPrefix("deleted file mode") ||
+            line.hasPrefix("similarity index") ||
+            line.hasPrefix("rename ") ||
+            line.hasPrefix("copy ") ||
+            line.hasPrefix("Binary files") ||
+            line.hasPrefix("old mode") ||
+            line.hasPrefix("new mode") {
+            return "file-header"
+        }
+        if line.hasPrefix("@@") {
+            return "hunk"
+        }
+        if line.hasPrefix("+") {
+            return "add"
+        }
+        if line.hasPrefix("-") {
+            return "del"
+        }
+        return "context"
+    }
+
+    // MARK: - Background detection (mirrors MarkdownHTMLRenderer)
+
+    private static func isDarkBackground(color: NSColor) -> Bool {
+        let rgb = color.usingColorSpace(.sRGB) ?? color
+        let luminance = 0.299 * rgb.redComponent + 0.587 * rgb.greenComponent + 0.114 * rgb.blueComponent
+        return luminance < 0.5
+    }
+
+    private static func cssBackground(color: NSColor, opacity: Double) -> String {
+        let rgb = color.usingColorSpace(.sRGB) ?? color
+        let r = Int(rgb.redComponent * 255)
+        let g = Int(rgb.greenComponent * 255)
+        let b = Int(rgb.blueComponent * 255)
+        return "background-color: rgba(\(r), \(g), \(b), \(opacity));"
+    }
+
+    private static func wrapInHTMLDocument(
+        _ body: String,
+        backgroundCSS: String,
+        isDark: Bool,
+        baseFontSize: Double
+    ) -> String {
+        """
+        <!DOCTYPE html>
+        <html class="\(isDark ? "dark" : "light")">
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+        \(css(backgroundCSS: backgroundCSS, baseFontSize: baseFontSize))
+        </style>
+        </head>
+        <body>
+        \(body)
+        </body>
+        </html>
+        """
+    }
+
+    // MARK: - Stylesheet
+
+    private static func css(backgroundCSS: String, baseFontSize: Double) -> String {
+        """
+        html, body {
+            margin: 0;
+            padding: 0;
+        }
+        body {
+            font-family: 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+            font-size: \(baseFontSize)px;
+            line-height: 1.45;
+            color: #1f2328;
+            \(backgroundCSS)
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+        .dark body { color: #e6edf3; }
+        .diff {
+            padding-bottom: 8px;
+        }
+        details.file { display: block; }
+        .hunks {
+            overflow-x: auto;
+        }
+        .hunks-inner {
+            display: inline-block;
+            min-width: 100%;
+        }
+        details.file > summary {
+            position: sticky;
+            top: 0;
+            z-index: 2;
+            list-style: none;
+            cursor: pointer;
+            user-select: none;
+            font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+            font-weight: 600;
+            color: #1f2328;
+            background: #f6f8fa;
+            border-top: 1px solid #d1d9e0;
+            border-bottom: 1px solid #d1d9e0;
+            padding: 6px 16px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        details.file > summary::-webkit-details-marker { display: none; }
+        details.file:first-child > summary { border-top: none; }
+        .dark details.file > summary {
+            background: #161b22;
+            color: #e6edf3;
+            border-top-color: #3d444d;
+            border-bottom-color: #3d444d;
+        }
+        .caret {
+            display: inline-block;
+            width: 10px;
+            color: #8b949e;
+            transition: transform 0.12s ease;
+        }
+        .caret::before { content: "\\25B6"; font-size: 9px; }
+        details[open] > summary .caret { transform: rotate(90deg); }
+        .file-path {
+            font-family: 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+            font-weight: 500;
+        }
+        .file-status {
+            font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+            font-size: 10px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            padding: 1px 6px;
+            border-radius: 3px;
+        }
+        .status-added { background: rgba(46, 160, 67, 0.18); color: #1a7f37; }
+        .dark .status-added { color: #4ac26b; background: rgba(46, 160, 67, 0.22); }
+        .status-deleted { background: rgba(248, 81, 73, 0.18); color: #cf222e; }
+        .dark .status-deleted { color: #ff7b72; background: rgba(248, 81, 73, 0.22); }
+        .status-modified { background: rgba(56, 139, 253, 0.18); color: #0969da; }
+        .dark .status-modified { color: #58a6ff; background: rgba(56, 139, 253, 0.22); }
+        .status-renamed { background: rgba(163, 113, 247, 0.18); color: #8250df; }
+        .dark .status-renamed { color: #d2a8ff; background: rgba(163, 113, 247, 0.22); }
+        .status-binary, .status-mode {
+            background: rgba(101, 109, 118, 0.18);
+            color: #57606a;
+        }
+        .dark .status-binary, .dark .status-mode {
+            color: #8b949e;
+            background: rgba(139, 148, 158, 0.18);
+        }
+        .diff-stats {
+            margin-left: auto;
+            font-family: 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+            font-size: 12px;
+            display: inline-flex;
+            gap: 8px;
+        }
+        .stat-add { color: #1a7f37; font-weight: 600; }
+        .dark .stat-add { color: #4ac26b; }
+        .stat-del { color: #cf222e; font-weight: 600; }
+        .dark .stat-del { color: #ff7b72; }
+        .line {
+            display: block;
+            padding: 0 16px;
+            white-space: pre;
+        }
+        .line:empty::before { content: "\\00a0"; }
+        .line-add {
+            background: #e6ffec;
+            color: #1a7f37;
+        }
+        .dark .line-add {
+            background: rgba(46, 160, 67, 0.15);
+            color: #4ac26b;
+        }
+        .line-del {
+            background: #ffebe9;
+            color: #cf222e;
+        }
+        .dark .line-del {
+            background: rgba(248, 81, 73, 0.15);
+            color: #ff7b72;
+        }
+        .line-hunk {
+            background: #ddf4ff;
+            color: #57606a;
+        }
+        .dark .line-hunk {
+            background: rgba(56, 139, 253, 0.15);
+            color: #8b949e;
+        }
+        .line-file-header {
+            color: #57606a;
+            font-size: 0.92em;
+            padding-top: 2px;
+            padding-bottom: 2px;
+        }
+        .dark .line-file-header { color: #8b949e; }
+        .empty {
+            text-align: center;
+            color: #57606a;
+            font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            padding: 80px 20px;
+        }
+        .dark .empty { color: #8b949e; }
+        """
+    }
+
+    // MARK: - HTML escaping
+
+    private static func escape(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}

--- a/Nex/Features/DiffPane/DiffPaneView.swift
+++ b/Nex/Features/DiffPane/DiffPaneView.swift
@@ -1,0 +1,222 @@
+import AppKit
+import ComposableArchitecture
+import SwiftUI
+import WebKit
+
+/// Renders the output of `git diff` in a WKWebView. Mirrors `MarkdownPaneView`
+/// but without edit mode or file watching — refresh is triggered by pane focus
+/// regaining and by external `refreshToken` bumps from the header refresh button.
+struct DiffPaneView: NSViewRepresentable {
+    let paneID: UUID
+    let repoPath: String
+    let targetPath: String?
+    let isFocused: Bool
+    let refreshToken: UInt64
+    var backgroundColor: NSColor = .windowBackgroundColor
+    var backgroundOpacity: Double = 1.0
+    var fontSize: Double = 13
+    @Environment(\.sidebarTextEditingActive) private var sidebarTextEditingActive
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> PaneFocusView {
+        let container = PaneFocusView(paneID: paneID)
+
+        let config = WKWebViewConfiguration()
+        let scrollHandler = context.coordinator
+        config.userContentController.add(scrollHandler, name: "scrollHandler")
+        config.userContentController.addUserScript(WKUserScript(
+            source: """
+            window.addEventListener('scroll', function() {
+                var maxScroll = document.body.scrollHeight - window.innerHeight;
+                var fraction = maxScroll > 0 ? window.scrollY / maxScroll : 0;
+                window.webkit.messageHandlers.scrollHandler.postMessage(fraction);
+            });
+            """,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        ))
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.setValue(false, forKey: "drawsBackground")
+        webView.underPageBackgroundColor = .clear
+        webView.navigationDelegate = context.coordinator
+
+        let coord = context.coordinator
+        coord.webView = webView
+        coord.paneID = paneID
+        coord.pendingScrollFraction = PaneFocusView.scrollFraction(for: paneID)
+        coord.repoPath = repoPath
+        coord.targetPath = targetPath
+        coord.backgroundColor = backgroundColor
+        coord.backgroundOpacity = backgroundOpacity
+        coord.fontSize = fontSize
+        coord.lastRefreshToken = refreshToken
+        coord.loadDiff()
+
+        container.embed(webView)
+
+        if isFocused, !sidebarTextEditingActive {
+            claimFirstResponder(webView)
+        }
+        coord.lastIsFocused = isFocused
+        return container
+    }
+
+    func updateNSView(_: PaneFocusView, context: Context) {
+        let coord = context.coordinator
+        let pathChanged = coord.repoPath != repoPath || coord.targetPath != targetPath
+        let tokenBumped = coord.lastRefreshToken != refreshToken
+        let focusGained = isFocused && !coord.lastIsFocused
+        let fontChanged = coord.fontSize != fontSize
+
+        coord.repoPath = repoPath
+        coord.targetPath = targetPath
+        coord.fontSize = fontSize
+        coord.backgroundColor = backgroundColor
+        coord.backgroundOpacity = backgroundOpacity
+
+        if pathChanged || tokenBumped || focusGained {
+            coord.lastRefreshToken = refreshToken
+            coord.loadDiff()
+        } else if fontChanged {
+            coord.renderCurrent()
+        }
+
+        if isFocused, !coord.lastIsFocused, !sidebarTextEditingActive,
+           let webView = coord.webView {
+            claimFirstResponder(webView)
+        }
+        coord.lastIsFocused = isFocused
+    }
+
+    private func claimFirstResponder(_ webView: WKWebView) {
+        DispatchQueue.main.async { [weak webView] in
+            guard let webView, let window = webView.window else { return }
+            if window.firstResponder === webView { return }
+            window.makeFirstResponder(webView)
+        }
+    }
+
+    static func dismantleNSView(_: PaneFocusView, coordinator: Coordinator) {
+        coordinator.cancelInFlight()
+        coordinator.webView = nil
+    }
+
+    // MARK: - Coordinator
+
+    @MainActor
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        @Dependency(\.gitService) var gitService
+
+        var webView: WKWebView?
+        var paneID: UUID?
+        var repoPath: String = ""
+        var targetPath: String?
+        var backgroundColor: NSColor = .windowBackgroundColor
+        var backgroundOpacity: Double = 1.0
+        var fontSize: Double = 13
+        var lastIsFocused: Bool = false
+        var lastRefreshToken: UInt64 = 0
+        var pendingScrollFraction: CGFloat?
+
+        private var currentDiffText: String = ""
+        private var inFlightTask: Task<Void, Never>?
+
+        func loadDiff() {
+            guard !repoPath.isEmpty else { return }
+            cancelInFlight()
+            let repo = repoPath
+            let target = targetPath
+            inFlightTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                let text: String
+                do {
+                    text = try await gitService.getDiff(repo, target)
+                } catch {
+                    text = "Failed to run git diff in \(repo):\n\(error.localizedDescription)"
+                }
+                guard !Task.isCancelled else { return }
+                currentDiffText = text
+                renderAndReload(text)
+            }
+        }
+
+        func renderCurrent() {
+            renderAndReload(currentDiffText)
+        }
+
+        func cancelInFlight() {
+            inFlightTask?.cancel()
+            inFlightTask = nil
+        }
+
+        private func renderAndReload(_ diffText: String) {
+            let html = DiffHTMLRenderer.renderToHTML(
+                diffText: diffText,
+                backgroundColor: backgroundColor,
+                backgroundOpacity: backgroundOpacity,
+                baseFontSize: fontSize
+            )
+            webView?.evaluateJavaScript("window.scrollY") { [weak self] result, _ in
+                guard let self else { return }
+                let scrollY = result as? Double ?? 0
+                webView?.loadHTMLString(html, baseURL: nil)
+                if scrollY > 0 {
+                    pendingScrollFraction = nil
+                    webView?.evaluateJavaScript("window.scrollTo(0, \(scrollY))")
+                }
+            }
+        }
+
+        // MARK: - WKScriptMessageHandler
+
+        @preconcurrency
+        func userContentController(
+            _: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard let fraction = message.body as? Double, let paneID else { return }
+            PaneFocusView.saveScrollFraction(CGFloat(fraction), for: paneID)
+        }
+
+        // MARK: - WKNavigationDelegate
+
+        @preconcurrency
+        func webView(_: WKWebView, didFinish _: WKNavigation!) {
+            guard let paneID else { return }
+            let fraction = pendingScrollFraction ?? PaneFocusView.scrollFraction(for: paneID)
+            if let fraction, fraction > 0 {
+                pendingScrollFraction = nil
+                webView?.evaluateJavaScript(
+                    "window.scrollTo(0, \(fraction) * Math.max(1, document.body.scrollHeight - window.innerHeight))"
+                )
+            }
+        }
+
+        @preconcurrency
+        func webView(
+            _: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
+        ) {
+            // Right-click → Reload (and ⌘R) on a `loadHTMLString` page has no
+            // source URL to reload from, which lands on about:blank. Map any
+            // such reload back to our own re-fetch.
+            if navigationAction.navigationType == .reload {
+                decisionHandler(.cancel)
+                loadDiff()
+                return
+            }
+            if navigationAction.navigationType == .linkActivated,
+               let url = navigationAction.request.url {
+                NSWorkspace.shared.open(url)
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+    }
+}

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -43,6 +43,7 @@ struct PaneGridView: View {
     @State private var isResizing = false
     @State private var resizeHideTask: Task<Void, Never>?
     @State private var focusHoverTask: Task<Void, Never>?
+    @State private var diffRefreshTokens: [UUID: UInt64] = [:]
 
     var body: some View {
         if layout.isEmpty {
@@ -103,6 +104,9 @@ struct PaneGridView: View {
                 onToggleZoom: onToggleZoom,
                 isEditing: pane.isEditing,
                 onToggleEdit: pane.type == .markdown ? { onToggleMarkdownEdit(pane.id) } : nil,
+                onRefreshDiff: pane.type == .diff
+                    ? { diffRefreshTokens[pane.id, default: 0] &+= 1 }
+                    : nil,
                 onDragChanged: { point in
                     dragSourcePaneID = pane.id
                     let bounds = CGRect(origin: .zero, size: gridSize)
@@ -190,6 +194,17 @@ struct PaneGridView: View {
                     backgroundOpacity: ghosttyConfig.backgroundOpacity
                 )
                 .clipped()
+            case .diff:
+                DiffPaneView(
+                    paneID: pane.id,
+                    repoPath: pane.workingDirectory,
+                    targetPath: pane.filePath,
+                    isFocused: pane.id == focusedPaneID,
+                    refreshToken: diffRefreshTokens[pane.id] ?? 0,
+                    backgroundColor: ghosttyConfig.backgroundColor,
+                    backgroundOpacity: ghosttyConfig.backgroundOpacity,
+                    fontSize: pane.markdownFontSize
+                )
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -208,7 +223,7 @@ struct PaneGridView: View {
             }
         }
         .background {
-            if pane.type == .markdown || pane.type == .scratchpad {
+            if pane.type == .markdown || pane.type == .scratchpad || pane.type == .diff {
                 Color(nsColor: ghosttyConfig.backgroundColor)
                     .opacity(ghosttyConfig.backgroundOpacity)
             }

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -15,6 +15,7 @@ struct PaneHeaderView: View {
     var onToggleZoom: (() -> Void)?
     var isEditing: Bool = false
     var onToggleEdit: (() -> Void)?
+    var onRefreshDiff: (() -> Void)?
     var onDragChanged: ((CGPoint) -> Void)?
     var onDragEnded: (() -> Void)?
     var otherWorkspaces: [(id: UUID, name: String)] = []
@@ -32,6 +33,11 @@ struct PaneHeaderView: View {
                     .frame(width: 10, height: 10)
             } else if pane.type == .scratchpad {
                 Image(systemName: "note.text")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 10, height: 10)
+            } else if pane.type == .diff {
+                Image(systemName: "plusminus")
                     .font(.system(size: 10))
                     .foregroundStyle(.secondary)
                     .frame(width: 10, height: 10)
@@ -107,6 +113,19 @@ struct PaneHeaderView: View {
                 .buttonStyle(.plain)
                 .opacity(0.6)
                 .help(isEditing ? "Preview (⌘E)" : "Edit (⌘E)")
+            }
+
+            if pane.type == .diff, let onRefreshDiff {
+                Button(action: onRefreshDiff) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20, height: 20)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .opacity(0.6)
+                .help("Refresh diff")
             }
 
             Button(action: onSplitHorizontal) {
@@ -213,6 +232,8 @@ struct PaneHeaderView: View {
     private func openInFinder() {
         if pane.type == .markdown, let filePath = pane.filePath {
             NSWorkspace.shared.selectFile(filePath, inFileViewerRootedAtPath: "")
+        } else if pane.type == .diff, let filePath = pane.filePath, !filePath.isEmpty {
+            NSWorkspace.shared.selectFile(filePath, inFileViewerRootedAtPath: "")
         } else {
             NSWorkspace.shared.open(URL(fileURLWithPath: pane.workingDirectory))
         }
@@ -229,6 +250,13 @@ struct PaneHeaderView: View {
         }
         if pane.type == .markdown, let filePath = pane.filePath {
             return (filePath as NSString).lastPathComponent
+        }
+        if pane.type == .diff {
+            let target = pane.filePath ?? ""
+            let scope = target.isEmpty
+                ? (pane.workingDirectory as NSString).lastPathComponent
+                : (target as NSString).lastPathComponent
+            return "diff: \(scope)"
         }
         let path = pane.title ?? pane.workingDirectory
         if let home = ProcessInfo.processInfo.environment["HOME"],

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -140,6 +140,7 @@ struct WorkspaceFeature {
         case clearPaneStatus(UUID)
         case paneBranchChanged(paneID: UUID, branch: String?)
         case openMarkdownFile(filePath: String, reusePaneID: UUID? = nil)
+        case openDiffPane(repoPath: String, targetPath: String?, reusePaneID: UUID? = nil)
         case toggleMarkdownEdit(UUID)
         case increaseMarkdownFontSize(UUID)
         case decreaseMarkdownFontSize(UUID)
@@ -314,6 +315,72 @@ struct WorkspaceFeature {
                 }
 
                 if let sourceID = state.focusedPaneID {
+                    let (newLayout, _) = state.layout.splitting(
+                        paneID: sourceID,
+                        direction: .horizontal,
+                        newPaneID: newPaneID
+                    )
+                    state.layout = newLayout
+                } else {
+                    state.layout = .leaf(newPaneID)
+                }
+                state.panes.append(newPane)
+                state.focusedPaneID = newPaneID
+                state.currentLayoutIndex = nil
+                return branchEffect
+
+            case .openDiffPane(let repoPath, let targetPath, let reusePaneID):
+                let newPaneID = uuid()
+                let scopeName: String = if let targetPath, !targetPath.isEmpty {
+                    (targetPath as NSString).lastPathComponent
+                } else {
+                    (repoPath as NSString).lastPathComponent
+                }
+                let newPane = Pane(
+                    id: newPaneID,
+                    label: scopeName,
+                    type: .diff,
+                    title: "diff: \(scopeName)",
+                    workingDirectory: repoPath,
+                    filePath: targetPath,
+                    createdAt: now,
+                    lastActivityAt: now
+                )
+
+                let branchEffect: Effect<Action> = .run { send in
+                    let branch = try? await gitService.getCurrentBranch(repoPath)
+                    await send(.paneBranchChanged(paneID: newPaneID, branch: branch))
+                }
+
+                if let reusePaneID, let oldPane = state.panes[id: reusePaneID] {
+                    if state.searchingPaneID == reusePaneID {
+                        state.searchingPaneID = nil
+                        state.searchNeedle = ""
+                        state.searchTotal = nil
+                        state.searchSelected = nil
+                    }
+                    if let saved = state.savedLayout {
+                        state.layout = saved
+                        state.zoomedPaneID = nil
+                        state.savedLayout = nil
+                    }
+                    var linkedPane = newPane
+                    linkedPane.parkedSourcePaneID = reusePaneID
+                    state.layout = state.layout.replacing(paneID: reusePaneID, with: .leaf(newPaneID))
+                    state.panes.remove(id: reusePaneID)
+                    state.parkedPanes.append(oldPane)
+                    state.panes.append(linkedPane)
+                    state.focusedPaneID = newPaneID
+                    state.currentLayoutIndex = nil
+                    return branchEffect
+                }
+
+                if let sourceID = state.focusedPaneID {
+                    if let saved = state.savedLayout {
+                        state.layout = saved
+                        state.zoomedPaneID = nil
+                        state.savedLayout = nil
+                    }
                     let (newLayout, _) = state.layout.splitting(
                         paneID: sourceID,
                         direction: .horizontal,
@@ -814,8 +881,8 @@ struct WorkspaceFeature {
                 state.focusedPaneID = newPaneID
                 state.currentLayoutIndex = nil
 
-                // Markdown and scratchpad panes don't need a surface
-                if snapshot.type == .markdown || snapshot.type == .scratchpad {
+                // Markdown, scratchpad, and diff panes don't need a surface
+                if snapshot.type == .markdown || snapshot.type == .scratchpad || snapshot.type == .diff {
                     return .none
                 }
 

--- a/Nex/Features/Workspace/WorkspaceInspectorView.swift
+++ b/Nex/Features/Workspace/WorkspaceInspectorView.swift
@@ -199,29 +199,37 @@ struct WorkspaceInspectorView: View {
                     Text(repo.name)
                         .font(.system(size: 12, weight: .medium))
                 }
-                if let branch = assoc.branchName {
-                    Text(branch)
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    if let branch = assoc.branchName {
+                        Text(branch)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                    }
+                    diffStatsLabel(for: assoc.id)
                 }
             }
 
             Spacer()
 
-            Button(action: {
+            InspectorIconButton(icon: "plusminus", tooltip: "Show diff for this repo") {
+                store.send(.openDiffPath(
+                    repoPath: assoc.worktreePath,
+                    targetPath: nil,
+                    fromPaneID: nil
+                ))
+            }
+
+            InspectorIconButton(
+                icon: "terminal",
+                tooltip: "Open terminal at this path (Shift: split vertical)"
+            ) {
                 let direction: PaneLayout.SplitDirection =
                     NSEvent.modifierFlags.contains(.shift) ? .vertical : .horizontal
                 store.send(.workspaces(.element(
                     id: activeID,
                     action: .splitPaneAtPath(assoc.worktreePath, direction: direction)
                 )))
-            }) {
-                Image(systemName: "terminal")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.secondary)
             }
-            .buttonStyle(.plain)
-            .help("Open terminal at this path (Shift: split vertical)")
         }
         .contentShape(Rectangle())
         .contextMenu {
@@ -239,6 +247,23 @@ struct WorkspaceInspectorView: View {
                     deleteWorktree: true
                 ))
             }
+        }
+    }
+
+    @ViewBuilder
+    private func diffStatsLabel(for associationID: UUID) -> some View {
+        if case .dirty(let files, let adds, let dels) = store.gitStatuses[associationID] ?? .unknown {
+            HStack(spacing: 4) {
+                Text("\(files) file\(files == 1 ? "" : "s")")
+                    .foregroundStyle(.secondary)
+                if adds > 0 {
+                    Text("+\(adds)").foregroundStyle(.green)
+                }
+                if dels > 0 {
+                    Text("-\(dels)").foregroundStyle(.red)
+                }
+            }
+            .font(.system(size: 10, design: .monospaced))
         }
     }
 
@@ -365,5 +390,42 @@ struct CreateWorktreeSheet: View {
         }
         .padding(20)
         .frame(width: 320)
+    }
+}
+
+/// Compact icon button used in the inspector for per-repo actions. Adds a
+/// hover background, brightened foreground, and pointing-hand cursor since
+/// `.buttonStyle(.plain)` provides none of these by default.
+private struct InspectorIconButton: View {
+    let icon: String
+    let tooltip: String
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 10))
+                .foregroundStyle(isHovered ? .primary : .secondary)
+                .frame(width: 20, height: 20)
+                .background {
+                    if isHovered {
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(Color.secondary.opacity(0.18))
+                    }
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(tooltip)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering {
+                NSCursor.pointingHand.push()
+            } else {
+                NSCursor.pop()
+            }
+        }
     }
 }

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -1634,11 +1634,17 @@ struct WorkspaceListView: View {
         }
         if statuses.isEmpty { return .unknown }
         if statuses.contains(where: { if case .dirty = $0 { true } else { false } }) {
-            let totalChanged = statuses.reduce(0) { total, status in
-                if case .dirty(let count) = status { return total + count }
-                return total
+            var totalChanged = 0
+            var totalAdds = 0
+            var totalDels = 0
+            for status in statuses {
+                if case .dirty(let count, let adds, let dels) = status {
+                    totalChanged += count
+                    totalAdds += adds
+                    totalDels += dels
+                }
             }
-            return .dirty(changedFiles: totalChanged)
+            return .dirty(changedFiles: totalChanged, additions: totalAdds, deletions: totalDels)
         }
         if statuses.allSatisfy({ $0 == .clean }) {
             return .clean

--- a/Nex/Models/GitStatus.swift
+++ b/Nex/Models/GitStatus.swift
@@ -3,5 +3,9 @@ import Foundation
 enum RepoGitStatus: Equatable {
     case unknown
     case clean
-    case dirty(changedFiles: Int)
+    /// Working tree has changes. `changedFiles` is the porcelain count
+    /// (includes untracked); `additions`/`deletions` come from
+    /// `git diff --shortstat` and so only count tracked-file edits.
+    /// They will be 0 for untracked-only or pure-mode-change states.
+    case dirty(changedFiles: Int, additions: Int = 0, deletions: Int = 0)
 }

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -245,6 +245,7 @@ enum NexAction: String, CaseIterable {
     case createScratchpad = "create_scratchpad"
     case commandPalette = "command_palette"
     case newGroup = "new_group"
+    case openDiff = "open_diff"
     case unbind
 
     /// Actions handled by SwiftUI Commands (menu bar items).
@@ -301,6 +302,7 @@ enum NexAction: String, CaseIterable {
         case .createScratchpad: "New Scratchpad"
         case .commandPalette: "Command Palette"
         case .newGroup: "New Group"
+        case .openDiff: "Open Diff"
         case .unbind: "Unbind"
         }
     }
@@ -320,7 +322,7 @@ enum NexAction: String, CaseIterable {
             "Workspaces"
         case .toggleSidebar, .toggleInspector:
             "View"
-        case .openFile, .toggleMarkdownEdit, .increaseMarkdownFontSize, .decreaseMarkdownFontSize:
+        case .openFile, .toggleMarkdownEdit, .increaseMarkdownFontSize, .decreaseMarkdownFontSize, .openDiff:
             "Files"
         case .toggleSearch, .closeSearch:
             "Search"

--- a/Nex/Models/PaneType.swift
+++ b/Nex/Models/PaneType.swift
@@ -2,4 +2,5 @@ enum PaneType: String, Codable {
     case shell
     case markdown
     case scratchpad
+    case diff
 }

--- a/Nex/Services/GitService.swift
+++ b/Nex/Services/GitService.swift
@@ -27,6 +27,7 @@ struct GitService {
     var listWorktrees: @Sendable (_ repoPath: String) async throws -> [WorktreeInfo]
     var pruneWorktrees: @Sendable (_ repoPath: String) async throws -> Void
     var resolveRepoRoot: @Sendable (_ path: String) async -> RepoRootInfo?
+    var getDiff: @Sendable (_ repoPath: String, _ targetPath: String?) async throws -> String
 }
 
 // MARK: - Live Implementation
@@ -86,7 +87,14 @@ extension GitService {
             if lines.isEmpty {
                 return .clean
             }
-            return .dirty(changedFiles: lines.count)
+            // `--shortstat HEAD` covers both staged and unstaged so the line
+            // counts match what `--porcelain` already reports as dirty (which
+            // also includes staged). Plain `--shortstat` would miss staged
+            // edits and produce +0/-0 for stage-only repos. Errors swallow
+            // (e.g. fresh repo with no HEAD yet) so the dirty count survives.
+            let shortstat = (try? runGit(args: ["diff", "--shortstat", "HEAD"], at: path)) ?? ""
+            let (additions, deletions) = parseShortstat(shortstat)
+            return .dirty(changedFiles: lines.count, additions: additions, deletions: deletions)
         },
 
         createWorktree: { repoPath, worktreePath, branchName in
@@ -204,6 +212,14 @@ extension GitService {
                 worktreeRoot: (worktreeRoot as NSString).standardizingPath,
                 parentRepoRoot: (parentRepoRoot as NSString).standardizingPath
             )
+        },
+
+        getDiff: { repoPath, targetPath in
+            var args = ["diff", "--no-color"]
+            if let targetPath, !targetPath.isEmpty {
+                args += ["--", targetPath]
+            }
+            return try runGit(args: args, at: repoPath)
         }
     )
 }
@@ -237,6 +253,25 @@ enum GitServiceError: Error, Equatable {
     case commandFailed(command: String, exitCode: Int)
 }
 
+/// Parse a `git diff --shortstat` summary line into (additions, deletions).
+/// Examples:
+///   " 3 files changed, 27 insertions(+), 12 deletions(-)"
+///   " 1 file changed, 5 insertions(+)"
+///   " 1 file changed, 3 deletions(-)"
+///   "" (no diff)
+func parseShortstat(_ text: String) -> (additions: Int, deletions: Int) {
+    var additions = 0
+    var deletions = 0
+    for part in text.split(separator: ",") {
+        let trimmed = part.trimmingCharacters(in: .whitespaces)
+        let tokens = trimmed.split(separator: " ", maxSplits: 1)
+        guard let first = tokens.first, let count = Int(first) else { continue }
+        if trimmed.contains("insertion") { additions = count }
+        if trimmed.contains("deletion") { deletions = count }
+    }
+    return (additions, deletions)
+}
+
 // MARK: - TCA Dependency
 
 extension GitService: DependencyKey {
@@ -252,7 +287,8 @@ extension GitService: DependencyKey {
             removeWorktree: unimplemented("GitService.removeWorktree"),
             listWorktrees: unimplemented("GitService.listWorktrees"),
             pruneWorktrees: unimplemented("GitService.pruneWorktrees"),
-            resolveRepoRoot: { _ in nil }
+            resolveRepoRoot: { _ in nil },
+            getDiff: { _, _ in "" }
         )
     }
 }

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -38,6 +38,8 @@ enum SocketMessage: Equatable {
     /// File commands. `reuse` = replace the originating pane in place
     /// (`nex open --here`) instead of splitting off it.
     case openFile(path: String, paneID: UUID?, reuse: Bool)
+    /// `nex diff` — render git diff for `repoPath`, optionally scoped to `targetPath`.
+    case openDiff(repoPath: String, targetPath: String?, paneID: UUID?)
     /// Layout commands
     case layoutCycle(paneID: UUID)
     case layoutSelect(paneID: UUID, name: String)
@@ -434,6 +436,9 @@ final class SocketServer: Sendable {
         var scope: String?
         /// `nex open --here` → replace originating pane in place.
         var reuse: Bool?
+        /// `nex diff` — repo root and optional file/directory scope.
+        var repoPath: String?
+        var targetPath: String?
 
         enum CodingKeys: String, CodingKey {
             case command
@@ -445,6 +450,8 @@ final class SocketServer: Sendable {
             case cascade, index, group
             case workspace, scope
             case reuse
+            case repoPath = "repo_path"
+            case targetPath = "target_path"
         }
     }
 
@@ -496,6 +503,13 @@ final class SocketServer: Sendable {
             guard let path = wire.path, !path.isEmpty else { return nil }
             let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
             return (.openFile(path: path, paneID: paneID, reuse: wire.reuse ?? false), wire)
+        }
+
+        if wire.command == "diff" {
+            guard let repoPath = wire.repoPath, !repoPath.isEmpty else { return nil }
+            let targetPath = (wire.targetPath?.isEmpty == true) ? nil : wire.targetPath
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            return (.openDiff(repoPath: repoPath, targetPath: targetPath, paneID: paneID), wire)
         }
 
         if wire.command == "pane-close" {

--- a/NexTests/DiffHTMLRendererTests.swift
+++ b/NexTests/DiffHTMLRendererTests.swift
@@ -1,0 +1,292 @@
+import AppKit
+import Foundation
+@testable import Nex
+import Testing
+
+struct DiffHTMLRendererTests {
+    @Test func emptyDiffRendersNoChangesPlaceholder() {
+        let html = DiffHTMLRenderer.renderToHTML(diffText: "")
+        #expect(html.contains("class=\"empty\""))
+        #expect(html.contains("No changes"))
+    }
+
+    @Test func whitespaceOnlyDiffRendersPlaceholder() {
+        let html = DiffHTMLRenderer.renderToHTML(diffText: "\n\n   \n")
+        #expect(html.contains("class=\"empty\""))
+    }
+
+    @Test func addedLineGetsAddClass() {
+        let diff = "+let added = 1"
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("class=\"line line-add\""))
+    }
+
+    @Test func deletedLineGetsDelClass() {
+        let diff = "-let removed = 1"
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("class=\"line line-del\""))
+    }
+
+    @Test func contextLineGetsContextClass() {
+        let diff = " unchanged context line"
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("class=\"line line-context\""))
+    }
+
+    @Test func hunkHeaderGetsHunkClass() {
+        let diff = "@@ -10,5 +10,6 @@ func foo() {"
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("class=\"line line-hunk\""))
+    }
+
+    @Test func diffGitHeaderGetsFileHeaderClass() {
+        let diff = "diff --git a/foo.swift b/foo.swift"
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("class=\"line line-file-header\""))
+    }
+
+    @Test func tripleDashAndPlusAreFileHeadersNotDelOrAdd() {
+        let diff = """
+        --- a/foo.swift
+        +++ b/foo.swift
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        // Both should be file-header, not line-del / line-add.
+        let headerCount = html.components(separatedBy: "class=\"line line-file-header\"").count - 1
+        #expect(headerCount == 2)
+        #expect(!html.contains("class=\"line line-add\""))
+        #expect(!html.contains("class=\"line line-del\""))
+    }
+
+    @Test func realisticHunkProducesExpectedClassMix() {
+        let diff = """
+        diff --git a/x.swift b/x.swift
+        index 1234567..89abcde 100644
+        --- a/x.swift
+        +++ b/x.swift
+        @@ -1,3 +1,4 @@
+         func foo() {
+        -    let y = 2
+        +    let y = 3
+        +    let z = 4
+         }
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("class=\"line line-hunk\""))
+        #expect(html.contains("class=\"line line-add\""))
+        #expect(html.contains("class=\"line line-del\""))
+        #expect(html.contains("class=\"line line-context\""))
+        #expect(html.contains("class=\"line line-file-header\""))
+    }
+
+    @Test func htmlSpecialsAreEscaped() {
+        let diff = "+let cmp = a < b && b > c"
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("&lt;"))
+        #expect(html.contains("&gt;"))
+        #expect(html.contains("&amp;"))
+    }
+
+    @Test func darkBackgroundProducesDarkHTMLClass() {
+        let html = DiffHTMLRenderer.renderToHTML(
+            diffText: "+x",
+            backgroundColor: NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1)
+        )
+        #expect(html.contains("<html class=\"dark\">"))
+    }
+
+    @Test func lightBackgroundProducesLightHTMLClass() {
+        let html = DiffHTMLRenderer.renderToHTML(
+            diffText: "+x",
+            backgroundColor: NSColor(red: 0.95, green: 0.95, blue: 0.95, alpha: 1)
+        )
+        #expect(html.contains("<html class=\"light\">"))
+    }
+
+    @Test func backgroundColorEmittedAsRGBA() {
+        let html = DiffHTMLRenderer.renderToHTML(
+            diffText: "+x",
+            backgroundColor: NSColor(red: 1, green: 0, blue: 0, alpha: 1),
+            backgroundOpacity: 0.5
+        )
+        #expect(html.contains("rgba(255, 0, 0, 0.5)"))
+    }
+
+    // MARK: - Sticky / collapsible file headers
+
+    @Test func diffGitOpensDetailsBlockWithFilePath() {
+        let diff = """
+        diff --git a/Sources/Foo.swift b/Sources/Foo.swift
+        @@ -1,1 +1,1 @@
+        -old
+        +new
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("<details class=\"file\" open>"))
+        #expect(html.contains("class=\"file-summary\""))
+        #expect(html.contains("class=\"file-path\">Sources/Foo.swift</span>"))
+        #expect(html.contains("</details>"))
+    }
+
+    @Test func multipleFilesProduceMultipleDetailsBlocks() {
+        let diff = """
+        diff --git a/foo.swift b/foo.swift
+        @@ -1 +1 @@
+        -a
+        +b
+        diff --git a/bar.swift b/bar.swift
+        @@ -1 +1 @@
+        -c
+        +d
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        let openCount = html.components(separatedBy: "<details class=\"file\" open>").count - 1
+        let closeCount = html.components(separatedBy: "</details>").count - 1
+        #expect(openCount == 2)
+        #expect(closeCount == 2)
+        #expect(html.contains(">foo.swift</span>"))
+        #expect(html.contains(">bar.swift</span>"))
+    }
+
+    @Test func summaryHasStickyCSSAndCursorPointer() {
+        let html = DiffHTMLRenderer.renderToHTML(diffText: "diff --git a/x b/x\n@@ -1 +1 @@\n+a")
+        #expect(html.contains("position: sticky"))
+        #expect(html.contains("cursor: pointer"))
+    }
+
+    @Test func hunksAreWrappedInPerFileScrollContainer() {
+        // The summary must sit OUTSIDE the horizontally-scrolling hunks
+        // wrapper so it stays at viewport width when long lines force the
+        // hunks to scroll horizontally.
+        let diff = "diff --git a/x b/x\n@@ -1 +1 @@\n+a very long line indeed"
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("class=\"hunks\""))
+        #expect(html.contains("class=\"hunks-inner\""))
+        // CSS: body must clip horizontally so per-file scroll handles it.
+        #expect(html.contains("overflow-x: hidden"))
+        // Order: <summary> ... </summary> ... <div class="hunks">
+        if let sumEnd = html.range(of: "</summary>"),
+           let hunksStart = html.range(of: "<div class=\"hunks\"") {
+            #expect(sumEnd.upperBound <= hunksStart.lowerBound)
+        } else {
+            Issue.record("Expected <summary> to precede <div class=\"hunks\">")
+        }
+    }
+
+    @Test func renamedFileExtractsDestinationPath() {
+        let diff = "diff --git a/old/path.swift b/new/path.swift\n@@ -1 +1 @@\n+x"
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains(">new/path.swift</span>"))
+    }
+
+    @Test func diffWithoutDiffGitLineStillRenders() {
+        // Edge case: lines without any `diff --git` header (e.g. raw hunk).
+        // Should render as plain lines without any <details> wrapper.
+        let html = DiffHTMLRenderer.renderToHTML(diffText: "+just an add")
+        #expect(!html.contains("<details"))
+        #expect(html.contains("class=\"line line-add\""))
+    }
+
+    // MARK: - Status badges + line counts
+
+    @Test func modifiedFileShowsModifiedBadgeAndCounts() {
+        let diff = """
+        diff --git a/foo.swift b/foo.swift
+        index 1..2 100644
+        --- a/foo.swift
+        +++ b/foo.swift
+        @@ -1,3 +1,4 @@
+         keep
+        -gone
+        +new1
+        +new2
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("status-modified"))
+        #expect(html.contains(">modified</span>"))
+        #expect(html.contains("class=\"stat-add\">+2</span>"))
+        #expect(html.contains("class=\"stat-del\">-1</span>"))
+    }
+
+    @Test func addedFileShowsAddedBadge() {
+        let diff = """
+        diff --git a/new.swift b/new.swift
+        new file mode 100644
+        index 0000000..1234567
+        --- /dev/null
+        +++ b/new.swift
+        @@ -0,0 +1,2 @@
+        +line one
+        +line two
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("status-added"))
+        #expect(html.contains(">added</span>"))
+        #expect(html.contains("class=\"stat-add\">+2</span>"))
+    }
+
+    @Test func deletedFileShowsDeletedBadge() {
+        let diff = """
+        diff --git a/gone.swift b/gone.swift
+        deleted file mode 100644
+        index 1234567..0000000
+        --- a/gone.swift
+        +++ /dev/null
+        @@ -1,2 +0,0 @@
+        -line one
+        -line two
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("status-deleted"))
+        #expect(html.contains(">deleted</span>"))
+        #expect(html.contains("class=\"stat-del\">-2</span>"))
+    }
+
+    @Test func renamedFileShowsRenamedBadgeAndArrow() {
+        let diff = """
+        diff --git a/old.swift b/new.swift
+        similarity index 95%
+        rename from old.swift
+        rename to new.swift
+        index 1..2 100644
+        --- a/old.swift
+        +++ b/new.swift
+        @@ -1 +1 @@
+        -tweak
+        +tweaked
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("status-renamed"))
+        #expect(html.contains(">renamed</span>"))
+        // Arrow uses → (U+2192) which gets escaped as a literal char in the HTML.
+        #expect(html.contains("old.swift → new.swift"))
+    }
+
+    @Test func binaryFileShowsBinaryBadgeWithoutCounts() {
+        let diff = """
+        diff --git a/icon.png b/icon.png
+        index 1..2 100644
+        Binary files a/icon.png and b/icon.png differ
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("status-binary"))
+        #expect(html.contains(">binary</span>"))
+        #expect(!html.contains("class=\"diff-stats\""))
+    }
+
+    @Test func tripleDashAndPlusNotCountedAsAddOrDel() {
+        // Sanity: `+++ b/path` and `--- a/path` lines must not inflate counts.
+        let diff = """
+        diff --git a/x b/x
+        index 1..2 100644
+        --- a/x
+        +++ b/x
+        @@ -1 +1 @@
+        -old
+        +new
+        """
+        let html = DiffHTMLRenderer.renderToHTML(diffText: diff)
+        #expect(html.contains("class=\"stat-add\">+1</span>"))
+        #expect(html.contains("class=\"stat-del\">-1</span>"))
+    }
+}

--- a/NexTests/GitServiceTests.swift
+++ b/NexTests/GitServiceTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import Nex
+import Testing
+
+struct GitServiceTests {
+    // MARK: - parseShortstat
+
+    @Test func emptyShortstatReturnsZeros() {
+        let (a, d) = parseShortstat("")
+        #expect(a == 0)
+        #expect(d == 0)
+    }
+
+    @Test func shortstatWithBothInsertionsAndDeletions() {
+        let (a, d) = parseShortstat(" 3 files changed, 27 insertions(+), 12 deletions(-)")
+        #expect(a == 27)
+        #expect(d == 12)
+    }
+
+    @Test func shortstatWithOnlyInsertions() {
+        let (a, d) = parseShortstat(" 1 file changed, 5 insertions(+)")
+        #expect(a == 5)
+        #expect(d == 0)
+    }
+
+    @Test func shortstatWithOnlyDeletions() {
+        let (a, d) = parseShortstat(" 1 file changed, 3 deletions(-)")
+        #expect(a == 0)
+        #expect(d == 3)
+    }
+
+    @Test func shortstatPureRenameHasZeroLines() {
+        // Pure rename / mode change emits no insertion/deletion clauses.
+        let (a, d) = parseShortstat(" 1 file changed")
+        #expect(a == 0)
+        #expect(d == 0)
+    }
+
+    @Test func shortstatSingularInsertionForm() {
+        // git uses "1 insertion(+)" (singular) for one-line changes.
+        let (a, d) = parseShortstat(" 1 file changed, 1 insertion(+), 1 deletion(-)")
+        #expect(a == 1)
+        #expect(d == 1)
+    }
+}

--- a/NexTests/WorkspaceFeatureTests.swift
+++ b/NexTests/WorkspaceFeatureTests.swift
@@ -1661,4 +1661,162 @@ struct WorkspaceFeatureTests {
         #expect(store.state.panes[id: markdownID]?.parkedSourcePaneID == nil)
         #expect(surfaceManager.activeSurfaceCount == 0)
     }
+
+    // MARK: - openDiffPane
+
+    @Test func openDiffPaneSplitsAndCreatesDiffPane() async {
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let sourceID = workspace.panes.first!.id
+        workspace.layout = .leaf(sourceID)
+        workspace.focusedPaneID = sourceID
+
+        let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000DDDDDD")!
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(Date(timeIntervalSince1970: 3000))
+            $0.uuid = .constant(newPaneID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openDiffPane(repoPath: "/tmp/repo", targetPath: nil)) { state in
+            let created = state.panes[id: newPaneID]
+            #expect(created?.type == .diff)
+            #expect(created?.workingDirectory == "/tmp/repo")
+            #expect(created?.filePath == nil)
+            #expect(created?.label == "repo")
+            #expect(state.focusedPaneID == newPaneID)
+            // Layout split: source on one side, new diff pane on the other.
+            if case .split(_, _, .leaf(let first), .leaf(let second)) = state.layout {
+                #expect((first == sourceID && second == newPaneID)
+                    || (first == newPaneID && second == sourceID))
+            } else {
+                Issue.record("Expected split layout after openDiffPane")
+            }
+        }
+    }
+
+    @Test func reopenClosedDiffPaneDoesNotCreateSurface() async {
+        // Diff panes have no PTY — reopening one must not spin up a shell
+        // surface behind the WKWebView.
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let firstID = workspace.panes.first!.id
+        workspace.recentlyClosedPanes = [
+            ClosedPaneSnapshot(
+                workingDirectory: "/tmp/repo",
+                label: "repo",
+                type: .diff,
+                filePath: nil,
+                claudeSessionID: nil
+            )
+        ]
+
+        let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000DDDD01")!
+        let surfaceManager = SurfaceManager()
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = surfaceManager
+            $0.uuid = .constant(newPaneID)
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.reopenClosedPane) { state in
+            #expect(state.recentlyClosedPanes.isEmpty)
+            #expect(state.panes[id: newPaneID]?.type == .diff)
+            #expect(state.panes[id: newPaneID]?.workingDirectory == "/tmp/repo")
+            #expect(state.focusedPaneID == newPaneID)
+            // Layout split horizontally with the original pane.
+            if case .split(_, _, .leaf(let first), .leaf(let second)) = state.layout {
+                #expect(first == firstID)
+                #expect(second == newPaneID)
+            } else {
+                Issue.record("Expected split layout after reopening diff pane")
+            }
+        }
+        await store.finish()
+
+        // Critical: no surface was created for the diff pane.
+        #expect(surfaceManager.activeSurfaceCount == 0)
+    }
+
+    @Test func openDiffPaneUnzoomsBeforeSplitting() async {
+        // Opening a diff while a pane is zoomed must restore the saved layout
+        // first; otherwise the diff pane gets spliced into the temporary
+        // single-pane layout and disappears on the next unzoom.
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let firstID = workspace.panes.first!.id
+        let zoomedID = UUID()
+        workspace.panes.append(Pane(id: zoomedID))
+        let originalLayout = PaneLayout.split(
+            .horizontal,
+            ratio: 0.5,
+            first: .leaf(firstID),
+            second: .leaf(zoomedID)
+        )
+        workspace.layout = .leaf(zoomedID) // zoomed in
+        workspace.savedLayout = originalLayout // remembered for restore
+        workspace.zoomedPaneID = zoomedID
+        workspace.focusedPaneID = zoomedID
+
+        let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000DDDD02")!
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(Date(timeIntervalSince1970: 5000))
+            $0.uuid = .constant(newPaneID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openDiffPane(repoPath: "/tmp/repo", targetPath: nil)) { state in
+            // Zoom state cleared before splitting.
+            #expect(state.savedLayout == nil)
+            #expect(state.zoomedPaneID == nil)
+            // Layout was rebuilt from the originalLayout, then split off the
+            // focused (zoomed) pane — so the original sibling is preserved.
+            #expect(state.panes[id: newPaneID]?.type == .diff)
+            #expect(state.panes[id: firstID] != nil)
+            #expect(state.panes[id: zoomedID] != nil)
+            #expect(state.focusedPaneID == newPaneID)
+            // Diff pane must be reachable in the live layout (not orphaned).
+            #expect(state.layout.contains(paneID: newPaneID))
+            #expect(state.layout.contains(paneID: firstID))
+        }
+    }
+
+    @Test func openDiffPaneWithTargetPathUsesTargetAsLabel() async {
+        var workspace = WorkspaceFeature.State(name: "Test")
+        workspace.focusedPaneID = workspace.panes.first?.id
+
+        let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-0000000EEEEE")!
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(Date(timeIntervalSince1970: 4000))
+            $0.uuid = .constant(newPaneID)
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.openDiffPane(
+            repoPath: "/tmp/repo",
+            targetPath: "/tmp/repo/Sources/Foo.swift"
+        )) { state in
+            let created = state.panes[id: newPaneID]
+            #expect(created?.type == .diff)
+            #expect(created?.workingDirectory == "/tmp/repo")
+            #expect(created?.filePath == "/tmp/repo/Sources/Foo.swift")
+            #expect(created?.label == "Foo.swift")
+            #expect(created?.title == "diff: Foo.swift")
+        }
+    }
 }

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -22,6 +22,7 @@
 //   nex layout cycle
 //   nex layout select <name>
 //   nex open [--here] <filepath>
+//   nex diff [<path>]
 //
 // Reads NEX_PANE_ID from the environment (injected by Nex when the PTY was created).
 // Reads NEX_SOCKET from the environment to select transport:
@@ -92,6 +93,7 @@ func printUsage() {
       nex layout cycle
       nex layout select <name>
       nex open [--here] <filepath>
+      nex diff [<path>]
     \n
     """, stderr)
 }
@@ -848,6 +850,27 @@ func handleOpen(_ args: inout ArraySlice<String>) {
     sendJSONAny(payload)
 }
 
+func handleDiff(_ args: inout ArraySlice<String>) {
+    let cwd = FileManager.default.currentDirectoryPath
+    var payload: [String: Any] = [
+        "command": "diff",
+        "repo_path": cwd
+    ]
+
+    if let target = args.popFirst() {
+        let absolute = URL(fileURLWithPath: target, relativeTo: URL(fileURLWithPath: cwd))
+            .standardizedFileURL
+            .path
+        payload["target_path"] = absolute
+    }
+
+    if let paneID = ProcessInfo.processInfo.environment["NEX_PANE_ID"] {
+        payload["pane_id"] = paneID
+    }
+
+    sendJSONAny(payload)
+}
+
 // MARK: - Main
 
 var args = CommandLine.arguments.dropFirst()
@@ -875,6 +898,8 @@ case "layout":
     handleLayout(&args)
 case "open":
     handleOpen(&args)
+case "diff":
+    handleDiff(&args)
 default:
     fputs("Unknown command: \(subcommand)\n", stderr)
     printUsage()


### PR DESCRIPTION
## Summary
- New `.diff` pane type that renders `git diff` for the focused pane's repo, opened via `nex diff [<path>]`, the bindable `open_diff` keybinding, or a button in the workspace inspector
- Each file gets a collapsible `<details>` block with a sticky `<summary>` showing path, status badge (added/deleted/modified/renamed/binary/mode), and `+N -M` line counts; per-file horizontal scroll keeps the summary at viewport width
- Inspector now shows `N files +A -B` under each repo association (sourced from `git status --porcelain` + `git diff --shortstat HEAD` so staged changes count toward the line totals)

## Test plan
- [x] `make check` — format, lint, build, all 615 tests pass
- [x] In a dirty repo: `nex diff` opens a diff pane with the working-tree diff
- [x] `nex diff path/to/file` scopes to that path
- [x] Inspector button (plusminus icon next to a repo association) opens the diff
- [x] Bind `Open Diff` in Settings → Keybindings; the chord opens diff for the focused pane's repo
- [x] Header refresh button, ⌘R, and right-click → Reload all re-render (the right-click reload was previously blanking the pane — fixed by intercepting `WKNavigationType.reload`)
- [x] Scroll horizontally inside a file with long lines — the file header stays pinned at viewport width
- [x] Click a file header to collapse/expand
- [x] Stage some changes — sidebar shows non-zero `+/-` counts (previously would show `+0/-0` for stage-only state)
- [x] Open a diff pane while another pane is zoomed — the saved layout restores cleanly and the diff pane is reachable after unzoom
- [x] Close a diff pane, then ⌘⇧T to reopen — no shell PTY is created behind the WKWebView
- [x] Quit and relaunch — diff panes restore from persistence and re-render
- [x] Toggle system appearance — light/dark CSS swaps; background matches surrounding terminal panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)