### PR TITLE
fix: refresh inspector branch name on git status refresh

### DIFF
--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -2826,6 +2826,12 @@ struct AppReducer {
                     for assoc in associations {
                         let status = await (try? gitService.getStatus(assoc.worktreePath)) ?? .unknown
                         await send(.gitStatusUpdated(associationID: assoc.id, status: status))
+                        let branch = try? await gitService.getCurrentBranch(assoc.worktreePath)
+                        await send(.repoAssociationBranchResolved(
+                            workspaceID: activeID,
+                            associationID: assoc.id,
+                            branch: branch
+                        ))
                     }
                 }
 


### PR DESCRIPTION
## Summary
- The branch name next to each repo association in the workspace inspector was only resolved once (when the association was first auto-detected), so switching branches left a stale name.
- Refresh the branch alongside the existing git status sweep so it updates on inspector toggle, pane focus, and the 30s timer.

## Test plan
- [x] Open the inspector on a repo association
- [x] Switch branches in a pane inside that worktree
- [x] Defocus and refocus the pane (or toggle the inspector) and verify the inspector now shows the new branch