### PR TITLE
feat: render markdown task list checkboxes visually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ Package.resolved
 
 # Claude
 .claude/
+.nex-tasks/
+.nex-results/
 
 # Python
 __pycache__/

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0A339E290783C7347081E4FC /* GlobalHotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8340B6640D25908803B93C2A /* GlobalHotkeyService.swift */; };
 		0A3E7A2B0CB52F2FE791A2B5 /* GroupCustomEmojiSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD30BE0FDF3CC57813A5DB46 /* GroupCustomEmojiSheet.swift */; };
 		0CB9F718A5EF25AF73DED570 /* WorkspaceGroupRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2445F37BD230A19B4FA07CDC /* WorkspaceGroupRenderTests.swift */; };
+		0D23E37D86270E1BAADFF549 /* MarkdownCheckboxRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CCB57D9C4E2AC2014127FC8 /* MarkdownCheckboxRenderingTests.swift */; };
 		0D7D8E5C230B6C98E7693D66 /* PaneListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */; };
 		0EAFF0FDB683293F95D8AB47 /* RenameWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */; };
 		0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B822ABF12B071E574E089BB4 /* GroupIconTests.swift */; };
@@ -179,6 +180,7 @@
 		3B2687F4D886D153C83D8A60 /* WorkspaceGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroup.swift; sourceTree = "<group>"; };
 		42A24C1FEC6EA31096603326 /* SurfaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceManager.swift; sourceTree = "<group>"; };
 		439174A029FAFE2C252A1B8B /* KeybindingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingsSettingsView.swift; sourceTree = "<group>"; };
+		4CCB57D9C4E2AC2014127FC8 /* MarkdownCheckboxRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCheckboxRenderingTests.swift; sourceTree = "<group>"; };
 		4DA17E3004A004E6B4DDDBF6 /* PersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceTests.swift; sourceTree = "<group>"; };
 		4F0D3AB3067CDBF5A490F532 /* NewWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceSheet.swift; sourceTree = "<group>"; };
 		523DE37561222E411737C3F8 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 				B822ABF12B071E574E089BB4 /* GroupIconTests.swift */,
 				EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */,
 				5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */,
+				4CCB57D9C4E2AC2014127FC8 /* MarkdownCheckboxRenderingTests.swift */,
 				200EB2588E40ABB7C51E24E6 /* MarkdownHTMLRendererTests.swift */,
 				8344DA5EFC15BF047C2003A4 /* PaneCaptureReplyTests.swift */,
 				F5CE8D708EEECA4A82BE0AC1 /* PaneCloseReplyTests.swift */,
@@ -706,6 +709,7 @@
 				0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */,
 				EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */,
 				B701F36FA68D43170D591F40 /* KeyBindingTests.swift in Sources */,
+				0D23E37D86270E1BAADFF549 /* MarkdownCheckboxRenderingTests.swift in Sources */,
 				EA22F9720B68648A78D237E3 /* MarkdownHTMLRendererTests.swift in Sources */,
 				7CFCDB77693B32481C402E8E /* PaneCaptureReplyTests.swift in Sources */,
 				3EB758164265D71D08B0156C /* PaneCloseReplyTests.swift in Sources */,

--- a/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
+++ b/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
@@ -350,10 +350,30 @@ enum MarkdownRenderer {
         li { margin: 0.25em 0; }
         li.task-list-item { list-style-type: none; }
         /* -1.4em pulls the checkbox into the bullet column. Assumes
-           `ul, ol { padding-left: 2em }` above. */
+           `ul, ol { padding-left: 2em }` above. Native disabled checkboxes
+           render very faintly, so we draw our own GitHub-style box. */
         li.task-list-item > input.task-list-item-checkbox {
+            appearance: none;
+            -webkit-appearance: none;
+            width: 14px;
+            height: 14px;
+            border: 1.5px solid #8c959f;
+            border-radius: 3px;
+            background: transparent;
             margin: 0 0.4em 0.15em -1.4em;
             vertical-align: middle;
+            cursor: default;
+        }
+        .dark li.task-list-item > input.task-list-item-checkbox {
+            border-color: #7d8590;
+        }
+        li.task-list-item > input.task-list-item-checkbox:checked {
+            background-color: #1f6feb;
+            border-color: #1f6feb;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3 8l3 3 7-7' stroke='white' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: 12px 12px;
         }
         /* Inline the leading paragraph so it sits beside the checkbox.
            Vertical margins drop on inline elements, so trailing block <p>s

--- a/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
+++ b/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
@@ -87,8 +87,10 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
     mutating func visitListItem(_ item: ListItem) -> String {
         let content = item.children.map { visit($0) }.joined()
         if let checkbox = item.checkbox {
-            let checked = checkbox == .checked ? " checked disabled" : " disabled"
-            return "<li><input type=\"checkbox\"\(checked)> \(content)</li>\n"
+            let attrs = checkbox == .checked ? " checked disabled" : " disabled"
+            return "<li class=\"task-list-item\">"
+                + "<input type=\"checkbox\" class=\"task-list-item-checkbox\"\(attrs)> "
+                + "\(content)</li>\n"
         }
         return "<li>\(content)</li>\n"
     }
@@ -346,7 +348,17 @@ enum MarkdownRenderer {
         .dark th { background: #161b22; }
         ul, ol { padding-left: 2em; margin: 0.5em 0; }
         li { margin: 0.25em 0; }
-        li > input[type="checkbox"] { margin-right: 0.5em; }
+        li.task-list-item { list-style-type: none; }
+        /* -1.4em pulls the checkbox into the bullet column. Assumes
+           `ul, ol { padding-left: 2em }` above. */
+        li.task-list-item > input.task-list-item-checkbox {
+            margin: 0 0.4em 0.15em -1.4em;
+            vertical-align: middle;
+        }
+        /* Inline the leading paragraph so it sits beside the checkbox.
+           Vertical margins drop on inline elements, so trailing block <p>s
+           in loose lists still get their own top margin. */
+        li.task-list-item > p:first-of-type { display: inline; }
         hr {
             border: none;
             border-top: 1px solid #d1d9e0;

--- a/NexTests/MarkdownCheckboxRenderingTests.swift
+++ b/NexTests/MarkdownCheckboxRenderingTests.swift
@@ -1,0 +1,151 @@
+import AppKit
+import Foundation
+@testable import Nex
+import Testing
+
+struct MarkdownCheckboxRenderingTests {
+    @Test func uncheckedItemEmitsTaskListClassesAndDisabledInput() {
+        let html = MarkdownRenderer.renderToHTML("- [ ] todo item")
+        #expect(html.contains("<li class=\"task-list-item\">"))
+        #expect(html.contains("<input type=\"checkbox\""))
+        #expect(html.contains("class=\"task-list-item-checkbox\""))
+        #expect(html.contains(" disabled>"))
+        #expect(html.contains("todo item"))
+        // Must not have the `checked` attribute on an unchecked item.
+        #expect(!html.contains(" checked "))
+    }
+
+    @Test func checkedItemEmitsCheckedAttribute() {
+        let html = MarkdownRenderer.renderToHTML("- [x] done item")
+        #expect(html.contains("<li class=\"task-list-item\">"))
+        #expect(html.contains("class=\"task-list-item-checkbox\""))
+        #expect(html.contains(" checked disabled>"))
+        #expect(html.contains("done item"))
+    }
+
+    @Test func capitalXAlsoChecked() {
+        // GFM tasklist accepts [X] as well as [x].
+        let html = MarkdownRenderer.renderToHTML("- [X] done")
+        #expect(html.contains(" checked disabled>"))
+    }
+
+    @Test func plainListItemKeepsBulletAndNoTaskClass() {
+        // A regular list item must not pick up the task-list-item class.
+        let html = MarkdownRenderer.renderToHTML("- regular item")
+        #expect(html.contains("<li><p>regular item</p>"))
+        #expect(!html.contains("<li class=\"task-list-item\">"))
+        #expect(!html.contains("<input"))
+    }
+
+    @Test func mixedListPreservesPerItemClassing() {
+        let html = MarkdownRenderer.renderToHTML("- [ ] task\n- regular")
+        // The checkbox item gets the class; the regular item does not.
+        #expect(html.contains("<li class=\"task-list-item\">"))
+        #expect(html.contains("<li><p>regular</p>"))
+    }
+
+    @Test func cssHidesBulletForTaskListItem() {
+        let html = MarkdownRenderer.renderToHTML("- [ ] x")
+        #expect(html.contains("li.task-list-item { list-style-type: none; }"))
+    }
+
+    @Test func cssInlinesLeadingParagraph() {
+        // Without this rule the checkbox would sit on its own line because the
+        // list item content is wrapped in a block `<p>`. :first-of-type covers
+        // both single- and multi-paragraph items: the trailing <p>s remain
+        // block and pick up their own top margin to space themselves.
+        let html = MarkdownRenderer.renderToHTML("- [ ] x")
+        #expect(html.contains("li.task-list-item > p:first-of-type"))
+        // Must NOT use :only-of-type — that fails to inline the leading <p>
+        // in loose lists where there are two siblings.
+        #expect(!html.contains("p:only-of-type { display: inline"))
+    }
+
+    @Test func multiParagraphTaskItemInlinesLeadingParagraph() {
+        // Loose task item with two <p>s. The leading <p> must still match the
+        // inline rule so the checkbox sits beside its label; the second <p>
+        // remains block. This test would fail with `p:only-of-type` because
+        // neither <p> is the only one of its type.
+        let md = "- [ ] first\n\n  second\n"
+        let html = MarkdownRenderer.renderToHTML(md)
+        // Both paragraphs render inside the task item.
+        #expect(html.contains("first"))
+        #expect(html.contains("second"))
+        #expect(html.contains("<li class=\"task-list-item\">"))
+        // The CSS selector must match BOTH the single-paragraph case AND
+        // the loose case. :first-of-type does, :only-of-type does not.
+        #expect(html.contains("li.task-list-item > p:first-of-type { display: inline; }"))
+    }
+
+    @Test func escapedCheckboxBracketsAreNotATaskItem() {
+        // `\[ \]` escapes the brackets so this is a plain list item. The CSS
+        // block always contains `task-list-item` rules — assert on the body
+        // marker instead.
+        let html = MarkdownRenderer.renderToHTML(#"- \[ \] not a checkbox"#)
+        #expect(!html.contains("<li class=\"task-list-item\">"))
+        #expect(!html.contains("<input"))
+        #expect(html.contains("[ ]"))
+    }
+
+    @Test func orderedListCheckboxAlsoSupported() {
+        // swift-markdown applies the same checkbox model to ordered lists.
+        // We treat them identically; the number is hidden by the same
+        // `list-style-type: none` rule. This test pins that behavior.
+        let html = MarkdownRenderer.renderToHTML("1. [ ] item")
+        #expect(html.contains("<ol"))
+        #expect(html.contains("<li class=\"task-list-item\">"))
+        #expect(html.contains("class=\"task-list-item-checkbox\""))
+    }
+
+    @Test func bracketSyntaxInPlainParagraphIsNotACheckbox() {
+        // `[x]` outside a list-item leading position must NOT become a checkbox.
+        let html = MarkdownRenderer.renderToHTML("plain [x] text in a paragraph")
+        #expect(!html.contains("<li class=\"task-list-item\">"))
+        #expect(!html.contains("<input"))
+        #expect(html.contains("plain [x] text in a paragraph"))
+    }
+
+    @Test func bracketSyntaxMidListItemIsNotACheckbox() {
+        // `[x]` must be at the START of a list item to be a task marker.
+        let html = MarkdownRenderer.renderToHTML("- not a [x] task")
+        #expect(!html.contains("<li class=\"task-list-item\">"))
+        #expect(!html.contains("<input"))
+    }
+
+    @Test func blockquotedTaskListIsAnUpstreamLimitation() {
+        // Pin current behaviour: swift-markdown's tasklist extension does not
+        // fire for `- [x]` inside a blockquote — the brackets reach us as
+        // plain text. If this starts producing a checkbox after a future
+        // swift-markdown bump, flip this test to assert task-list-item is
+        // present.
+        let html = MarkdownRenderer.renderToHTML("> - [x] inside a quote")
+        #expect(html.contains("<blockquote>"))
+        #expect(html.contains("<ul>"))
+        #expect(!html.contains("<li class=\"task-list-item\">"))
+        #expect(html.contains("[x] inside a quote"))
+    }
+
+    @Test func nestedCheckboxRendersAsTaskItem() {
+        let md = """
+        - parent
+          - [ ] child task
+        """
+        let html = MarkdownRenderer.renderToHTML(md)
+        #expect(html.contains("<li class=\"task-list-item\">"))
+        #expect(html.contains("child task"))
+    }
+
+    @Test func checkboxItemTextEscapesAmpersand() {
+        // Plain-text content inside a checkbox item must still go through the
+        // standard escape path (verifies we didn't accidentally bypass
+        // visitText when adding the task-list classes).
+        let html = MarkdownRenderer.renderToHTML("- [ ] a & b")
+        #expect(html.contains("a &amp; b"))
+    }
+
+    @Test func checkboxItemPreservesInlineMarkdown() {
+        // Bold/italic inside a checkbox label must still render.
+        let html = MarkdownRenderer.renderToHTML("- [ ] **bold** task")
+        #expect(html.contains("<strong>bold</strong>"))
+    }
+}


### PR DESCRIPTION
## Summary
- Render `- [ ] todo` / `- [x] done` items as visually distinct checkboxes in the markdown preview by adding GitHub-style `task-list-item` / `task-list-item-checkbox` classes plus CSS that hides the bullet, pulls the checkbox into the bullet column, and inlines the leading paragraph so the checkbox sits beside its label.
- Loose multi-paragraph items still space correctly: the leading `<p>` is `display: inline` (vertical margins drop), trailing block `<p>`s keep their own top margin.
- Adds 13 unit tests covering checked / unchecked / `[X]`, plain item exclusion, mixed lists, multi-paragraph items, ordered-list checkboxes, escaped brackets, inline `[x]` text, nested lists, and the (currently upstream-limited) blockquote case.

Closes #90

## Reviewer notes
- Inputs stay `disabled` (non-interactive). The issue accepts \"interactive (or at least visually distinct)\" — visual is the lower-cost path; making the checkboxes write back to disk would need round-tripping through swift-markdown which is a bigger change.
- Task lists inside blockquotes (`> - [x] x`) are NOT rendered as task items today: swift-markdown's tasklist extension does not fire in that container. Pinned with a passing test that documents the limitation; flip the assertion if a future swift-markdown bump enables it.

## Test plan
- [x] Open a markdown file containing `- [ ] todo` and `- [x] done` items in a Nex markdown pane and confirm checkboxes render flush-left with the label inline.
- [x] Confirm the bullet point is hidden for task items but still appears for regular `- ...` items in the same list.
- [x] Open a loose task list with multi-paragraph items and confirm the second paragraph still spaces below the first.
- [x] Toggle dark / light terminal background to confirm the checkbox is visible in both themes.
- [x] Open a markdown file with `1. [ ] task` and confirm ordered-list checkboxes also render correctly.