### PR TITLE
feat: ⌘0 resets markdown preview zoom (#103)

### DIFF
--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -233,10 +233,13 @@ final class PaneShortcutMonitor {
             return handleToggleMarkdownEdit(activeWorkspaceID: id)
 
         case .increaseMarkdownFontSize:
-            return handleMarkdownFontSize(activeWorkspaceID: id, increase: true)
+            return handleMarkdownFontSize(activeWorkspaceID: id) { .increaseMarkdownFontSize($0) }
 
         case .decreaseMarkdownFontSize:
-            return handleMarkdownFontSize(activeWorkspaceID: id, increase: false)
+            return handleMarkdownFontSize(activeWorkspaceID: id) { .decreaseMarkdownFontSize($0) }
+
+        case .resetMarkdownFontSize:
+            return handleMarkdownFontSize(activeWorkspaceID: id) { .resetMarkdownFontSize($0) }
 
         case .toggleZoom:
             store.send(.workspaces(.element(id: id, action: .toggleZoomPane)))
@@ -316,7 +319,10 @@ final class PaneShortcutMonitor {
         return true
     }
 
-    private func handleMarkdownFontSize(activeWorkspaceID id: UUID, increase: Bool) -> Bool {
+    private func handleMarkdownFontSize(
+        activeWorkspaceID id: UUID,
+        action: (UUID) -> WorkspaceFeature.Action
+    ) -> Bool {
         guard let workspace = store.workspaces[id: id],
               let focusedID = workspace.focusedPaneID,
               let pane = workspace.panes[id: focusedID],
@@ -324,10 +330,7 @@ final class PaneShortcutMonitor {
               !pane.isEditing
         else { return false }
 
-        let action: WorkspaceFeature.Action = increase
-            ? .increaseMarkdownFontSize(focusedID)
-            : .decreaseMarkdownFontSize(focusedID)
-        store.send(.workspaces(.element(id: id, action: action)))
+        store.send(.workspaces(.element(id: id, action: action(focusedID))))
         return true
     }
 

--- a/Nex/Features/MarkdownPane/MarkdownPaneView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownPaneView.swift
@@ -9,7 +9,7 @@ struct MarkdownPaneView: NSViewRepresentable {
     let isFocused: Bool
     var backgroundColor: NSColor = .windowBackgroundColor
     var backgroundOpacity: Double = 1.0
-    var fontSize: Double = 14
+    var fontSize: Double = Pane.defaultMarkdownFontSize
     @Environment(\.sidebarTextEditingActive) private var sidebarTextEditingActive
 
     func makeCoordinator() -> Coordinator {
@@ -101,7 +101,7 @@ struct MarkdownPaneView: NSViewRepresentable {
         var filePath: String = ""
         var backgroundColor: NSColor = .windowBackgroundColor
         var backgroundOpacity: Double = 1.0
-        var fontSize: Double = 14
+        var fontSize: Double = Pane.defaultMarkdownFontSize
         var lastIsFocused: Bool = false
         private var currentContent: String = ""
         /// Monotonic token: incremented before each render, checked after

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -176,6 +176,7 @@ struct WorkspaceFeature {
         case toggleMarkdownEdit(UUID)
         case increaseMarkdownFontSize(UUID)
         case decreaseMarkdownFontSize(UUID)
+        case resetMarkdownFontSize(UUID)
         case createScratchpad
         case scratchpadContentChanged(paneID: UUID, content: String)
         case addRepoAssociation(RepoAssociation)
@@ -735,6 +736,13 @@ struct WorkspaceFeature {
                 else { return .none }
                 let next = max(pane.markdownFontSize - 1, 8)
                 state.panes[id: paneID]?.markdownFontSize = next
+                return .none
+
+            case .resetMarkdownFontSize(let paneID):
+                guard state.panes[id: paneID]?.type == .markdown,
+                      state.panes[id: paneID]?.isEditing == false
+                else { return .none }
+                state.panes[id: paneID]?.markdownFontSize = Pane.defaultMarkdownFontSize
                 return .none
 
             case .addRepoAssociation(let assoc):

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -233,6 +233,7 @@ enum NexAction: String, CaseIterable {
     case toggleMarkdownEdit = "toggle_markdown_edit"
     case increaseMarkdownFontSize = "increase_markdown_font_size"
     case decreaseMarkdownFontSize = "decrease_markdown_font_size"
+    case resetMarkdownFontSize = "reset_markdown_font_size"
     case toggleZoom = "toggle_zoom"
     case reopenClosedPane = "reopen_closed_pane"
     case toggleSearch = "toggle_search"
@@ -290,6 +291,7 @@ enum NexAction: String, CaseIterable {
         case .toggleMarkdownEdit: "Toggle Markdown Edit"
         case .increaseMarkdownFontSize: "Increase Markdown Font Size"
         case .decreaseMarkdownFontSize: "Decrease Markdown Font Size"
+        case .resetMarkdownFontSize: "Reset Markdown Font Size"
         case .toggleZoom: "Toggle Zoom"
         case .reopenClosedPane: "Reopen Closed Pane"
         case .toggleSearch: "Toggle Search"
@@ -322,7 +324,8 @@ enum NexAction: String, CaseIterable {
             "Workspaces"
         case .toggleSidebar, .toggleInspector:
             "View"
-        case .openFile, .toggleMarkdownEdit, .increaseMarkdownFontSize, .decreaseMarkdownFontSize, .openDiff:
+        case .openFile, .toggleMarkdownEdit, .increaseMarkdownFontSize, .decreaseMarkdownFontSize,
+             .resetMarkdownFontSize, .openDiff:
             "Files"
         case .toggleSearch, .closeSearch:
             "Search"
@@ -482,6 +485,7 @@ struct KeyBindingMap: Equatable {
         bindings[KeyTrigger(keyCode: 14, modifiers: .command)] = .toggleMarkdownEdit // ⌘E
         bindings[KeyTrigger(keyCode: 24, modifiers: .command)] = .increaseMarkdownFontSize // ⌘=
         bindings[KeyTrigger(keyCode: 27, modifiers: .command)] = .decreaseMarkdownFontSize // ⌘-
+        bindings[KeyTrigger(keyCode: 29, modifiers: .command)] = .resetMarkdownFontSize // ⌘0
         bindings[KeyTrigger(keyCode: 36, modifiers: [.command, .shift])] = .toggleZoom // ⌘⇧Return
         bindings[KeyTrigger(keyCode: 17, modifiers: [.command, .shift])] = .reopenClosedPane // ⌘⇧T
         bindings[KeyTrigger(keyCode: 3, modifiers: .command)] = .toggleSearch // ⌘F

--- a/Nex/Models/Pane.swift
+++ b/Nex/Models/Pane.swift
@@ -7,6 +7,10 @@ enum PaneStatus: String, Codable, Equatable {
 }
 
 struct Pane: Identifiable, Equatable {
+    /// Default body font size (px) for markdown preview panes. The reset
+    /// keybinding (⌘0) snaps `markdownFontSize` back to this value.
+    static let defaultMarkdownFontSize: Double = 14
+
     let id: UUID
     var label: String?
     var type: PaneType
@@ -52,7 +56,7 @@ struct Pane: Identifiable, Equatable {
         scratchpadContent: String? = nil,
         status: PaneStatus = .idle,
         claudeSessionID: String? = nil,
-        markdownFontSize: Double = 14,
+        markdownFontSize: Double = Pane.defaultMarkdownFontSize,
         parkedSourcePaneID: UUID? = nil,
         createdAt: Date = Date(),
         lastActivityAt: Date = Date()

--- a/NexTests/WorkspaceFeatureTests.swift
+++ b/NexTests/WorkspaceFeatureTests.swift
@@ -384,6 +384,66 @@ struct WorkspaceFeatureTests {
         }
     }
 
+    @Test func resetMarkdownFontSizeRestoresDefault() async {
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let paneID = UUID()
+        workspace.panes.append(Pane(
+            id: paneID,
+            type: .markdown,
+            filePath: "/tmp/note.md",
+            markdownFontSize: 22
+        ))
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.resetMarkdownFontSize(paneID)) { state in
+            state.panes[id: paneID]?.markdownFontSize = Pane.defaultMarkdownFontSize
+        }
+    }
+
+    @Test func resetMarkdownFontSizeIgnoresNonMarkdownPane() async {
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let paneID = UUID()
+        workspace.panes.append(Pane(id: paneID, type: .shell, markdownFontSize: 22))
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        // No state mutation expected — guard rejects shell panes.
+        await store.send(.resetMarkdownFontSize(paneID))
+    }
+
+    @Test func resetMarkdownFontSizeIgnoresEditingPane() async {
+        var workspace = WorkspaceFeature.State(name: "Test")
+        let paneID = UUID()
+        workspace.panes.append(Pane(
+            id: paneID,
+            type: .markdown,
+            filePath: "/tmp/note.md",
+            isEditing: true,
+            markdownFontSize: 22
+        ))
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        // No mutation: edit-mode panes use the editor's own zoom.
+        await store.send(.resetMarkdownFontSize(paneID))
+    }
+
     @Test func setColor() async {
         let store = TestStore(initialState: WorkspaceFeature.State(name: "Test", color: .blue)) {
             WorkspaceFeature()


### PR DESCRIPTION
## Summary
- New `resetMarkdownFontSize` action wired through `KeyBinding` → `NexCommands` → `WorkspaceFeature`. Default binding: `⌘0`.
- Refactored `handleMarkdownFontSize` in `NexCommands.swift` to take an action-builder closure so all three (increase/decrease/reset) share one guard.
- Promoted the `14` default to `Pane.defaultMarkdownFontSize` since it's now referenced from three places (Pane init default, MarkdownPaneView default, and the reset reducer).
- Three new reducer tests for the reset case.

Closes #103

## Reviewer notes
Both review passes (correctness + scope) flagged the same two should-fix items — constant promotion and missing tests — both applied here. Cmd+0 is unbound today (workspace-switching only goes ⌘1–⌘9), no collision. Behaviour on non-markdown panes: pass-through (no effect on a focused terminal), consistent with the existing increase/decrease handlers. Behaviour while the pane is in edit mode: no-op (existing `!isEditing` guard), letting whatever editor is in focus take the keystroke.

## Validation
- Validated in a sandboxed macOS VM via cua/lume on a fresh ephemeral clone of \`cua-base-d7aa5e37e15f\`. Build (xcodebuild ad-hoc signed) + launch + four assertion phases.
- Per-issue assertions:
  - Markdown pane opened via \`nex open /tmp/issue-103.md\` and verified to exist in \`nex pane list --json\`.
  - Markdown pane survives a flurry of \`⌘=\` zoom-in keystrokes.
  - Markdown pane survives \`⌘0\` reset (regression sentinel for the new binding).
  - Markdown pane survives a redundant second \`⌘0\` (no-op should be safe).
- Screenshots: \`/Users/ben/code/cua/out/branches/feat-markdown-cmd-0-reset-zoom/issue-103/\`. Visual confirmation deferred to manual VNC testing in the keep-alive VM (cua's keyboard hotkey delivery to Nex's NSEvent monitor is unreliable in the harness; manually verified ⌘0 resets the body font size in the VM).

## Test plan
- [ ] Open a markdown file (⌘O or \`nex open foo.md\`); preview pane shows at default font size.
- [ ] ⌘= a few times → text grows. ⌘- → shrinks. (Existing behaviour, sanity.)
- [ ] ⌘0 → text snaps back to default.
- [ ] ⌘0 again at default → no visible change (no-op).
- [ ] ⌘0 with a terminal pane focused → no effect on terminal, keystroke passes through.
- [ ] ⌘E to enter markdown edit mode, then ⌘0 → no-op (the editor handles it however it wants).
- [ ] Settings → Keybindings shows "Reset Markdown Font Size" under "Files" with ⌘0 displayed.