### PR TITLE
fix: cmd+click on wrapped markdown paths opens the file (#107)

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -94,7 +94,9 @@
 		B652FDDE5CE91C5CA1DAC8E2 /* DatabaseMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21064C4AB47888B6A02CCD73 /* DatabaseMigrationTests.swift */; };
 		B701F36FA68D43170D591F40 /* KeyBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */; };
 		B8DCB316773E208FABEDA9D7 /* UpdaterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C711FF0D53387D16F50C5EA6 /* UpdaterService.swift */; };
+		BC03D29CE48A7376A7F2B97E /* CmdClickPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CA9FDA34D1BCE30C07D121 /* CmdClickPathResolver.swift */; };
 		BF19A66EC95FA4FB46CA400D /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F228193206574DB257C8B3FB /* AppKit.framework */; };
+		BFC73C4306DF628DF52FF55D /* CmdClickPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A830B6BF72CE183AC4EC7C17 /* CmdClickPathResolverTests.swift */; };
 		C052FE23BF089795BB04E10E /* RenamePaneSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191592BF0EBCEC22DF9F5745 /* RenamePaneSheet.swift */; };
 		C0DDF7284D01523225E5EEE7 /* GhosttyConfigClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47FF7FB9A9C29221EAD089E /* GhosttyConfigClient.swift */; };
 		C276E6F9F7B46ED43FF491D5 /* NexApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3714AA1F15C85762BF36B1FE /* NexApp.swift */; };
@@ -165,6 +167,7 @@
 		200EB2588E40ABB7C51E24E6 /* MarkdownHTMLRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownHTMLRendererTests.swift; sourceTree = "<group>"; };
 		21064C4AB47888B6A02CCD73 /* DatabaseMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseMigrationTests.swift; sourceTree = "<group>"; };
 		221A3B0170CFD708F3B03A84 /* Repo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repo.swift; sourceTree = "<group>"; };
+		22CA9FDA34D1BCE30C07D121 /* CmdClickPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmdClickPathResolver.swift; sourceTree = "<group>"; };
 		2445F37BD230A19B4FA07CDC /* WorkspaceGroupRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupRenderTests.swift; sourceTree = "<group>"; };
 		257A1CB3D7653911EF93F8F5 /* RepoAssociation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoAssociation.swift; sourceTree = "<group>"; };
 		281BB8BFA202B0E43FC1E2AE /* GitHeadWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHeadWatcher.swift; sourceTree = "<group>"; };
@@ -216,6 +219,7 @@
 		A11F5427AE75515696FB8295 /* PaneLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutTests.swift; sourceTree = "<group>"; };
 		A2554566AF4F790EB30637E3 /* AgentLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleTests.swift; sourceTree = "<group>"; };
 		A47FF7FB9A9C29221EAD089E /* GhosttyConfigClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigClient.swift; sourceTree = "<group>"; };
+		A830B6BF72CE183AC4EC7C17 /* CmdClickPathResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmdClickPathResolverTests.swift; sourceTree = "<group>"; };
 		AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketParsingTests.swift; sourceTree = "<group>"; };
 		ADBC4A3F4B30336A12D32DF4 /* AutoDetectRepoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectRepoTests.swift; sourceTree = "<group>"; };
 		ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeatureTests.swift; sourceTree = "<group>"; };
@@ -353,6 +357,7 @@
 				A2554566AF4F790EB30637E3 /* AgentLifecycleTests.swift */,
 				D6B83DC43AEA38B4929307FA /* AppReducerTests.swift */,
 				ADBC4A3F4B30336A12D32DF4 /* AutoDetectRepoTests.swift */,
+				A830B6BF72CE183AC4EC7C17 /* CmdClickPathResolverTests.swift */,
 				89FC5F004277851CEA0CFF3F /* CommandPaletteTests.swift */,
 				309F641591BB580429299666 /* ConfigParserTests.swift */,
 				21064C4AB47888B6A02CCD73 /* DatabaseMigrationTests.swift */,
@@ -400,6 +405,7 @@
 			isa = PBXGroup;
 			children = (
 				DC371B0DE7B02828E9EDFE8E /* ClipboardImageHelper.swift */,
+				22CA9FDA34D1BCE30C07D121 /* CmdClickPathResolver.swift */,
 				000C46C62FB60503295A92E8 /* GhosttyApp.swift */,
 				96AD7A8D7E6592B90FBB7D24 /* GhosttyConfig.swift */,
 				A47FF7FB9A9C29221EAD089E /* GhosttyConfigClient.swift */,
@@ -702,6 +708,7 @@
 				840B487024194CA181EE42F8 /* AgentLifecycleTests.swift in Sources */,
 				B5EDCEE4998F1F0B6F844814 /* AppReducerTests.swift in Sources */,
 				DC11308E0E92225F551CF162 /* AutoDetectRepoTests.swift in Sources */,
+				BFC73C4306DF628DF52FF55D /* CmdClickPathResolverTests.swift in Sources */,
 				FD494AFC9E74F4C5D7E125B8 /* CommandPaletteTests.swift in Sources */,
 				A1937931A23F2D0EB8472737 /* ConfigParserTests.swift in Sources */,
 				B652FDDE5CE91C5CA1DAC8E2 /* DatabaseMigrationTests.swift in Sources */,
@@ -744,6 +751,7 @@
 				EFDCA64CD227A833D2801893 /* CLIInstallService.swift in Sources */,
 				B23A46CD372F9E16C2C1D716 /* CheckForUpdatesView.swift in Sources */,
 				B221D950378165611A0DF932 /* ClipboardImageHelper.swift in Sources */,
+				BC03D29CE48A7376A7F2B97E /* CmdClickPathResolver.swift in Sources */,
 				3C74513CA9D5FD60E672B477 /* CommandPaletteItem.swift in Sources */,
 				741144CE5AC7DEC20A18A89D /* CommandPaletteView.swift in Sources */,
 				2D8754E0B3E9AD185D7EB6B0 /* ConfigParser.swift in Sources */,

--- a/Nex/Ghostty/CmdClickPathResolver.swift
+++ b/Nex/Ghostty/CmdClickPathResolver.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Finds the markdown file path under a cmd+click in a terminal pane, including
+/// paths that wrap across multiple terminal rows.
+///
+/// libghostty's own link detection is supposed to span soft-wraps, but in
+/// practice cmd+click on a wrapped path drops the file open (issue #107). The
+/// observed failure mode is that libghostty matches the visual fragment on the
+/// clicked row instead of the full wrapped path. This resolver is invoked by
+/// SurfaceView before forwarding the click and short-circuits the markdown
+/// open path when we can identify a `.md` file under the click.
+enum CmdClickPathResolver {
+    /// Find the markdown path at the given click cell.
+    ///
+    /// `viewportText` is the result of reading the viewport via
+    /// `ghostty_surface_read_text`, which uses `selectionString(unwrap=true)`:
+    /// soft-wrapped rows are joined directly (no separator) and hard line
+    /// breaks become `\n`. Wrap-chained rows are full (cols characters each)
+    /// because the wrap fired only because content exceeded width. The trailing
+    /// row of a logical line may be partial — libghostty drops trailing blank
+    /// cells. The chunk-row math here uses ceil(chunk.count / cols) so a
+    /// partial trailing row still counts as one row.
+    ///
+    /// ASCII-path assumption: clickCol → character offset uses
+    /// `(clickRow - chunkStartRow) * cols + clickCol`, which is exact for
+    /// single-byte/single-cell content. Wide CJK or wide-emoji surrounding
+    /// text will misalign the click within the chunk; markdown paths in
+    /// practice are ASCII so this is acceptable scope.
+    ///
+    /// `firstRow` is the viewport row index of the first row included in
+    /// `viewportText`. `cols` is the terminal width in cells. `clickRow` and
+    /// `clickCol` are 0-based viewport cell coordinates.
+    ///
+    /// Returns the matched markdown path (trimmed), or nil if none was found.
+    static func findMarkdownPath(
+        in viewportText: String,
+        firstRow: Int,
+        cols: Int,
+        clickRow: Int,
+        clickCol: Int
+    ) -> String? {
+        guard cols > 0 else { return nil }
+        // Split into logical lines: each chunk is a sequence of soft-wrapped
+        // rows joined together, separated from the next chunk by a hard break.
+        let chunks = viewportText.components(separatedBy: "\n")
+        var rowCursor = firstRow
+        for chunk in chunks {
+            // ceil(chunk.count / cols) — wrap-chained rows are full (=cols),
+            // the trailing row may be partial. Empty chunk still occupies 1
+            // physical row (a blank line in the viewport).
+            let rowsInChunk = max(1, (chunk.count + cols - 1) / cols)
+            let chunkStartRow = rowCursor
+            let chunkEndRow = chunkStartRow + rowsInChunk - 1
+            defer { rowCursor = chunkEndRow + 1 }
+            guard clickRow >= chunkStartRow, clickRow <= chunkEndRow else { continue }
+
+            let clickOffsetInChunk = (clickRow - chunkStartRow) * cols + clickCol
+            return findContainingMarkdownPath(in: chunk, clickOffset: clickOffsetInChunk)
+        }
+        return nil
+    }
+
+    /// Find a `.md` path in `line` that contains `clickOffset`. Returns the
+    /// matched path (trimmed of trailing `.` and surrounding whitespace) or
+    /// nil if no .md path covers the click position.
+    static func findContainingMarkdownPath(in line: String, clickOffset: Int) -> String? {
+        // Path candidates: must end with `.md` (case-insensitive) followed by
+        // a path-terminator (whitespace / paren / bracket / angle / quote /
+        // colon / comma / end-of-string). Without the terminator anchor the
+        // greedy `[^\s...]+` would match `foo.md.bak` then backtrack to expose
+        // `.md`, opening a non-existent `foo.md`. Anchored, `foo.md.bak` does
+        // not match at all.
+        // Roots accepted: `/`, `~`, `./`, `../`. Bare relatives (`notes/x.md`)
+        // are out of scope — libghostty already handles those via its own
+        // regex when the path doesn't wrap.
+        let pattern = #"(?:[/~]|\.{1,2}/)[^\s\(\)\[\]<>"'\\]+?\.[mM][dD](?=[\s\(\)\[\]<>"',:]|$)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsLine = line as NSString
+        let matches = regex.matches(in: line, range: NSRange(location: 0, length: nsLine.length))
+        for match in matches {
+            // Inclusive containment: clicking on the very last char of a path
+            // (the final 'd' in `.md`) should still resolve.
+            let start = match.range.location
+            let end = match.range.location + match.range.length
+            guard clickOffset >= start, clickOffset < end else { continue }
+            let raw = nsLine.substring(with: match.range)
+            return cleanupPath(raw)
+        }
+        return nil
+    }
+
+    /// Strip trailing dots and whitespace, mirroring what
+    /// `GhosttyApp.handleAction(GHOSTTY_ACTION_OPEN_URL)` does to the URL it
+    /// receives from libghostty.
+    private static func cleanupPath(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        while s.hasSuffix(".") {
+            s.removeLast()
+        }
+        return s
+    }
+}

--- a/Nex/Ghostty/SurfaceView.swift
+++ b/Nex/Ghostty/SurfaceView.swift
@@ -308,9 +308,29 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
         return NSPoint(x: point.x, y: frame.height - point.y)
     }
 
+    /// Set on cmd+click mouseDown when we resolve a markdown path locally
+    /// (issue #107). When set, the matching mouseUp posts the open notification
+    /// and skips forwarding press/release to libghostty so its fragment-only
+    /// match doesn't fight with us. Cleared at the top of every mouseDown so
+    /// a missed mouseUp (window closed mid-drag, focus stolen, etc.) cannot
+    /// strand libghostty's mouse state into the next click.
+    private var consumedCmdClickPath: String?
+
     override func mouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
+        // Stale state from a missed mouseUp must never carry over: if it did,
+        // the next mouseUp would suppress libghostty's RELEASE for a click we
+        // didn't intercept here, leaving its mouse button stuck.
+        consumedCmdClickPath = nil
         let point = mousePoint(from: event)
+        if event.modifierFlags.contains(.command),
+           let path = resolveWrappedMarkdownPath(at: point) {
+            // Defer the open until mouseUp to match libghostty's
+            // press-then-release activation timing. mouseUp also handles the
+            // surface lookup for the notification's userInfo.
+            consumedCmdClickPath = path
+            return
+        }
         ghosttySurface?.sendMousePos(x: point.x, y: point.y, mods: Self.mods(from: event))
         _ = ghosttySurface?.sendMouseButton(
             state: GHOSTTY_MOUSE_PRESS,
@@ -320,6 +340,11 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
     }
 
     override func mouseUp(with event: NSEvent) {
+        if let path = consumedCmdClickPath {
+            consumedCmdClickPath = nil
+            postOpenMarkdownNotification(path: path)
+            return
+        }
         let point = mousePoint(from: event)
         ghosttySurface?.sendMousePos(x: point.x, y: point.y, mods: Self.mods(from: event))
         _ = ghosttySurface?.sendMouseButton(
@@ -329,7 +354,53 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
         )
     }
 
+    /// Try to resolve a markdown path under a cmd+click, including paths that
+    /// wrap across multiple terminal rows. Returns nil when no .md path
+    /// covers the click; in that case the caller should forward the click to
+    /// libghostty so non-markdown links (URLs, single-line bare paths handled
+    /// by libghostty's regex) keep working.
+    private func resolveWrappedMarkdownPath(at point: NSPoint) -> String? {
+        guard let ghostty = ghosttySurface else { return nil }
+        let size = ghostty.size
+        guard size.cell_width_px > 0, size.cell_height_px > 0,
+              size.columns > 0, size.rows > 0 else { return nil }
+        // `cell_width_px` / `cell_height_px` are physical pixels (libghostty
+        // is sized via `bounds * backingScaleFactor` in viewDidMoveToWindow /
+        // setFrameSize). `point` is in NSView logical points. Convert before
+        // dividing or Retina (2x) gives half the correct column.
+        let scale = window?.backingScaleFactor ?? 1.0
+        let clickCol = Int(point.x * scale) / Int(size.cell_width_px)
+        let clickRow = Int(point.y * scale) / Int(size.cell_height_px)
+        guard clickRow >= 0, clickRow < Int(size.rows),
+              clickCol >= 0, clickCol < Int(size.columns) else { return nil }
+        guard let viewportText = ghostty.readText(includeScrollback: false) else { return nil }
+        return CmdClickPathResolver.findMarkdownPath(
+            in: viewportText,
+            firstRow: 0,
+            cols: Int(size.columns),
+            clickRow: clickRow,
+            clickCol: clickCol
+        )
+    }
+
+    private func postOpenMarkdownNotification(path: String) {
+        let surface = ghosttySurface?.surface as Any
+        let standardized = NSString(string: path).standardizingPath
+        NotificationCenter.default.post(
+            name: GhosttyApp.openFileNotification,
+            object: nil,
+            userInfo: [
+                "path": standardized,
+                "surface": surface
+            ]
+        )
+    }
+
     override func mouseDragged(with event: NSEvent) {
+        // If we intercepted the matching mouseDown, libghostty never received
+        // a PRESS — feeding it cursor moves now would desync its hover/select
+        // state. Drop the drag; mouseUp will post the open notification.
+        if consumedCmdClickPath != nil { return }
         let point = mousePoint(from: event)
         ghosttySurface?.sendMousePos(
             x: point.x, y: point.y,

--- a/NexTests/CmdClickPathResolverTests.swift
+++ b/NexTests/CmdClickPathResolverTests.swift
@@ -1,0 +1,230 @@
+import Foundation
+@testable import Nex
+import Testing
+
+struct CmdClickPathResolverTests {
+    // MARK: - findContainingMarkdownPath (single-string regex behaviour)
+
+    @Test func returnsAbsolutePathWhenClickIsInsideIt() {
+        let line = "open /Users/ben/notes/foo.md please"
+        let clickOffset = line.distance(from: line.startIndex, to: line.range(of: "notes")!.lowerBound)
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: clickOffset)
+        #expect(path == "/Users/ben/notes/foo.md")
+    }
+
+    @Test func returnsHomePathWhenClickIsInsideIt() {
+        let line = "see ~/Documents/spec.md for details"
+        let clickOffset = line.distance(from: line.startIndex, to: line.range(of: "spec")!.lowerBound)
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: clickOffset)
+        #expect(path == "~/Documents/spec.md")
+    }
+
+    @Test func returnsNilWhenClickIsOutsideAllMatches() {
+        let line = "  /Users/ben/notes/foo.md   "
+        // Click in the trailing whitespace, well past the path.
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: line.count - 2)
+        #expect(path == nil)
+    }
+
+    @Test func returnsNilWhenLineHasNoMarkdownPath() {
+        let line = "hello world https://example.com no markdown here"
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: 5)
+        #expect(path == nil)
+    }
+
+    @Test func picksContainingPathWhenMultiplePathsOnSameLine() {
+        let line = "/tmp/a.md and /tmp/long/b.md again"
+        let clickOffset = line.distance(from: line.startIndex, to: line.range(of: "b.md")!.lowerBound)
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: clickOffset)
+        #expect(path == "/tmp/long/b.md")
+    }
+
+    @Test func extractsPathFromMarkdownLinkSyntax() {
+        // The trailing `)` must not be consumed by the path match.
+        let line = "see [the spec](/Users/ben/notes/spec.md) for details"
+        let clickOffset = line.distance(from: line.startIndex, to: line.range(of: "spec.md")!.lowerBound)
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: clickOffset)
+        #expect(path == "/Users/ben/notes/spec.md")
+    }
+
+    @Test func clickOnFinalCharacterStillResolves() {
+        let line = "/tmp/file.md"
+        // Click on the final `d` (last char in the path) — inclusive containment.
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: line.count - 1)
+        #expect(path == "/tmp/file.md")
+    }
+
+    @Test func handlesRelativeDotPaths() {
+        let line = "open ./notes/today.md"
+        let clickOffset = line.distance(from: line.startIndex, to: line.range(of: "today")!.lowerBound)
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: clickOffset)
+        #expect(path == "./notes/today.md")
+    }
+
+    @Test func handlesParentDirRelativePaths() {
+        let line = "see ../shared/index.md"
+        let clickOffset = line.distance(from: line.startIndex, to: line.range(of: "index")!.lowerBound)
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: clickOffset)
+        #expect(path == "../shared/index.md")
+    }
+
+    @Test func doesNotMatchMdInsideBakSuffix() {
+        // Without the path-terminator lookahead, /tmp/foo.md.bak would
+        // backtrack to expose `.md` and cmd+click on `foo` would open a
+        // bogus `/tmp/foo.md`. With the lookahead, no .md path is matched.
+        let line = "edit /tmp/foo.md.bak now"
+        let clickOffset = line.distance(from: line.startIndex, to: line.range(of: "foo")!.lowerBound)
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: clickOffset)
+        #expect(path == nil)
+    }
+
+    @Test func doesNotMatchPathFollowedByPeriod() {
+        // Trade-off: requiring a non-`.` terminator after `.md` is what blocks
+        // the .md.bak false-match. The cost is that a sentence-ending period
+        // immediately after `.md` (no space between) doesn't match either.
+        // Acceptable: this case is rare; the bak case is common.
+        let line = "/tmp/file.md."
+        let clickOffset = line.distance(from: line.startIndex, to: line.range(of: "file")!.lowerBound)
+        let path = CmdClickPathResolver.findContainingMarkdownPath(in: line, clickOffset: clickOffset)
+        #expect(path == nil)
+    }
+
+    @Test func resolvesPathFollowedByCommaOrColon() {
+        // Compiler/lint output frequently emits `path.md:42` or `a.md, b.md`.
+        let line1 = "see /tmp/foo.md:42 here"
+        let off1 = line1.distance(from: line1.startIndex, to: line1.range(of: "foo")!.lowerBound)
+        #expect(CmdClickPathResolver.findContainingMarkdownPath(in: line1, clickOffset: off1) == "/tmp/foo.md")
+
+        let line2 = "/tmp/a.md, /tmp/b.md"
+        let off2 = line2.distance(from: line2.startIndex, to: line2.range(of: "a.md")!.lowerBound)
+        #expect(CmdClickPathResolver.findContainingMarkdownPath(in: line2, clickOffset: off2) == "/tmp/a.md")
+    }
+
+    // MARK: - findMarkdownPath (full viewport-aware flow)
+
+    /// Builds a viewport text mock matching libghostty's
+    /// selectionString(unwrap=true, trim=false) shape:
+    /// - Wrap-chained rows are always full (`cols` chars). The caller asserts
+    ///   this by passing wraps[i]=true; we precondition that row.count==cols.
+    /// - The last row of any logical line may be partial. libghostty drops
+    ///   trailing blank cells (formatter resets blank_cells on row end), so
+    ///   we emit the row literally with no padding.
+    /// - Hard breaks insert `\n` between chunks; the trailing chunk has no
+    ///   trailing newline.
+    private func makeViewport(rows: [String], cols: Int, wraps: [Bool]) -> String {
+        precondition(rows.count == wraps.count, "wraps array must match rows")
+        var out = ""
+        for (idx, row) in rows.enumerated() {
+            if wraps[idx] {
+                precondition(row.count == cols, "wrap-chained row must be exactly cols chars")
+                out.append(row)
+            } else {
+                // Last row of a logical line: emit as-is (libghostty drops
+                // trailing blank cells; trailing spaces from explicit ` `
+                // writes would survive but partial rows in tests are usually
+                // shorter than `cols`).
+                out.append(row)
+                if idx != rows.count - 1 {
+                    out.append("\n")
+                }
+            }
+        }
+        return out
+    }
+
+    @Test func resolvesSingleLineMarkdownPath() {
+        let cols = 40
+        let viewport = makeViewport(
+            rows: ["see /tmp/foo.md please"],
+            cols: cols,
+            wraps: [false]
+        )
+        let clickCol = "see ".count + 4 // somewhere inside "/tmp/foo.md"
+        let path = CmdClickPathResolver.findMarkdownPath(
+            in: viewport,
+            firstRow: 0,
+            cols: cols,
+            clickRow: 0,
+            clickCol: clickCol
+        )
+        #expect(path == "/tmp/foo.md")
+    }
+
+    @Test func resolvesPathThatWrapsAcrossTwoRowsClickedOnFirstRow() {
+        // 30-col terminal. Path is "/Users/ben/notes/very-long-name.md".
+        // Row 0 holds "see /Users/ben/notes/very-lon" (29 chars + 1 pad).
+        // We need the path to actually fill row 0 to force wrap, so build by
+        // hand with enough leading text.
+        let cols = 20
+        let path = "/Users/ben/notes/spec.md"
+        // Row 0 (20 cols): "abc /Users/ben/notes" -> 20 chars exactly.
+        let row0 = "abc " + String(path.prefix(16)) // "abc /Users/ben/notes" = 20 chars
+        // Row 1 (20 cols): "/spec.md            " -> "/spec.md" + padding.
+        let row1 = String(path.suffix(path.count - 16)) // "/spec.md" = 8 chars
+        let viewport = makeViewport(rows: [row0, row1], cols: cols, wraps: [true, false])
+        // Click on row 0, col where "Users" starts (col 5).
+        let path1 = CmdClickPathResolver.findMarkdownPath(
+            in: viewport, firstRow: 0, cols: cols, clickRow: 0, clickCol: 5
+        )
+        #expect(path1 == path)
+    }
+
+    @Test func resolvesPathThatWrapsAcrossTwoRowsClickedOnSecondRow() {
+        let cols = 20
+        let path = "/Users/ben/notes/spec.md"
+        let row0 = "abc " + String(path.prefix(16))
+        let row1 = String(path.suffix(path.count - 16))
+        let viewport = makeViewport(rows: [row0, row1], cols: cols, wraps: [true, false])
+        // Click on row 1, col 2 (inside "/spec.md").
+        let path2 = CmdClickPathResolver.findMarkdownPath(
+            in: viewport, firstRow: 0, cols: cols, clickRow: 1, clickCol: 2
+        )
+        #expect(path2 == path)
+    }
+
+    @Test func returnsNilWhenClickRowOutsideViewport() {
+        let viewport = makeViewport(rows: ["/tmp/foo.md"], cols: 20, wraps: [false])
+        let path = CmdClickPathResolver.findMarkdownPath(
+            in: viewport, firstRow: 0, cols: 20, clickRow: 5, clickCol: 0
+        )
+        #expect(path == nil)
+    }
+
+    @Test func returnsNilWhenClickRowOnDifferentLogicalLineFromPath() {
+        // Two non-wrapping rows: row 0 has the path, row 1 doesn't. Clicking
+        // on row 1 should not match the row 0 path.
+        let viewport = makeViewport(
+            rows: ["/tmp/foo.md", "no path here"],
+            cols: 20,
+            wraps: [false, false]
+        )
+        let path = CmdClickPathResolver.findMarkdownPath(
+            in: viewport, firstRow: 0, cols: 20, clickRow: 1, clickCol: 5
+        )
+        #expect(path == nil)
+    }
+
+    @Test func resolvesWrappedPathInWindowStartingMidViewport() {
+        // The caller may pass a non-zero firstRow when reading a window
+        // around the click; row indexing must offset accordingly.
+        let cols = 20
+        let path = "/long/wrapped/file.md"
+        // Wrap path across 2 rows, starting at viewport row 3.
+        let row3 = String(path.prefix(20)) // 20 chars: "/long/wrapped/file.m"
+        let row4 = String(path.suffix(path.count - 20)) // "d"
+        let viewport = makeViewport(rows: [row3, row4], cols: cols, wraps: [true, false])
+        // Click on viewport row 4, col 0 (the trailing 'd').
+        let path1 = CmdClickPathResolver.findMarkdownPath(
+            in: viewport, firstRow: 3, cols: cols, clickRow: 4, clickCol: 0
+        )
+        #expect(path1 == path)
+    }
+
+    @Test func returnsNilForZeroCols() {
+        // Pathological: cols = 0 should not crash.
+        let path = CmdClickPathResolver.findMarkdownPath(
+            in: "anything", firstRow: 0, cols: 0, clickRow: 0, clickCol: 0
+        )
+        #expect(path == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- libghostty's link detection drops the open when a markdown path wraps across multiple terminal rows. The visible fragment on the click row isn't a valid `.md` path on its own, so Nex's `GHOSTTY_ACTION_OPEN_URL` handler rejects it and ghostty's fallback opener fails on the bogus fragment.
- Add a Nex-side cmd+click intercept in `SurfaceView` that runs before forwarding the click to libghostty. The new `CmdClickPathResolver` reads the viewport text via the existing `ghostty_surface_read_text` path (which already joins soft-wrapped rows into a single logical line via `selectionString` with `unwrap=true`) and matches an `.md`-anchored regex against the chunk that contains the click row, returning the path that covers the click character offset.
- On a hit, mouseUp posts the same `openFileNotification` `GhosttyApp` posts today and skips the press/release to libghostty so its fragment-only match doesn't fight us. On a miss, we fall through, so URLs and single-line non-markdown links keep going via libghostty unchanged.

Closes #107

## Reviewer notes
- Two parallel reviewers (correctness + scope/design) flagged: a Retina DPI bug (point coords vs. physical pixels), `consumedCmdClickPath` desync if mouseUp is missed, drag forwarding without a matching press, and a regex over-match for `.md.bak`. All addressed in this PR. Lower-priority items deferred and noted in code: `:42` line-ref form, bare relative paths, wide CJK in surrounding text.
- The intercept always runs on cmd+click but only consumes the event when an `.md` path is matched — single-line non-`.md` paths and URLs continue to flow through libghostty's existing handler.

## Validation
- Validated in a sandboxed macOS VM via cua/lume.
- 13 new unit tests in `CmdClickPathResolverTests` cover: head/tail/middle of wrap, markdown link form `[..](path.md)`, multiple paths on the same line, no-match, `.md.bak` (must NOT match), `path.md:42` (matches `path.md` and stops at `:`), period-after-`.md` (intentional non-match — trade-off for the `.bak` block), partial-trailing-row chunk math, dot-relative and parent-relative roots, zero-cols guard.
- Full host check: 719 tests pass via `make check`.
- VM run: build (108s), Nex.app launched, long path written to disk, `nex pane send` printed it via the calling pane, `nex pane capture` confirmed the wrapped path is rendered as a single logical line in the viewport text. Manual gate: cmd+click on first/last/middle rows of the wrapped path opens the markdown pane; cmd+click on a single-line `.md` regression check still works.
- Screenshots: \`/Users/ben/code/cua/out/branches/issue-107-cmdclick-wrapped-path/issue-107/\`

## Test plan
- [ ] Open Nex on a non-Retina monitor, narrow a terminal pane, `printf` a long absolute markdown path so it wraps. Cmd+click on each row of the wrap, confirm the same markdown file opens for each.
- [ ] Repeat on a Retina display (DPI scaling fix).
- [ ] Regression: cmd+click on a single-line absolute path still opens.
- [ ] Regression: cmd+click on a URL still opens in the browser (libghostty path).
- [ ] Regression: cmd+click on a non-`.md` file path falls through to libghostty's default handler.
- [ ] Verify dragging after a normal (non-cmd) mouseDown still works (selection, scrollback drag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)