### PR TITLE
feat: sub-second sidebar git updates via .git/HEAD watcher

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		59239C7AD0D26E390C647C46 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 98CF017F4F26916F63300A33 /* Yams */; };
 		5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */; };
 		62564D224FD57BC3C02100EA /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191E820170ADF2ADB58B8079 /* GitServiceTests.swift */; };
+		62BC1CC522515C8E6A99F508 /* GitHeadWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281BB8BFA202B0E43FC1E2AE /* GitHeadWatcher.swift */; };
 		64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A24C1FEC6EA31096603326 /* SurfaceManager.swift */; };
 		696312BB96D35569F48B7CAE /* MarkdownFrontMatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43F769C33118440222BF5FA /* MarkdownFrontMatter.swift */; };
 		6ACFF31A3875EBE87E78C587 /* RepoAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A1CB3D7653911EF93F8F5 /* RepoAssociation.swift */; };
@@ -54,6 +55,7 @@
 		741144CE5AC7DEC20A18A89D /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70E36C00A55A87562F4AC1D /* CommandPaletteView.swift */; };
 		759B67A4E8D35868EC6E2295 /* AppActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D46DA7C3A37F67FBBBEAC7 /* AppActivation.swift */; };
 		75BECE7D63EF981C344D4902 /* SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */; };
+		76FC0D784C9823F0B870C6C5 /* GitHeadWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B88C15DF87E94A115F9FD7 /* GitHeadWatcherTests.swift */; };
 		77C780C65EFA8114C681638B /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 8B14B7BF7BD4FCD61EBB97A9 /* ComposableArchitecture */; };
 		77CF808E3AF2C06BD12D11C0 /* SplitDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DED98594372C8E34542A5C2 /* SplitDividerView.swift */; };
 		77FB1142F26F5C33539E3F23 /* DiffHTMLRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E85EE83A315989753EADF1 /* DiffHTMLRenderer.swift */; };
@@ -163,6 +165,7 @@
 		221A3B0170CFD708F3B03A84 /* Repo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repo.swift; sourceTree = "<group>"; };
 		2445F37BD230A19B4FA07CDC /* WorkspaceGroupRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupRenderTests.swift; sourceTree = "<group>"; };
 		257A1CB3D7653911EF93F8F5 /* RepoAssociation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoAssociation.swift; sourceTree = "<group>"; };
+		281BB8BFA202B0E43FC1E2AE /* GitHeadWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHeadWatcher.swift; sourceTree = "<group>"; };
 		281D0362CA8542610B8329F6 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceColorSelectionTests.swift; sourceTree = "<group>"; };
 		2F6F950849E47A0BCC6DEAB5 /* ResizeDimensionsOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeDimensionsOverlay.swift; sourceTree = "<group>"; };
@@ -198,6 +201,7 @@
 		8344DA5EFC15BF047C2003A4 /* PaneCaptureReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneCaptureReplyTests.swift; sourceTree = "<group>"; };
 		84D4EC6AC4CDFB5377057239 /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
 		852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineNumberRulerView.swift; sourceTree = "<group>"; };
+		86B88C15DF87E94A115F9FD7 /* GitHeadWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHeadWatcherTests.swift; sourceTree = "<group>"; };
 		89FC5F004277851CEA0CFF3F /* CommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteTests.swift; sourceTree = "<group>"; };
 		8C693AF419763177AE1CEA0F /* UserDefaultsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsClient.swift; sourceTree = "<group>"; };
 		92E85EE83A315989753EADF1 /* DiffHTMLRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffHTMLRenderer.swift; sourceTree = "<group>"; };
@@ -350,6 +354,7 @@
 				21064C4AB47888B6A02CCD73 /* DatabaseMigrationTests.swift */,
 				396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */,
 				77FDA3FB200AA7846BCDC7A7 /* EditorServiceTests.swift */,
+				86B88C15DF87E94A115F9FD7 /* GitHeadWatcherTests.swift */,
 				191E820170ADF2ADB58B8079 /* GitServiceTests.swift */,
 				B822ABF12B071E574E089BB4 /* GroupIconTests.swift */,
 				EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */,
@@ -458,6 +463,7 @@
 				CF4114D723403D4FF8F4AC1B /* ConfigParser.swift */,
 				3879BA745F8737CA5872F80D /* DatabaseService.swift */,
 				D0CED7EFE254E4491327CAE0 /* EditorService.swift */,
+				281BB8BFA202B0E43FC1E2AE /* GitHeadWatcher.swift */,
 				0153509BA13BB205C40DE2D5 /* GitService.swift */,
 				8340B6640D25908803B93C2A /* GlobalHotkeyService.swift */,
 				93D45D65A66C475B0CEEC53C /* KeybindingService.swift */,
@@ -695,6 +701,7 @@
 				B652FDDE5CE91C5CA1DAC8E2 /* DatabaseMigrationTests.swift in Sources */,
 				149E80DD671127055EF67F7F /* DiffHTMLRendererTests.swift in Sources */,
 				F9EF0D090461E0518C6EB23F /* EditorServiceTests.swift in Sources */,
+				76FC0D784C9823F0B870C6C5 /* GitHeadWatcherTests.swift in Sources */,
 				62564D224FD57BC3C02100EA /* GitServiceTests.swift in Sources */,
 				0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */,
 				EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */,
@@ -742,6 +749,7 @@
 				ECA2C078504EB9BF0E04B343 /* GhosttyConfig.swift in Sources */,
 				C0DDF7284D01523225E5EEE7 /* GhosttyConfigClient.swift in Sources */,
 				7C78EA65C2D22749546715A0 /* GhosttySurface.swift in Sources */,
+				62BC1CC522515C8E6A99F508 /* GitHeadWatcher.swift in Sources */,
 				DBBD0CD88C3B7EF588D5CB04 /* GitService.swift in Sources */,
 				E19F4E0C87CB85D959F0C8F2 /* GitStatus.swift in Sources */,
 				0A339E290783C7347081E4FC /* GlobalHotkeyService.swift in Sources */,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -378,6 +378,9 @@ struct AppReducer {
         case refreshGitStatus
         case gitStatusUpdated(associationID: UUID, status: RepoGitStatus)
         case startGitStatusTimer
+        case startHeadWatcher(workspaceID: UUID, associationID: UUID, worktreePath: String)
+        case stopHeadWatcher(associationID: UUID)
+        case headChanged(workspaceID: UUID, associationID: UUID)
 
         /// External indicators (menu bar, dock badge)
         case updateExternalIndicators
@@ -429,6 +432,7 @@ struct AppReducer {
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.persistenceService) var persistenceService
     @Dependency(\.gitService) var gitService
+    @Dependency(\.gitHeadWatcher) var gitHeadWatcher
     @Dependency(\.socketServer) var socketServer
     @Dependency(\.notificationService) var notificationService
     @Dependency(\.statusBarController) var statusBarController
@@ -442,6 +446,14 @@ struct AppReducer {
     private enum AutoLinkDebounceID: Hashable { case pane(UUID) }
     private enum AutoUnlinkDebounceID: Hashable { case workspace(UUID) }
     private enum PaletteFocusID: Hashable { case pending }
+    private enum HeadWatcherID: Hashable { case association(UUID) }
+    private enum HeadChangedDebounceID: Hashable { case association(UUID) }
+
+    /// Debounce for `headChanged` effects. `git checkout` typically writes
+    /// HEAD via temp file + atomic rename, which can fire two events back
+    /// to back. Coalesce them so we only run `git status` + branch resolve
+    /// once per logical checkout.
+    static let headChangedDebounce: Duration = .milliseconds(150)
 
     /// Delay after the palette triggers a focus change before we claim
     /// first responder for the destination surface. Matches the palette
@@ -1099,17 +1111,28 @@ struct AppReducer {
                 let paneID = workspace.panes.first!.id
                 let cwd = workspace.panes.first!.workingDirectory
                 let opacity = ghosttyConfig.backgroundOpacity
+                let workspaceID = workspace.id
+                let watcherSeeds: [Effect<Action>] = workspace.repoAssociations.map { assoc in
+                    Effect.send(.startHeadWatcher(
+                        workspaceID: workspaceID,
+                        associationID: assoc.id,
+                        worktreePath: assoc.worktreePath
+                    ))
+                }
                 return .merge(
-                    .run { _ in
-                        await surfaceManager.createSurface(paneID: paneID, workingDirectory: cwd, backgroundOpacity: opacity)
-                    },
-                    .send(.persistState)
+                    [
+                        .run { _ in
+                            await surfaceManager.createSurface(paneID: paneID, workingDirectory: cwd, backgroundOpacity: opacity)
+                        },
+                        .send(.persistState)
+                    ] + watcherSeeds
                 )
 
             case .deleteWorkspace(let id):
                 guard let workspace = state.workspaces[id: id] else { return .none }
                 let paneIDs = workspace.layout.allPaneIDs
                     + workspace.parkedPanes.map(\.id)
+                let assocIDs = workspace.repoAssociations.map(\.id)
                 state.workspaces.remove(id: id)
                 state.topLevelOrder.removeAll { $0 == .workspace(id) }
                 for groupID in state.groups.ids {
@@ -1135,13 +1158,16 @@ struct AppReducer {
                     state.lastSelectionAnchor = nil
                 }
 
+                let stopEffects = assocIDs.map { Effect.send(Action.stopHeadWatcher(associationID: $0)) }
                 return .merge(
-                    .run { _ in
-                        for paneID in paneIDs {
-                            await surfaceManager.destroySurface(paneID: paneID)
-                        }
-                    },
-                    .send(.persistState)
+                    [
+                        .run { _ in
+                            for paneID in paneIDs {
+                                await surfaceManager.destroySurface(paneID: paneID)
+                            }
+                        },
+                        .send(.persistState)
+                    ] + stopEffects
                 )
 
             case .moveWorkspace(let id, let toIndex):
@@ -1807,34 +1833,49 @@ struct AppReducer {
                 let shellPanes: [(id: UUID, cwd: String)] = workspaces.flatMap { ws in
                     ws.panes.filter { $0.type == .shell }.map { (id: $0.id, cwd: $0.workingDirectory) }
                 }
-                return .merge(
-                    .run { send in
-                        for pane in shellPanes {
-                            await surfaceManager.createSurface(
-                                paneID: pane.id,
-                                workingDirectory: pane.cwd,
-                                backgroundOpacity: opacity
-                            )
-                        }
+                // Seed HEAD watchers for every persisted RepoAssociation so
+                // sidebar branch/status updates land within ~200ms of any
+                // `git checkout` after restart.
+                let watcherSeeds: [Effect<Action>] = state.workspaces.flatMap { ws in
+                    ws.repoAssociations.map { assoc in
+                        Effect.send(.startHeadWatcher(
+                            workspaceID: ws.id,
+                            associationID: assoc.id,
+                            worktreePath: assoc.worktreePath
+                        ))
+                    }
+                }
 
-                        // Auto-resume Claude Code sessions after surfaces are ready.
-                        // Persist AFTER sending resume commands so session IDs survive
-                        // if the app crashes before the resume actually executes.
-                        if !panesToResume.isEmpty {
-                            try? await clock.sleep(for: .seconds(2))
-                            for entry in panesToResume {
-                                await surfaceManager.sendCommand(
-                                    to: entry.paneID,
-                                    command: "claude --resume \(entry.sessionID)"
+                return .merge(
+                    [
+                        .run { send in
+                            for pane in shellPanes {
+                                await surfaceManager.createSurface(
+                                    paneID: pane.id,
+                                    workingDirectory: pane.cwd,
+                                    backgroundOpacity: opacity
                                 )
                             }
-                        }
 
-                        // Now that resume commands have been sent, persist the cleared state
-                        await send(.persistState)
-                    },
-                    .send(.refreshGitStatus),
-                    .send(.startGitStatusTimer)
+                            // Auto-resume Claude Code sessions after surfaces are ready.
+                            // Persist AFTER sending resume commands so session IDs survive
+                            // if the app crashes before the resume actually executes.
+                            if !panesToResume.isEmpty {
+                                try? await clock.sleep(for: .seconds(2))
+                                for entry in panesToResume {
+                                    await surfaceManager.sendCommand(
+                                        to: entry.paneID,
+                                        command: "claude --resume \(entry.sessionID)"
+                                    )
+                                }
+                            }
+
+                            // Now that resume commands have been sent, persist the cleared state
+                            await send(.persistState)
+                        },
+                        .send(.refreshGitStatus),
+                        .send(.startGitStatusTimer)
+                    ] + watcherSeeds
                 )
 
             case .workspaces(.element(_, action: .agentStarted)):
@@ -2618,10 +2659,27 @@ struct AppReducer {
             case .surfaceDirectoryChanged(let paneID, let directory):
                 guard let workspace = state.workspaceContainingPane(paneID)
                 else { return .none }
-                return .send(.workspaces(.element(
-                    id: workspace.id,
-                    action: .paneDirectoryChanged(paneID: paneID, directory: directory)
-                )))
+                // Refresh any RepoAssociation whose worktree contains the new
+                // pwd. Catches `cd ../other-worktree` instantly, before the
+                // 30s timer or an unrelated HEAD change would otherwise pick
+                // it up.
+                let standardizedPwd = (directory as NSString).standardizingPath
+                let touched = workspace.repoAssociations.filter { assoc in
+                    let root = (assoc.worktreePath as NSString).standardizingPath
+                    return standardizedPwd == root || standardizedPwd.hasPrefix(root + "/")
+                }
+                let workspaceID = workspace.id
+                let pwdRefreshes: [Effect<Action>] = touched.map { assoc in
+                    Effect.send(.headChanged(workspaceID: workspaceID, associationID: assoc.id))
+                }
+                return .merge(
+                    [
+                        .send(.workspaces(.element(
+                            id: workspace.id,
+                            action: .paneDirectoryChanged(paneID: paneID, directory: directory)
+                        )))
+                    ] + pwdRefreshes
+                )
 
             case .surfaceProcessExited(let paneID):
                 guard let workspace = state.workspaceContainingPane(paneID)
@@ -2741,7 +2799,12 @@ struct AppReducer {
                 state.repoRegistry[id: repoID]?.isAutoDiscovered = false
                 return .merge(
                     .send(.persistState),
-                    .send(.refreshGitStatus)
+                    .send(.refreshGitStatus),
+                    .send(.startHeadWatcher(
+                        workspaceID: workspaceID,
+                        associationID: assoc.id,
+                        worktreePath: worktreePath
+                    ))
                 )
 
             case .worktreeCreationFailed:
@@ -2758,13 +2821,17 @@ struct AppReducer {
 
                 if deleteWorktree {
                     return .merge(
+                        .send(.stopHeadWatcher(associationID: associationID)),
                         .run { _ in
                             try? await gitService.removeWorktree(repo.path, assoc.worktreePath)
                         },
                         .send(.persistState)
                     )
                 }
-                return .send(.persistState)
+                return .merge(
+                    .send(.stopHeadWatcher(associationID: associationID)),
+                    .send(.persistState)
+                )
 
             // MARK: - Auto-Detected Repo Associations
 
@@ -2850,6 +2917,11 @@ struct AppReducer {
                             ))
                         }
                     )
+                    effects.append(.send(.startHeadWatcher(
+                        workspaceID: workspaceID,
+                        associationID: assocID,
+                        worktreePath: resolvedWorktree
+                    )))
                 }
 
                 if addedRepo {
@@ -2889,6 +2961,7 @@ struct AppReducer {
                 }
 
                 var removedRepoIDs: Set<UUID> = []
+                var stoppedAssocIDs: [UUID] = []
                 for assocID in candidateIDs {
                     guard let assoc = state.workspaces[id: workspaceID]?
                         .repoAssociations[id: assocID] else { continue }
@@ -2897,6 +2970,7 @@ struct AppReducer {
                         state.workspaces[id: workspaceID]?.repoAssociations.remove(id: assocID)
                         state.gitStatuses.removeValue(forKey: assocID)
                         removedRepoIDs.insert(assoc.repoID)
+                        stoppedAssocIDs.append(assocID)
                     }
                 }
 
@@ -2914,7 +2988,9 @@ struct AppReducer {
                     }
                 }
 
-                return removedRepoIDs.isEmpty ? .none : .send(.persistState)
+                if removedRepoIDs.isEmpty { return .none }
+                let stopEffects = stoppedAssocIDs.map { Effect.send(Action.stopHeadWatcher(associationID: $0)) }
+                return .merge(stopEffects + [.send(.persistState)])
 
             case .repoRemoteURLResolved(let repoID, let url):
                 state.repoRegistry[id: repoID]?.remoteURL = url
@@ -2966,6 +3042,60 @@ struct AppReducer {
                     }
                 }
                 .cancellable(id: GitStatusTimerID.timer, cancelInFlight: true)
+
+            case .startHeadWatcher(let workspaceID, let associationID, let worktreePath):
+                return .run { [gitService, gitHeadWatcher] send in
+                    // Resolve the real HEAD path. For a linked worktree this
+                    // is `<repo>/.git/worktrees/<name>/HEAD`, not the
+                    // worktree's own `.git/HEAD`.
+                    guard let headPath = try? await gitService.resolveHeadPath(worktreePath) else {
+                        return
+                    }
+                    let stream = gitHeadWatcher.start(
+                        associationID: associationID,
+                        headPath: headPath
+                    )
+                    for await _ in stream {
+                        await send(.headChanged(
+                            workspaceID: workspaceID,
+                            associationID: associationID
+                        ))
+                    }
+                }
+                .cancellable(id: HeadWatcherID.association(associationID), cancelInFlight: true)
+
+            case .stopHeadWatcher(let associationID):
+                gitHeadWatcher.stop(associationID: associationID)
+                return .merge(
+                    .cancel(id: HeadWatcherID.association(associationID)),
+                    .cancel(id: HeadChangedDebounceID.association(associationID))
+                )
+
+            case .headChanged(let workspaceID, let associationID):
+                guard let assoc = state.workspaces[id: workspaceID]?
+                    .repoAssociations[id: associationID]
+                else { return .none }
+                let path = assoc.worktreePath
+                return .run { [gitService, clock] send in
+                    // Coalesce the double-write of `git checkout` (HEAD is
+                    // typically rewritten via temp file + atomic rename, so
+                    // we see two events back to back). `cancelInFlight: true`
+                    // means a second event within the debounce window starts
+                    // a fresh sleep.
+                    try? await clock.sleep(for: Self.headChangedDebounce)
+                    let status = await (try? gitService.getStatus(path)) ?? .unknown
+                    let branch = try? await gitService.getCurrentBranch(path)
+                    await send(.gitStatusUpdated(associationID: associationID, status: status))
+                    await send(.repoAssociationBranchResolved(
+                        workspaceID: workspaceID,
+                        associationID: associationID,
+                        branch: branch
+                    ))
+                }
+                .cancellable(
+                    id: HeadChangedDebounceID.association(associationID),
+                    cancelInFlight: true
+                )
 
             // MARK: - Search
 

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -1910,6 +1910,23 @@ struct AppReducer {
                     .run { _ in notifService.removeNotification(for: paneID) }
                 )
 
+            case .workspaces(.element(id: let wsID, action: .addRepoAssociation(let assoc))):
+                return .merge(
+                    .send(.persistState),
+                    .send(.startHeadWatcher(
+                        workspaceID: wsID,
+                        associationID: assoc.id,
+                        worktreePath: assoc.worktreePath
+                    ))
+                )
+
+            case .workspaces(.element(_, action: .removeRepoAssociation(let associationID))):
+                state.gitStatuses.removeValue(forKey: associationID)
+                return .merge(
+                    .send(.stopHeadWatcher(associationID: associationID)),
+                    .send(.persistState)
+                )
+
             case .workspaces(.element(id: let wsID, action: .paneDirectoryChanged(let paneID, let directory))):
                 return .merge(
                     .send(.persistState),
@@ -2753,10 +2770,20 @@ struct AppReducer {
             case .removeRepo(let id):
                 state.repoRegistry.remove(id: id)
                 // Cascade-remove associations from all workspaces
+                var removedAssociationIDs: [UUID] = []
                 for wsIndex in state.workspaces.indices {
+                    removedAssociationIDs.append(contentsOf: state.workspaces[wsIndex].repoAssociations
+                        .filter { $0.repoID == id }
+                        .map(\.id))
                     state.workspaces[wsIndex].repoAssociations.removeAll(where: { $0.repoID == id })
                 }
-                return .send(.persistState)
+                for associationID in removedAssociationIDs {
+                    state.gitStatuses.removeValue(forKey: associationID)
+                }
+                let stopEffects = removedAssociationIDs.map {
+                    Effect.send(Action.stopHeadWatcher(associationID: $0))
+                }
+                return .merge(stopEffects + [.send(.persistState)])
 
             case .renameRepo(let id, let name):
                 state.repoRegistry[id: id]?.name = name

--- a/Nex/Services/GitHeadWatcher.swift
+++ b/Nex/Services/GitHeadWatcher.swift
@@ -1,0 +1,174 @@
+import ComposableArchitecture
+import Foundation
+
+/// Watches the `HEAD` file for each registered `RepoAssociation` and emits
+/// a stream event whenever it changes. Used to drive sub-second sidebar
+/// updates after `git checkout`, `git switch`, `git reset`, etc.
+///
+/// At rest this costs zero CPU — `kqueue` only wakes the dispatch queue on
+/// actual filesystem events. Per watcher: one open file descriptor + a
+/// `DispatchSourceFileSystemObject`.
+final class GitHeadWatcher: Sendable {
+    private struct Entry {
+        let headPath: String
+        let fileDescriptor: Int32
+        let source: DispatchSourceFileSystemObject
+        let continuation: AsyncStream<Void>.Continuation
+    }
+
+    private let lock = NSLock()
+    /// nonisolated(unsafe) because all access is gated by `lock`.
+    private nonisolated(unsafe) var entries: [UUID: Entry] = [:]
+    /// Re-arm timers fired after a `.delete`/`.rename` event. Held so they
+    /// can be cancelled if the association is stopped during the 200ms gap.
+    private nonisolated(unsafe) var pendingReopens: [UUID: DispatchWorkItem] = [:]
+
+    private let queue = DispatchQueue(label: "nex.git-head-watcher", qos: .utility)
+
+    /// Begin watching `HEAD` for the given association. Calling `start`
+    /// twice with the same `associationID` cancels the prior watcher and
+    /// installs a new one — useful for `cancelInFlight` semantics in TCA.
+    ///
+    /// The returned stream emits `()` on each `HEAD` change (atomic-rename
+    /// re-opens are handled internally — the consumer only sees the logical
+    /// "HEAD changed" signal). Cancelling the consumer task stops the
+    /// underlying watcher via the stream's termination handler.
+    func start(associationID: UUID, headPath: String) -> AsyncStream<Void> {
+        // Tear down any prior entry for this ID so callers don't have to.
+        stop(associationID: associationID)
+
+        return AsyncStream { continuation in
+            guard let entry = makeEntry(
+                associationID: associationID,
+                headPath: headPath,
+                continuation: continuation
+            ) else {
+                continuation.finish()
+                return
+            }
+
+            lock.withLock { entries[associationID] = entry }
+
+            continuation.onTermination = { [weak self] _ in
+                self?.stop(associationID: associationID)
+            }
+        }
+    }
+
+    /// Stop watching for the given association. Idempotent.
+    func stop(associationID: UUID) {
+        let removedEntry: Entry? = lock.withLock {
+            entries.removeValue(forKey: associationID)
+        }
+        let removedReopen: DispatchWorkItem? = lock.withLock {
+            pendingReopens.removeValue(forKey: associationID)
+        }
+        // `cancel` triggers the source's cancel handler, which closes the fd.
+        removedEntry?.source.cancel()
+        removedEntry?.continuation.finish()
+        removedReopen?.cancel()
+    }
+
+    /// Stop all watchers. Used on app teardown.
+    func stopAll() {
+        let allIDs: [UUID] = lock.withLock { Array(entries.keys) }
+        for id in allIDs {
+            stop(associationID: id)
+        }
+    }
+
+    var watchedCount: Int {
+        lock.withLock { entries.count }
+    }
+
+    // MARK: - Internal
+
+    private func makeEntry(
+        associationID: UUID,
+        headPath: String,
+        continuation: AsyncStream<Void>.Continuation
+    ) -> Entry? {
+        let fd = open(headPath, O_EVTONLY)
+        guard fd >= 0 else { return nil }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .rename, .delete],
+            queue: queue
+        )
+
+        source.setEventHandler { [weak self] in
+            guard let self else { return }
+            let flags = source.data
+            // Always emit so the consumer knows HEAD changed. `git checkout`
+            // typically writes HEAD via a temp file + atomic rename, so we'll
+            // see one event with `.rename`/`.delete`. `git update-ref` and
+            // some other tools just write in place (`.write`).
+            continuation.yield()
+            if flags.contains(.delete) || flags.contains(.rename) {
+                scheduleReopen(associationID: associationID, headPath: headPath)
+            }
+        }
+
+        source.setCancelHandler { [fd] in
+            close(fd)
+        }
+
+        source.resume()
+        return Entry(
+            headPath: headPath,
+            fileDescriptor: fd,
+            source: source,
+            continuation: continuation
+        )
+    }
+
+    private func scheduleReopen(associationID: UUID, headPath: String) {
+        // Cancel the current source — the cancel handler will close the fd.
+        // We keep the continuation alive so the consumer sees the next event
+        // through the same stream.
+        let prior: Entry? = lock.withLock {
+            entries.removeValue(forKey: associationID)
+        }
+        prior?.source.cancel()
+
+        guard let continuation = prior?.continuation else { return }
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            // Remove ourselves from the pending map before re-arming so a
+            // racing `stop` after this point can still cancel cleanly.
+            lock.withLock { _ = pendingReopens.removeValue(forKey: associationID) }
+
+            guard let next = makeEntry(
+                associationID: associationID,
+                headPath: headPath,
+                continuation: continuation
+            ) else {
+                // The HEAD file disappeared and didn't reappear. End the
+                // stream so the consuming TCA effect exits its for-await
+                // loop instead of hanging forever.
+                continuation.finish()
+                return
+            }
+            lock.withLock { entries[associationID] = next }
+        }
+
+        lock.withLock { pendingReopens[associationID] = work }
+        queue.asyncAfter(deadline: .now() + 0.2, execute: work)
+    }
+}
+
+// MARK: - TCA Dependency
+
+extension GitHeadWatcher: DependencyKey {
+    static let liveValue = GitHeadWatcher()
+    static let testValue = GitHeadWatcher()
+}
+
+extension DependencyValues {
+    var gitHeadWatcher: GitHeadWatcher {
+        get { self[GitHeadWatcher.self] }
+        set { self[GitHeadWatcher.self] = newValue }
+    }
+}

--- a/Nex/Services/GitHeadWatcher.swift
+++ b/Nex/Services/GitHeadWatcher.swift
@@ -10,10 +10,22 @@ import Foundation
 /// `DispatchSourceFileSystemObject`.
 final class GitHeadWatcher: Sendable {
     private struct Entry {
+        let token: UUID
         let headPath: String
         let fileDescriptor: Int32
         let source: DispatchSourceFileSystemObject
         let continuation: AsyncStream<Void>.Continuation
+    }
+
+    private struct PendingReopen {
+        let token: UUID
+        let workItem: DispatchWorkItem
+        let continuation: AsyncStream<Void>.Continuation
+    }
+
+    private struct RemovedWatch {
+        let entry: Entry?
+        let pendingReopen: PendingReopen?
     }
 
     private let lock = NSLock()
@@ -21,9 +33,17 @@ final class GitHeadWatcher: Sendable {
     private nonisolated(unsafe) var entries: [UUID: Entry] = [:]
     /// Re-arm timers fired after a `.delete`/`.rename` event. Held so they
     /// can be cancelled if the association is stopped during the 200ms gap.
-    private nonisolated(unsafe) var pendingReopens: [UUID: DispatchWorkItem] = [:]
+    private nonisolated(unsafe) var pendingReopens: [UUID: PendingReopen] = [:]
+    /// Per-start generation tokens. AsyncStream termination and delayed
+    /// reopens only tear down the watcher that created them.
+    private nonisolated(unsafe) var tokens: [UUID: UUID] = [:]
 
     private let queue = DispatchQueue(label: "nex.git-head-watcher", qos: .utility)
+    private let reopenDelay: DispatchTimeInterval
+
+    init(reopenDelay: DispatchTimeInterval = .milliseconds(200)) {
+        self.reopenDelay = reopenDelay
+    }
 
     /// Begin watching `HEAD` for the given association. Calling `start`
     /// twice with the same `associationID` cancels the prior watcher and
@@ -34,46 +54,67 @@ final class GitHeadWatcher: Sendable {
     /// "HEAD changed" signal). Cancelling the consumer task stops the
     /// underlying watcher via the stream's termination handler.
     func start(associationID: UUID, headPath: String) -> AsyncStream<Void> {
-        // Tear down any prior entry for this ID so callers don't have to.
-        stop(associationID: associationID)
+        let token = UUID()
+        let removed = lock.withLock {
+            tokens[associationID] = token
+            return removeLocked(associationID: associationID)
+        }
+        tearDown(removed, finishContinuation: true)
 
         return AsyncStream { continuation in
+            continuation.onTermination = { [weak self] _ in
+                self?.stop(associationID: associationID, token: token)
+            }
+
             guard let entry = makeEntry(
                 associationID: associationID,
                 headPath: headPath,
+                token: token,
                 continuation: continuation
             ) else {
+                lock.withLock {
+                    if tokens[associationID] == token {
+                        tokens.removeValue(forKey: associationID)
+                    }
+                }
                 continuation.finish()
                 return
             }
 
-            lock.withLock { entries[associationID] = entry }
-
-            continuation.onTermination = { [weak self] _ in
-                self?.stop(associationID: associationID)
+            let installed = lock.withLock {
+                guard tokens[associationID] == token else { return false }
+                entries[associationID] = entry
+                return true
+            }
+            if !installed {
+                entry.source.cancel()
+                continuation.finish()
             }
         }
     }
 
     /// Stop watching for the given association. Idempotent.
     func stop(associationID: UUID) {
-        let removedEntry: Entry? = lock.withLock {
-            entries.removeValue(forKey: associationID)
-        }
-        let removedReopen: DispatchWorkItem? = lock.withLock {
-            pendingReopens.removeValue(forKey: associationID)
+        let removed = lock.withLock {
+            tokens.removeValue(forKey: associationID)
+            return removeLocked(associationID: associationID)
         }
         // `cancel` triggers the source's cancel handler, which closes the fd.
-        removedEntry?.source.cancel()
-        removedEntry?.continuation.finish()
-        removedReopen?.cancel()
+        tearDown(removed, finishContinuation: true)
     }
 
     /// Stop all watchers. Used on app teardown.
     func stopAll() {
-        let allIDs: [UUID] = lock.withLock { Array(entries.keys) }
-        for id in allIDs {
-            stop(associationID: id)
+        let removed: [RemovedWatch] = lock.withLock {
+            tokens.removeAll()
+            let active = entries.values.map { RemovedWatch(entry: $0, pendingReopen: nil) }
+            let pending = pendingReopens.values.map { RemovedWatch(entry: nil, pendingReopen: $0) }
+            entries.removeAll()
+            pendingReopens.removeAll()
+            return active + pending
+        }
+        for watch in removed {
+            tearDown(watch, finishContinuation: true)
         }
     }
 
@@ -81,11 +122,16 @@ final class GitHeadWatcher: Sendable {
         lock.withLock { entries.count }
     }
 
+    var pendingReopenCount: Int {
+        lock.withLock { pendingReopens.count }
+    }
+
     // MARK: - Internal
 
     private func makeEntry(
         associationID: UUID,
         headPath: String,
+        token: UUID,
         continuation: AsyncStream<Void>.Continuation
     ) -> Entry? {
         let fd = open(headPath, O_EVTONLY)
@@ -106,7 +152,12 @@ final class GitHeadWatcher: Sendable {
             // some other tools just write in place (`.write`).
             continuation.yield()
             if flags.contains(.delete) || flags.contains(.rename) {
-                scheduleReopen(associationID: associationID, headPath: headPath)
+                scheduleReopen(
+                    associationID: associationID,
+                    headPath: headPath,
+                    token: token,
+                    continuation: continuation
+                )
             }
         }
 
@@ -116,6 +167,7 @@ final class GitHeadWatcher: Sendable {
 
         source.resume()
         return Entry(
+            token: token,
             headPath: headPath,
             fileDescriptor: fd,
             source: source,
@@ -123,39 +175,121 @@ final class GitHeadWatcher: Sendable {
         )
     }
 
-    private func scheduleReopen(associationID: UUID, headPath: String) {
-        // Cancel the current source — the cancel handler will close the fd.
-        // We keep the continuation alive so the consumer sees the next event
-        // through the same stream.
-        let prior: Entry? = lock.withLock {
-            entries.removeValue(forKey: associationID)
-        }
-        prior?.source.cancel()
-
-        guard let continuation = prior?.continuation else { return }
-
+    private func scheduleReopen(
+        associationID: UUID,
+        headPath: String,
+        token: UUID,
+        continuation: AsyncStream<Void>.Continuation
+    ) {
         let work = DispatchWorkItem { [weak self] in
-            guard let self else { return }
-            // Remove ourselves from the pending map before re-arming so a
-            // racing `stop` after this point can still cancel cleanly.
-            lock.withLock { _ = pendingReopens.removeValue(forKey: associationID) }
-
-            guard let next = makeEntry(
+            self?.performReopen(
                 associationID: associationID,
                 headPath: headPath,
+                token: token,
                 continuation: continuation
-            ) else {
-                // The HEAD file disappeared and didn't reappear. End the
-                // stream so the consuming TCA effect exits its for-await
-                // loop instead of hanging forever.
-                continuation.finish()
-                return
-            }
-            lock.withLock { entries[associationID] = next }
+            )
         }
 
-        lock.withLock { pendingReopens[associationID] = work }
-        queue.asyncAfter(deadline: .now() + 0.2, execute: work)
+        // Cancel the current source — the cancel handler will close the fd.
+        // We keep the continuation alive so the consumer sees the next event
+        // through the same stream. The pending work item is installed under
+        // the same lock as removing the active entry, so `stop` cannot miss
+        // the watcher during the 200ms re-open gap.
+        let prior: Entry? = lock.withLock {
+            guard tokens[associationID] == token,
+                  let current = entries[associationID],
+                  current.token == token else { return nil }
+            entries.removeValue(forKey: associationID)
+            pendingReopens[associationID] = PendingReopen(
+                token: token,
+                workItem: work,
+                continuation: continuation
+            )
+            return current
+        }
+
+        guard let prior else {
+            work.cancel()
+            return
+        }
+
+        prior.source.cancel()
+        queue.asyncAfter(deadline: .now() + reopenDelay, execute: work)
+    }
+
+    private func performReopen(
+        associationID: UUID,
+        headPath: String,
+        token: UUID,
+        continuation: AsyncStream<Void>.Continuation
+    ) {
+        let shouldAttempt = lock.withLock {
+            tokens[associationID] == token
+                && pendingReopens[associationID]?.token == token
+        }
+        guard shouldAttempt else { return }
+
+        guard let next = makeEntry(
+            associationID: associationID,
+            headPath: headPath,
+            token: token,
+            continuation: continuation
+        ) else {
+            let shouldFinish = lock.withLock {
+                guard tokens[associationID] == token,
+                      pendingReopens[associationID]?.token == token else {
+                    return false
+                }
+                tokens.removeValue(forKey: associationID)
+                pendingReopens.removeValue(forKey: associationID)
+                return true
+            }
+            if shouldFinish {
+                continuation.finish()
+            }
+            return
+        }
+
+        let installed = lock.withLock {
+            guard tokens[associationID] == token,
+                  pendingReopens[associationID]?.token == token else {
+                return false
+            }
+            pendingReopens.removeValue(forKey: associationID)
+            entries[associationID] = next
+            return true
+        }
+
+        if !installed {
+            next.source.cancel()
+            continuation.finish()
+        }
+    }
+
+    private func stop(associationID: UUID, token: UUID) {
+        let removed = lock.withLock {
+            guard tokens[associationID] == token else {
+                return RemovedWatch(entry: nil, pendingReopen: nil)
+            }
+            tokens.removeValue(forKey: associationID)
+            return removeLocked(associationID: associationID)
+        }
+        tearDown(removed, finishContinuation: true)
+    }
+
+    private func removeLocked(associationID: UUID) -> RemovedWatch {
+        let entry = entries.removeValue(forKey: associationID)
+        let pendingReopen = pendingReopens.removeValue(forKey: associationID)
+        return RemovedWatch(entry: entry, pendingReopen: pendingReopen)
+    }
+
+    private func tearDown(_ removed: RemovedWatch, finishContinuation: Bool) {
+        removed.entry?.source.cancel()
+        removed.pendingReopen?.workItem.cancel()
+        if finishContinuation {
+            removed.entry?.continuation.finish()
+            removed.pendingReopen?.continuation.finish()
+        }
     }
 }
 

--- a/Nex/Services/GitService.swift
+++ b/Nex/Services/GitService.swift
@@ -28,6 +28,7 @@ struct GitService {
     var pruneWorktrees: @Sendable (_ repoPath: String) async throws -> Void
     var resolveRepoRoot: @Sendable (_ path: String) async -> RepoRootInfo?
     var getDiff: @Sendable (_ repoPath: String, _ targetPath: String?) async throws -> String
+    var resolveHeadPath: @Sendable (_ worktreePath: String) async throws -> String
 }
 
 // MARK: - Live Implementation
@@ -220,6 +221,22 @@ extension GitService {
                 args += ["--", targetPath]
             }
             return try runGit(args: args, at: repoPath)
+        },
+
+        resolveHeadPath: { worktreePath in
+            // `--git-path HEAD` returns the absolute path to the worktree's
+            // HEAD file. For the main worktree this is `<repo>/.git/HEAD`;
+            // for a linked worktree it's `<repo>/.git/worktrees/<name>/HEAD`.
+            let raw = try runGit(args: ["rev-parse", "--git-path", "HEAD"], at: worktreePath)
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            // `--git-path` returns relative paths for the main worktree
+            // (e.g. ".git/HEAD"). Resolve against the worktree root.
+            let absolute: String = if trimmed.hasPrefix("/") {
+                trimmed
+            } else {
+                (worktreePath as NSString).appendingPathComponent(trimmed)
+            }
+            return (absolute as NSString).standardizingPath
         }
     )
 }
@@ -288,7 +305,12 @@ extension GitService: DependencyKey {
             listWorktrees: unimplemented("GitService.listWorktrees"),
             pruneWorktrees: unimplemented("GitService.pruneWorktrees"),
             resolveRepoRoot: { _ in nil },
-            getDiff: { _, _ in "" }
+            getDiff: { _, _ in "" },
+            // Non-failing stub: an empty path causes `open()` to return -1
+            // in `GitHeadWatcher`, so the watcher silently no-ops in tests
+            // that don't care about HEAD watching. Tests that do care should
+            // override this to return a real HEAD path.
+            resolveHeadPath: { _ in "" }
         )
     }
 }

--- a/NexTests/GitHeadWatcherTests.swift
+++ b/NexTests/GitHeadWatcherTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+@testable import Nex
+import Testing
+
+struct GitHeadWatcherTests {
+    // MARK: - Helpers
+
+    /// Spin up a fresh git repo in a temp dir and return its path. The repo
+    /// is initialised on `main`, with one commit so HEAD is a valid ref
+    /// (some git versions misbehave on a HEAD that's never been written).
+    private static func makeRepo() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nex-head-watcher-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try runGit(["init", "-b", "main"], at: dir)
+        try runGit(["config", "user.email", "test@example.com"], at: dir)
+        try runGit(["config", "user.name", "Test"], at: dir)
+        try runGit(["commit", "--allow-empty", "-m", "initial"], at: dir)
+        return dir
+    }
+
+    @discardableResult
+    private static func runGit(_ args: [String], at dir: URL) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = dir
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private static func headPath(for worktree: URL) throws -> String {
+        let raw = try runGit(["rev-parse", "--git-path", "HEAD"], at: worktree)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return raw.hasPrefix("/")
+            ? raw
+            : (worktree.path as NSString).appendingPathComponent(raw)
+    }
+
+    /// Wait for the next event on the stream with a timeout. Returns true
+    /// if an event arrived, false if the timeout elapsed first.
+    private static func awaitEvent(
+        _ stream: AsyncStream<Void>,
+        timeout: Duration = .seconds(2)
+    ) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                var iterator = stream.makeAsyncIterator()
+                _ = await iterator.next()
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+
+    // MARK: - Tests
+
+    @Test func emitsOnDirectHeadWrite() async throws {
+        let repo = try Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try Self.headPath(for: repo)
+        let watcher = GitHeadWatcher()
+        let id = UUID()
+        let stream = watcher.start(associationID: id, headPath: head)
+        defer { watcher.stop(associationID: id) }
+
+        // Give the dispatch source a beat to register before we mutate.
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Directly overwrite HEAD (simulates `git update-ref` style writes).
+        try "ref: refs/heads/other\n".write(
+            toFile: head,
+            atomically: false,
+            encoding: .utf8
+        )
+
+        let received = await Self.awaitEvent(stream)
+        #expect(received, "watcher should emit on a direct HEAD write")
+    }
+
+    @Test func emitsOnGitCheckout() async throws {
+        let repo = try Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try Self.headPath(for: repo)
+        let watcher = GitHeadWatcher()
+        let id = UUID()
+        let stream = watcher.start(associationID: id, headPath: head)
+        defer { watcher.stop(associationID: id) }
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        // `git checkout -b` rewrites HEAD via temp-file + atomic rename.
+        // The watcher needs to see this through its `.rename`/`.delete`
+        // re-open dance.
+        try Self.runGit(["checkout", "-b", "feature"], at: repo)
+
+        let received = await Self.awaitEvent(stream)
+        #expect(received, "watcher should emit on `git checkout -b`")
+    }
+
+    @Test func reopensAfterAtomicRenameForSubsequentWrites() async throws {
+        let repo = try Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try Self.headPath(for: repo)
+        let watcher = GitHeadWatcher()
+        let id = UUID()
+        let stream = watcher.start(associationID: id, headPath: head)
+        defer { watcher.stop(associationID: id) }
+
+        var iterator = stream.makeAsyncIterator()
+
+        try await Task.sleep(for: .milliseconds(50))
+        try Self.runGit(["checkout", "-b", "branch-a"], at: repo)
+        _ = await iterator.next() // first checkout
+
+        // After the rename re-arms (200ms), a second checkout should still
+        // emit. This is the regression guard for the cancel-then-reopen
+        // dance — without re-opening the fd, this second event would be
+        // silently dropped.
+        try await Task.sleep(for: .milliseconds(300))
+        try Self.runGit(["checkout", "-b", "branch-b"], at: repo)
+
+        let received = await Self.awaitEvent(stream)
+        #expect(received, "watcher should still fire after re-arm")
+    }
+
+    @Test func stopHaltsFurtherEvents() async throws {
+        let repo = try Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try Self.headPath(for: repo)
+        let watcher = GitHeadWatcher()
+        let id = UUID()
+        let stream = watcher.start(associationID: id, headPath: head)
+
+        watcher.stop(associationID: id)
+        #expect(watcher.watchedCount == 0, "stop should evict the entry")
+
+        // Mutate HEAD after stop. The stream should be finished, so
+        // awaiting the next event yields nil immediately.
+        try "ref: refs/heads/postcancel\n".write(
+            toFile: head,
+            atomically: false,
+            encoding: .utf8
+        )
+
+        var iterator = stream.makeAsyncIterator()
+        let next = await iterator.next()
+        #expect(next == nil, "stream should be finished after stop")
+    }
+
+    @Test func startReplacesExistingEntryForSameID() async throws {
+        let repo = try Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try Self.headPath(for: repo)
+        let watcher = GitHeadWatcher()
+        let id = UUID()
+
+        let firstStream = watcher.start(associationID: id, headPath: head)
+        let secondStream = watcher.start(associationID: id, headPath: head)
+        defer { watcher.stop(associationID: id) }
+
+        // The first stream should be terminated by the replacement.
+        var firstIterator = firstStream.makeAsyncIterator()
+        let firstNext = await firstIterator.next()
+        #expect(firstNext == nil, "first stream should finish when replaced")
+
+        try await Task.sleep(for: .milliseconds(50))
+        try "ref: refs/heads/replaced\n".write(
+            toFile: head,
+            atomically: false,
+            encoding: .utf8
+        )
+
+        let received = await Self.awaitEvent(secondStream)
+        #expect(received, "second stream should receive the event")
+        #expect(watcher.watchedCount == 1, "only one entry should remain")
+    }
+
+    @Test func stopAllEvictsEverything() throws {
+        let repoA = try Self.makeRepo()
+        let repoB = try Self.makeRepo()
+        defer {
+            try? FileManager.default.removeItem(at: repoA)
+            try? FileManager.default.removeItem(at: repoB)
+        }
+
+        let watcher = GitHeadWatcher()
+        // Hold the streams — dropping the AsyncStream finishes the
+        // continuation, which fires our onTermination handler and would
+        // drop the entries before we get a chance to call stopAll.
+        let streamA = try watcher.start(associationID: UUID(), headPath: Self.headPath(for: repoA))
+        let streamB = try watcher.start(associationID: UUID(), headPath: Self.headPath(for: repoB))
+        #expect(watcher.watchedCount == 2)
+
+        watcher.stopAll()
+        #expect(watcher.watchedCount == 0)
+
+        // Silence "unused" warnings — keeps the streams alive until here.
+        _ = streamA
+        _ = streamB
+    }
+}

--- a/NexTests/GitHeadWatcherTests.swift
+++ b/NexTests/GitHeadWatcherTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 @testable import Nex
 import Testing
@@ -25,13 +26,27 @@ struct GitHeadWatcherTests {
         process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
         process.arguments = args
         process.currentDirectoryURL = dir
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
         try process.run()
         process.waitUntilExit()
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            let message = String(data: errorData, encoding: .utf8) ?? ""
+            throw GitTestError.commandFailed(
+                command: "git \(args.joined(separator: " "))",
+                exitCode: Int(process.terminationStatus),
+                stderr: message
+            )
+        }
         return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private enum GitTestError: Error {
+        case commandFailed(command: String, exitCode: Int, stderr: String)
     }
 
     private static func headPath(for worktree: URL) throws -> String {
@@ -40,6 +55,18 @@ struct GitHeadWatcherTests {
         return raw.hasPrefix("/")
             ? raw
             : (worktree.path as NSString).appendingPathComponent(raw)
+    }
+
+    private static func atomicallyReplaceHead(_ head: String, contents: String) throws {
+        let tmp = "\(head).tmp-\(UUID().uuidString)"
+        try contents.write(toFile: tmp, atomically: false, encoding: .utf8)
+        guard rename(tmp, head) == 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [NSLocalizedDescriptionKey: String(cString: strerror(errno))]
+            )
+        }
     }
 
     /// Wait for the next event on the stream with a timeout. Returns true
@@ -62,6 +89,18 @@ struct GitHeadWatcherTests {
             group.cancelAll()
             return result
         }
+    }
+
+    private static func waitUntil(
+        timeoutAttempts: Int = 200,
+        sleep: Duration = .milliseconds(5),
+        _ condition: () -> Bool
+    ) async -> Bool {
+        for _ in 0 ..< timeoutAttempts {
+            if condition() { return true }
+            try? await Task.sleep(for: sleep)
+        }
+        return condition()
     }
 
     // MARK: - Tests
@@ -163,6 +202,39 @@ struct GitHeadWatcherTests {
         #expect(next == nil, "stream should be finished after stop")
     }
 
+    @Test func stopDuringPendingReopenDoesNotRestartWatcher() async throws {
+        let repo = try Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try Self.headPath(for: repo)
+        let watcher = GitHeadWatcher(reopenDelay: .seconds(1))
+        let id = UUID()
+        let stream = watcher.start(associationID: id, headPath: head)
+        defer { watcher.stop(associationID: id) }
+        var iterator = stream.makeAsyncIterator()
+
+        try await Task.sleep(for: .milliseconds(50))
+        try Self.atomicallyReplaceHead(head, contents: "ref: refs/heads/pending-stop\n")
+        let event = await iterator.next()
+        #expect(event != nil, "watcher should emit for the atomic HEAD replace")
+
+        let pending = await Self.waitUntil {
+            watcher.pendingReopenCount == 1
+        }
+        #expect(pending, "watcher should enter the pending reopen window")
+
+        watcher.stop(associationID: id)
+        #expect(watcher.watchedCount == 0)
+        #expect(watcher.pendingReopenCount == 0)
+
+        try await Task.sleep(for: .milliseconds(1200))
+        #expect(watcher.watchedCount == 0, "stop should cancel the delayed reopen")
+        #expect(watcher.pendingReopenCount == 0)
+
+        let next = await iterator.next()
+        #expect(next == nil, "stream should be finished after stop")
+    }
+
     @Test func startReplacesExistingEntryForSameID() async throws {
         let repo = try Self.makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -214,5 +286,37 @@ struct GitHeadWatcherTests {
         // Silence "unused" warnings — keeps the streams alive until here.
         _ = streamA
         _ = streamB
+    }
+
+    @Test func stopAllCancelsPendingReopens() async throws {
+        let repo = try Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let head = try Self.headPath(for: repo)
+        let watcher = GitHeadWatcher(reopenDelay: .seconds(1))
+        let id = UUID()
+        let stream = watcher.start(associationID: id, headPath: head)
+        var iterator = stream.makeAsyncIterator()
+
+        try await Task.sleep(for: .milliseconds(50))
+        try Self.atomicallyReplaceHead(head, contents: "ref: refs/heads/pending-stop-all\n")
+        let event = await iterator.next()
+        #expect(event != nil, "watcher should emit for the atomic HEAD replace")
+
+        let pending = await Self.waitUntil {
+            watcher.pendingReopenCount == 1
+        }
+        #expect(pending, "watcher should enter the pending reopen window")
+
+        watcher.stopAll()
+        #expect(watcher.watchedCount == 0)
+        #expect(watcher.pendingReopenCount == 0)
+
+        try await Task.sleep(for: .milliseconds(1200))
+        #expect(watcher.watchedCount == 0, "stopAll should cancel delayed reopens")
+        #expect(watcher.pendingReopenCount == 0)
+
+        let next = await iterator.next()
+        #expect(next == nil, "stream should be finished after stopAll")
     }
 }


### PR DESCRIPTION
## Summary

- Adds a per-`RepoAssociation` `kqueue` file watcher (`GitHeadWatcher`) on each worktree's `HEAD` file. Sidebar branch label and dirty/clean indicator now refresh within ~200ms of any HEAD-changing git operation (`checkout`, `switch`, `reset`, fast-forward `pull`) instead of waiting up to 30s for the polling timer.
- At rest the watcher costs zero CPU — `kqueue` only wakes the dispatch queue on actual filesystem events. The 30s timer stays as a backstop for index-only changes (working-tree edits don't touch HEAD) and for any missed kqueue events.
- Also fires a scoped refresh on `paneDirectoryChanged` so `cd ../other-worktree` updates instantly.

## Lifecycle wiring

Watchers are started/stopped at every `RepoAssociation` add/remove site:

- **Start:** `stateLoaded` (rehydrate), `createWorkspace` (seeded repos), `worktreeCreated`, `autoLinkResolved`, and the nested `WorkspaceFeature.addRepoAssociation` action (inspector "+ Repo" button).
- **Stop:** `removeWorktreeAssociation`, `deleteWorkspace`, `autoUnlinkUnusedRepos`, `removeRepo` (cascade), and the nested `WorkspaceFeature.removeRepoAssociation` action.

## Codex review

A `codex` agent ran an independent review of the diff (see `9ca889f` and `b1dd29f`) and surfaced four real issues — three of which were fixed before this PR opened:

- **Reopen race**: `scheduleReopen` removed the active entry before installing the pending state, so a racing `stop` could miss the watcher and the delayed work item could resurrect a stopped one. Fixed by holding pending state under the same lock and adding per-start generation tokens so termination/reopen/install paths only mutate when the token is current.
- **`stopAll` gap**: `stopAll` didn't cancel watchers sitting in the reopen window. Fixed.
- **`removeRepo` cascade**: didn't stop watchers or clear `gitStatuses` for cascade-removed associations. Fixed.
- **Inspector add/remove**: nested `WorkspaceFeature.addRepoAssociation`/`removeRepoAssociation` actions bypassed the parent lifecycle hooks. Fixed by intercepting them in `AppReducer`.

## Test plan

- [ ] `xcodebuild test` — 651 tests pass (35 suites). Includes 8 new `GitHeadWatcherTests` covering direct HEAD writes, `git checkout` (atomic-rename re-open dance), `stop` during reopen window, `stopAll` during reopen window, `start` replacing an existing entry for the same ID.
- [ ] `swiftformat --lint .` clean.
- [ ] `swiftlint lint` clean (one pre-existing `function_parameter_count` warning at `AppReducer.swift:917`, unrelated).
- [ ] Smoke: open inspector on a repo workspace, run `git checkout -b foo` in a Nex pane → branch label flips within ~200ms.
- [ ] Smoke: same flow inside a linked worktree (`git worktree add ../wt-foo`) → only that row updates.
- [ ] Smoke: `lsof -p <Nex pid> | grep -c HEAD` drops by 1 after removing a worktree association via the inspector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)