### PR TITLE
feat: clickable URLs in markdown panes

### DIFF
--- a/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
+++ b/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
@@ -6,7 +6,20 @@ import Markdown
 struct MarkdownHTMLRenderer: MarkupVisitor {
     typealias Result = String
 
+    private static let urlDetector: NSDataDetector? =
+        try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+
+    /// Only auto-link matches whose source text starts with one of these
+    /// schemes. NSDataDetector also matches schemeless domains like
+    /// `example.com` and bare emails like `foo@example.com`, which we
+    /// deliberately leave as plain text — terminal-style "make pasted
+    /// URLs clickable" behaviour, not GitHub-style fuzzy linkification.
+    private static let allowedSchemePrefixes: [String] = [
+        "http://", "https://", "ftp://", "file://", "mailto:"
+    ]
+
     private var isInTableHead = false
+    private var skipAutolinkDepth = 0
 
     mutating func defaultVisit(_ markup: any Markup) -> String {
         markup.children.map { visit($0) }.joined()
@@ -27,7 +40,10 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
     }
 
     mutating func visitText(_ text: Text) -> String {
-        escapeHTML(text.string)
+        if skipAutolinkDepth > 0 {
+            return escapeHTML(text.string)
+        }
+        return autolinkText(text.string)
     }
 
     mutating func visitEmphasis(_ emphasis: Emphasis) -> String {
@@ -78,13 +94,17 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
     }
 
     mutating func visitLink(_ link: Link) -> String {
+        skipAutolinkDepth += 1
         let content = link.children.map { visit($0) }.joined()
+        skipAutolinkDepth -= 1
         let dest = escapeHTML(link.destination ?? "")
         return "<a href=\"\(dest)\">\(content)</a>"
     }
 
     mutating func visitImage(_ image: Image) -> String {
+        skipAutolinkDepth += 1
         let alt = image.children.map { visit($0) }.joined()
+        skipAutolinkDepth -= 1
         let src = escapeHTML(image.source ?? "")
         let titleAttr = image.title.map { " title=\"\(escapeHTML($0))\"" } ?? ""
         return "<img src=\"\(src)\" alt=\"\(alt)\"\(titleAttr)>"
@@ -152,6 +172,44 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
             .replacingOccurrences(of: "<", with: "&lt;")
             .replacingOccurrences(of: ">", with: "&gt;")
             .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    /// Wrap any URLs detected in plain text with `<a>` tags so bare links
+    /// (e.g. `https://example.com`) are clickable, matching terminal behaviour.
+    /// swift-markdown only auto-detects `<>`-wrapped URLs and `[text](url)`
+    /// syntax — bare URLs in text reach us as plain `Text` nodes.
+    private func autolinkText(_ text: String) -> String {
+        guard let detector = Self.urlDetector else {
+            return escapeHTML(text)
+        }
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let matches = detector.matches(in: text, options: [], range: fullRange)
+        guard !matches.isEmpty else {
+            return escapeHTML(text)
+        }
+        var result = ""
+        var cursor = 0
+        for match in matches {
+            let urlText = nsText.substring(with: match.range)
+            let lower = urlText.lowercased()
+            let hasAllowedScheme = Self.allowedSchemePrefixes.contains(where: lower.hasPrefix)
+            // Skip schemeless domains and bare emails — let them render as
+            // plain text so they fall through into the surrounding escape.
+            guard hasAllowedScheme else { continue }
+            if match.range.location > cursor {
+                let preLen = match.range.location - cursor
+                result += escapeHTML(nsText.substring(with: NSRange(location: cursor, length: preLen)))
+            }
+            let href = match.url?.absoluteString ?? urlText
+            result += "<a href=\"\(escapeHTML(href))\">\(escapeHTML(urlText))</a>"
+            cursor = match.range.location + match.range.length
+        }
+        if cursor < nsText.length {
+            let tailLen = nsText.length - cursor
+            result += escapeHTML(nsText.substring(with: NSRange(location: cursor, length: tailLen)))
+        }
+        return result
     }
 }
 

--- a/NexTests/MarkdownHTMLRendererTests.swift
+++ b/NexTests/MarkdownHTMLRendererTests.swift
@@ -26,6 +26,110 @@ struct MarkdownHTMLRendererTests {
         #expect(html.contains("@claude"))
     }
 
+    // MARK: - Bare URL autolinking
+
+    @Test func bareHTTPSURLAutolinked() {
+        let html = MarkdownRenderer.renderToHTML("See https://example.com for details.")
+        #expect(html.contains("<a href=\"https://example.com\">https://example.com</a>"))
+    }
+
+    @Test func bareURLAtStartOfLineAutolinked() {
+        let html = MarkdownRenderer.renderToHTML("https://example.com is the home page")
+        #expect(html.contains("<a href=\"https://example.com\">https://example.com</a>"))
+    }
+
+    @Test func bareURLAtEndOfLineAutolinked() {
+        let html = MarkdownRenderer.renderToHTML("Visit us at https://example.com")
+        #expect(html.contains("<a href=\"https://example.com\">https://example.com</a>"))
+    }
+
+    @Test func multipleBareURLsAllAutolinked() {
+        let html = MarkdownRenderer.renderToHTML("See https://a.com and https://b.com today.")
+        #expect(html.contains("<a href=\"https://a.com\">https://a.com</a>"))
+        #expect(html.contains("<a href=\"https://b.com\">https://b.com</a>"))
+    }
+
+    @Test func bareURLInListItemAutolinked() {
+        let html = MarkdownRenderer.renderToHTML("- See https://example.com for details")
+        #expect(html.contains("<a href=\"https://example.com\">https://example.com</a>"))
+    }
+
+    @Test func explicitMarkdownLinkNotDoubleWrapped() {
+        // [text](url) must produce exactly one <a> tag — no nested anchor from autolinking the visible text.
+        let html = MarkdownRenderer.renderToHTML("[https://example.com](https://example.com)")
+        let anchorCount = html.components(separatedBy: "<a ").count - 1
+        #expect(anchorCount == 1)
+        #expect(html.contains("<a href=\"https://example.com\">https://example.com</a>"))
+    }
+
+    @Test func bareURLInImageAltNotAutolinked() {
+        // The alt text becomes an HTML attribute; injecting <a> there would break the tag.
+        let html = MarkdownRenderer.renderToHTML("![see https://example.com](pic.png)")
+        #expect(!html.contains("alt=\"see <a"))
+    }
+
+    @Test func plainTextWithoutURLUnchanged() {
+        let html = MarkdownRenderer.renderToHTML("Just some plain text with no links.")
+        #expect(!html.contains("<a "))
+        #expect(html.contains("<p>Just some plain text with no links.</p>"))
+    }
+
+    @Test func trailingPunctuationNotPartOfURL() {
+        // NSDataDetector strips trailing sentence punctuation so the period stays as text.
+        let html = MarkdownRenderer.renderToHTML("Visit https://example.com.")
+        #expect(html.contains("<a href=\"https://example.com\">https://example.com</a>."))
+    }
+
+    @Test func bareURLInsideInlineCodeNotAutolinked() {
+        // Inline code goes through a different path and must remain literal.
+        let html = MarkdownRenderer.renderToHTML("Use `https://example.com` literally.")
+        #expect(html.contains("<code>https://example.com</code>"))
+    }
+
+    @Test func schemelessDomainNotAutolinked() {
+        // NSDataDetector matches `example.com` as a link, but we deliberately
+        // require an explicit scheme so prose mentions of a domain stay text.
+        let html = MarkdownRenderer.renderToHTML("Visit example.com today.")
+        #expect(!html.contains("<a "))
+        #expect(html.contains("Visit example.com today."))
+    }
+
+    @Test func schemelessWWWDomainNotAutolinked() {
+        let html = MarkdownRenderer.renderToHTML("Try www.example.com.")
+        #expect(!html.contains("<a "))
+        #expect(html.contains("Try www.example.com."))
+    }
+
+    @Test func bareEmailNotAutolinked() {
+        // NSDataDetector turns `foo@example.com` into a `mailto:` URL, but
+        // the source text has no scheme so it should render as plain text.
+        let html = MarkdownRenderer.renderToHTML("Email foo@example.com please.")
+        #expect(!html.contains("<a "))
+        #expect(html.contains("Email foo@example.com please."))
+    }
+
+    @Test func explicitMailtoSchemeAutolinked() {
+        // `mailto:` prefix is in the allowed list, so it links.
+        let html = MarkdownRenderer.renderToHTML("Reach mailto:foo@example.com.")
+        #expect(html.contains("<a href=\"mailto:foo@example.com\">mailto:foo@example.com</a>"))
+    }
+
+    @Test func ftpAndFileSchemesAutolinked() {
+        let html = MarkdownRenderer.renderToHTML("ftp://x.example/y and file:///etc/hosts")
+        #expect(html.contains("<a href=\"ftp://x.example/y\">ftp://x.example/y</a>"))
+        #expect(html.contains("<a href=\"file:///etc/hosts\">file:///etc/hosts</a>"))
+    }
+
+    @Test func mixedSchemedAndBareURLsAutolinkOnlyTheSchemed() {
+        let html = MarkdownRenderer.renderToHTML("See example.com and https://anthropic.com.")
+        // Schemed URL becomes a link; schemeless one stays text.
+        #expect(html.contains("<a href=\"https://anthropic.com\">https://anthropic.com</a>"))
+        #expect(html.contains("example.com and "))
+        // Exactly one anchor.
+        let anchorCount = html.components(separatedBy: "<a ").count - 1
+        #expect(anchorCount == 1)
+    }
+
     // MARK: - Basic rendering sanity
 
     @Test func headingRendered() {


### PR DESCRIPTION
## Summary

- Auto-links bare URLs like `https://example.com` in markdown pane previews so they're clickable, matching terminal behaviour for pasted URLs (#91). Schemed autolinks (`<https://...>`) and explicit `[text](url)` syntax already worked via swift-markdown — this covers the gap where bare URLs were reaching the renderer as plain `Text` nodes.
- Only links whose source text starts with an allowed scheme (`http://`, `https://`, `ftp://`, `file://`, `mailto:`) are wrapped. NSDataDetector also matches schemeless domains like `example.com` and bare emails like `foo@example.com`, but we deliberately leave those as plain text — terminal-style "make pasted URLs clickable" behaviour, not GitHub-style fuzzy linkification.
- Skips autolinking inside code spans, code blocks, image alt text, and the visible text of explicit `[text](url)` links so we don't double-wrap.

Closes #91.

## Test plan

- [x] `xcodebuild test -only-testing:NexTests/MarkdownHTMLRendererTests` passes (44 prior + 6 new tests covering schemeless domains, www-prefixed domains, bare emails, explicit `mailto:`, `ftp://`/`file://`, and a mixed schemed-vs-bare case).
- [x] `xcodebuild test` full suite passes.
- [x] `swiftformat --lint .` clean.
- [x] Manual smoke: open `tickets/link-test.md` (added on this branch, gitignored) and confirm:
  - bare https/http/ftp/file/mailto links are clickable
  - schemeless `example.com`, `www.example.com`, and `foo@example.com` render as plain text
  - URLs inside code spans / code blocks / image alt text are not linked
  - trailing punctuation (period, comma, paren) is not part of the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)