### PR TITLE
docs: add auto and dontAsk permission modes to nex-agentic skill

### DIFF
--- a/Resources/skills/nex-agentic/SKILL.md
+++ b/Resources/skills/nex-agentic/SKILL.md
@@ -49,8 +49,17 @@ Otherwise ask via `AskUserQuestion` — do not assume defaults.
      babysit each worker)
    - `acceptEdits` — auto-accept file edits, still prompt on Bash/other
    - `plan` — planning only, no writes
+   - `auto` — auto-approves all tool calls with background safety
+     checks. Covers Bash/Edit/Read/web, unlike `acceptEdits` which is
+     file-writes only. Good middle ground for trusted fan-outs that
+     still want some guardrails
    - `bypassPermissions` (aka `--dangerously-skip-permissions`) — full
-     autonomy, no prompts. Common for trusted fan-outs in worktrees.
+     autonomy, no prompts, no checks. Common for trusted fan-outs in
+     worktrees or sandboxed VMs
+   - `dontAsk` — auto-denies any tool not pre-approved via
+     `/permissions` or an allowlist. Strictest mode for unattended
+     orchestration with an explicit whitelist; non-whitelisted calls
+     silently fail
 
 Ask both in a single `AskUserQuestion` call with two questions. Record
 the answers and reuse them for every worker spawn in the session unless


### PR DESCRIPTION
## Summary
- Document the two newer `--permission-mode` values Claude Code now supports (`auto`, `dontAsk`) alongside the existing four
- Each entry frames when to pick it relative to the others, so coordinator panes can answer the up-front permission-mode question with the full menu

## Test plan
- [x] Skill renders correctly (text-only change)
- [ ] Read-through: confirm new bullets fit the existing voice and the AskUserQuestion flow still makes sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)