### PR TITLE
feat: scope cmd+P picker via w:/p: query prefixes

### DIFF
--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -145,11 +145,20 @@ struct AppReducer {
             }
 
             if commandPaletteQuery.isEmpty { return items }
-            let terms = commandPaletteQuery.lowercased()
-                .split(separator: " ")
-                .filter { !$0.isEmpty }
-            guard !terms.isEmpty else { return items }
-            return items.filter { item in
+            var query = Substring(commandPaletteQuery.lowercased()).drop(while: \.isWhitespace)
+            let scopedItems: [CommandPaletteItem]
+            if query.hasPrefix("w:") {
+                query = query.dropFirst(2)
+                scopedItems = items.filter { $0.paneID == nil }
+            } else if query.hasPrefix("p:") {
+                query = query.dropFirst(2)
+                scopedItems = items.filter { $0.paneID != nil }
+            } else {
+                scopedItems = items
+            }
+            let terms = query.split(separator: " ").filter { !$0.isEmpty }
+            guard !terms.isEmpty else { return scopedItems }
+            return scopedItems.filter { item in
                 let searchable = (item.title + " " + item.subtitle + " " + item.workspaceName).lowercased()
                 return terms.allSatisfy { searchable.contains($0) }
             }

--- a/NexTests/CommandPaletteTests.swift
+++ b/NexTests/CommandPaletteTests.swift
@@ -229,6 +229,131 @@ struct CommandPaletteTests {
         #expect(state.commandPaletteItems.count == 2) // 1 workspace + 1 pane
     }
 
+    // MARK: - Scope Prefixes (w: / p:)
+
+    /// Fixture where a pane label collides with the workspace name term so
+    /// scope tests can prove cross-scope exclusion (i.e. `w:loy` returns the
+    /// "Loyalty" workspace and NOT the pane labeled "loyal-server").
+    private static func collidingNameWorkspaces() -> [WorkspaceFeature.State] {
+        let pane1 = Pane(id: Self.paneID1, label: "loyal-server", workingDirectory: "/tmp")
+        let pane2 = Pane(id: Self.paneID2, label: "client", workingDirectory: "/tmp")
+        let pane3 = Pane(id: Self.paneID3, label: "default-shell", workingDirectory: "/tmp")
+        let ws1 = makeWorkspace(
+            id: Self.wsID1, name: "Loyalty",
+            panes: [pane1, pane2],
+            layout: .split(.horizontal, ratio: 0.5,
+                           first: .leaf(Self.paneID1), second: .leaf(Self.paneID2))
+        )
+        let ws2 = makeWorkspace(
+            id: Self.wsID2, name: "Default",
+            panes: [pane3], layout: .leaf(Self.paneID3)
+        )
+        return [ws1, ws2]
+    }
+
+    @Test func workspacePrefixScopesToWorkspacesOnly() {
+        var state = AppReducer.State()
+        state.workspaces = IdentifiedArray(uniqueElements: Self.collidingNameWorkspaces())
+        state.commandPaletteQuery = "w:"
+
+        let items = state.commandPaletteItems
+        #expect(items.count == 2)
+        #expect(items.allSatisfy { $0.paneID == nil })
+    }
+
+    @Test func workspacePrefixWithTermExcludesMatchingPanes() {
+        // Without the scope, "loy" matches both the "Loyalty" workspace AND
+        // the pane "loyal-server" (and arguably "client" via workspaceName).
+        // The `w:` prefix must drop everything but the workspace.
+        var state = AppReducer.State()
+        state.workspaces = IdentifiedArray(uniqueElements: Self.collidingNameWorkspaces())
+
+        // Sanity: bare term matches both kinds.
+        state.commandPaletteQuery = "loy"
+        #expect(state.commandPaletteItems.contains { $0.paneID == Self.paneID1 })
+
+        // With the prefix, only the workspace remains.
+        state.commandPaletteQuery = "w:loy"
+        let items = state.commandPaletteItems
+        #expect(items.count == 1)
+        #expect(items[0].paneID == nil)
+        #expect(items[0].workspaceID == Self.wsID1)
+    }
+
+    @Test func panePrefixScopesToPanesOnly() {
+        var state = AppReducer.State()
+        state.workspaces = IdentifiedArray(uniqueElements: Self.collidingNameWorkspaces())
+        state.commandPaletteQuery = "p:"
+
+        let items = state.commandPaletteItems
+        #expect(items.count == 3)
+        #expect(items.allSatisfy { $0.paneID != nil })
+    }
+
+    @Test func panePrefixWithTermExcludesMatchingWorkspaces() {
+        // Without the scope, "default" matches the "Default" workspace AND
+        // the pane "default-shell". The `p:` prefix must drop the workspace.
+        var state = AppReducer.State()
+        state.workspaces = IdentifiedArray(uniqueElements: Self.collidingNameWorkspaces())
+
+        state.commandPaletteQuery = "default"
+        #expect(state.commandPaletteItems.contains { $0.paneID == nil && $0.workspaceID == Self.wsID2 })
+
+        state.commandPaletteQuery = "p:default"
+        let items = state.commandPaletteItems
+        #expect(items.count == 1)
+        #expect(items[0].paneID == Self.paneID3)
+    }
+
+    @Test func prefixIsCaseInsensitive() {
+        var state = AppReducer.State()
+        state.workspaces = IdentifiedArray(uniqueElements: Self.collidingNameWorkspaces())
+        state.commandPaletteQuery = "W:LOY"
+
+        let items = state.commandPaletteItems
+        #expect(items.count == 1)
+        #expect(items[0].workspaceID == Self.wsID1)
+    }
+
+    @Test func prefixToleratesLeadingWhitespace() {
+        // Pasted queries or accidental leading spaces should still trigger
+        // the prefix, since the user clearly meant the scope.
+        var state = AppReducer.State()
+        state.workspaces = IdentifiedArray(uniqueElements: Self.collidingNameWorkspaces())
+        state.commandPaletteQuery = "  w:loy"
+
+        let items = state.commandPaletteItems
+        #expect(items.count == 1)
+        #expect(items[0].paneID == nil)
+        #expect(items[0].workspaceID == Self.wsID1)
+    }
+
+    @Test func prefixWithTrailingWhitespaceReturnsScopedAll() {
+        var state = AppReducer.State()
+        state.workspaces = IdentifiedArray(uniqueElements: Self.collidingNameWorkspaces())
+        state.commandPaletteQuery = "w:   "
+
+        let items = state.commandPaletteItems
+        #expect(items.count == 2)
+        #expect(items.allSatisfy { $0.paneID == nil })
+    }
+
+    @Test func prefixDoesNotApplyMidQuery() {
+        // The literal string "w:" appearing mid-query is not a prefix.
+        let pane1 = Pane(id: Self.paneID1, label: "w:report", workingDirectory: "/tmp")
+        let ws = Self.makeWorkspace(
+            id: Self.wsID1, name: "Dev",
+            panes: [pane1], layout: .leaf(Self.paneID1)
+        )
+
+        var state = AppReducer.State()
+        state.workspaces = [ws]
+        state.commandPaletteQuery = "report w:"
+        let items = state.commandPaletteItems
+        #expect(items.count == 1)
+        #expect(items[0].paneID == Self.paneID1)
+    }
+
     // MARK: - Navigation
 
     @Test func selectNextClampsToEnd() async {


### PR DESCRIPTION
## Summary
- Typing `w:` in the cmd+P picker scopes the list to workspaces only; `p:` scopes to panes only. Anything after the prefix runs through the existing multi-term substring matcher (e.g. `w:loy` returns just the Loyalty workspace).
- Leading whitespace before the prefix is tolerated, so a paste with a stray space still triggers the scope.
- The prefix is only recognised at the start of the query; mid-query `w:` falls through to plain substring matching.

Closes #106

## Reviewer notes
- I implemented both `w:` and `p:` even though the issue mainly asked for `w:`. The author flagged `p:` as a "natural extension" and you confirmed Both via the planning prompt. Cost was a few lines and three more tests; symmetric design.
- The placeholder text in `CommandPaletteView.swift` ("Jump to workspace or pane...") was left unchanged. The scope reviewer flagged this as a discoverability gap (the feature is invisible unless documented) but it was out of scope for this issue. Worth a follow-up ticket if discoverability matters.
- Multi-agent review used two parallel `Agent` subagents (general-purpose for correctness, Plan for scope/edge cases) because `nex pane list --json` returned the v0.20+ upgrade-required message and the worker-pane fan-out wasn't available. Codex was not run. Reviews are saved at `.nex-tasks/` / `.nex-results/`.

## Validation
- Unit tests: 8 new cases in `NexTests/CommandPaletteTests.swift` covering scope-only, scope-plus-term cross-exclusion, case-insensitivity, leading and trailing whitespace, and mid-query non-prefix. All 733 tests pass via `make test`.
- Sandboxed macOS VM (cua/lume): built Nex.app from this branch in a fresh VM, created Default + Loyalty + Reports workspaces via the bundled `nex` CLI, opened the picker with cmd+P, and captured screenshots of each prefix state.
  - `04_w_prefix.png` shows only workspace rows (gray "workspace" tag) when `w:` is typed.
  - `05_w_loy.png` shows only the Loyalty row when narrowed to `w:loy`.
  - `06_p_prefix.png` shows only pane rows (each tagged with their workspace colour) when `p:` is typed.
  - Pane set was preserved before / during / after palette interactions.
- Screenshots: `/Users/ben/code/cua/out/branches/feat-command-palette-prefix-filter/issue-106/`
- Validator script: `/Users/ben/code/cua/validate_issue_106.py` (one assertion at TEST 5 hit a cua key-name bug; fixed in the script for next time, but the substantive screenshots were all captured pre-failure and the post-escape state was verified manually in the VM).

## Test plan
- [x] Open cmd+P with multiple workspaces and panes loaded; type \`w:\` and confirm only workspace rows are shown.
- [x] Type \`w:\` then narrow with a fragment of a workspace name; confirm fuzzy substring match still applies.
- [x] Type \`p:\` and confirm only pane rows are shown.
- [x] Type \`p:\` then narrow with a fragment of a pane label / title / path.
- [x] Type \`W:LOY\` (uppercase) and confirm case-insensitive prefix.
- [x] Type \` w:loy\` (with a leading space) and confirm leading whitespace is tolerated.
- [x] Type a query with \`w:\` mid-string (e.g. \`report w:\`) and confirm it falls through to substring matching, not prefix scoping.
- [x] Confirm an empty query still shows everything (no regression).
- [x] Confirm escape still dismisses the picker cleanly.