### PR TITLE
fix: apply macOS Spaces binding at launch (#102)

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		DA4AC555E9C3FC84061F2FB9 /* PaneFocusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD9BCE4ABC267C7E34EAF09 /* PaneFocusView.swift */; };
 		DBBD0CD88C3B7EF588D5CB04 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0153509BA13BB205C40DE2D5 /* GitService.swift */; };
 		DC11308E0E92225F551CF162 /* AutoDetectRepoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBC4A3F4B30336A12D32DF4 /* AutoDetectRepoTests.swift */; };
+		DDD05A3B3A535DEA66485A47 /* WindowSpacesBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D09D767C96B3F96E4DF7C5 /* WindowSpacesBindingTests.swift */; };
 		DE4BB209669A230B465E2722 /* WorkspaceFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA19A5A6562DDB77C0AE44B6 /* WorkspaceFeatureTests.swift */; };
 		E02D1D3DE36CC8F66B5072AB /* GroupIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C5539104EFEFA5CCB936F1 /* GroupIcon.swift */; };
 		E0ABD2D68012C6BF24A92E7D /* KeybindingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D45D65A66C475B0CEEC53C /* KeybindingService.swift */; };
@@ -119,6 +120,7 @@
 		ECA2C078504EB9BF0E04B343 /* GhosttyConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AD7A8D7E6592B90FBB7D24 /* GhosttyConfig.swift */; };
 		ED79F70009D8C2A4A1A742F8 /* ResizeDimensionsOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6F950849E47A0BCC6DEAB5 /* ResizeDimensionsOverlay.swift */; };
 		EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */; };
+		EDF35E86B633BB1E8C3DE844 /* WindowSpacesBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */; };
 		EFDCA64CD227A833D2801893 /* CLIInstallService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EC869803E36C99B3653FF5 /* CLIInstallService.swift */; };
 		F01CDB667AE2A0CF2A825AD3 /* WorkspaceDropTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C66D4D59D04F6372D8AD7 /* WorkspaceDropTargetTests.swift */; };
 		F1139F84E35AF1181F136C9D /* KeyBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF3FB912BD029F17AF0AA25 /* KeyBinding.swift */; };
@@ -213,6 +215,7 @@
 		933D5B5E664E30B2E88EE3C7 /* WorkspaceGroupPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupPersistenceTests.swift; sourceTree = "<group>"; };
 		93D45D65A66C475B0CEEC53C /* KeybindingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingService.swift; sourceTree = "<group>"; };
 		94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceView.swift; sourceTree = "<group>"; };
+		94D09D767C96B3F96E4DF7C5 /* WindowSpacesBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowSpacesBindingTests.swift; sourceTree = "<group>"; };
 		96AD7A8D7E6592B90FBB7D24 /* GhosttyConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfig.swift; sourceTree = "<group>"; };
 		9D96CD47FF756C95404DF4F6 /* Pane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pane.swift; sourceTree = "<group>"; };
 		A11F5427AE75515696FB8295 /* PaneLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutTests.swift; sourceTree = "<group>"; };
@@ -252,6 +255,7 @@
 		E08D39F8F87D7505CD32D25D /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		E5859C5B2E1850D1262AFE4B /* Nex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nex.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5A4C5D8F4C099C65A7EA890 /* ScratchpadEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadEditorView.swift; sourceTree = "<group>"; };
+		E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowSpacesBinding.swift; sourceTree = "<group>"; };
 		E9F7D5571F89D43BC6C76928 /* WorkspaceGroupSocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupSocketTests.swift; sourceTree = "<group>"; };
 		EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpDataTests.swift; sourceTree = "<group>"; };
 		EA19A5A6562DDB77C0AE44B6 /* WorkspaceFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFeatureTests.swift; sourceTree = "<group>"; };
@@ -378,6 +382,7 @@
 				1C625959E287CE9896D5BA4D /* RepoRegistryTests.swift */,
 				ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */,
 				AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */,
+				94D09D767C96B3F96E4DF7C5 /* WindowSpacesBindingTests.swift */,
 				28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */,
 				E01C66D4D59D04F6372D8AD7 /* WorkspaceDropTargetTests.swift */,
 				EA19A5A6562DDB77C0AE44B6 /* WorkspaceFeatureTests.swift */,
@@ -482,6 +487,7 @@
 				42A24C1FEC6EA31096603326 /* SurfaceManager.swift */,
 				C711FF0D53387D16F50C5EA6 /* UpdaterService.swift */,
 				8C693AF419763177AE1CEA0F /* UserDefaultsClient.swift */,
+				E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -728,6 +734,7 @@
 				B5B3A5F0C2FA6509D37FA74A /* RepoRegistryTests.swift in Sources */,
 				EAF43DC55C5612F3AE83BF02 /* SettingsFeatureTests.swift in Sources */,
 				2B4533964D77117EE6D98690 /* SocketParsingTests.swift in Sources */,
+				DDD05A3B3A535DEA66485A47 /* WindowSpacesBindingTests.swift in Sources */,
 				5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */,
 				F01CDB667AE2A0CF2A825AD3 /* WorkspaceDropTargetTests.swift in Sources */,
 				DE4BB209669A230B465E2722 /* WorkspaceFeatureTests.swift in Sources */,
@@ -812,6 +819,7 @@
 				B8DCB316773E208FABEDA9D7 /* UpdaterService.swift in Sources */,
 				A8F1A82072120476BAEC2D52 /* UserDefaultsClient.swift in Sources */,
 				B167B81282ADF716B21B1679 /* VibrancyView.swift in Sources */,
+				EDF35E86B633BB1E8C3DE844 /* WindowSpacesBinding.swift in Sources */,
 				4AF9CB9A4E7CE871FBE1A6F2 /* WorkspaceColor.swift in Sources */,
 				B4846A1AC5C67E51AFA9C846 /* WorkspaceDropTarget.swift in Sources */,
 				E62618BAC6927017CC4ECC44 /* WorkspaceFeature.swift in Sources */,

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -28,6 +28,7 @@ struct NexApp: App {
                 .environment(\.surfaceManager, SurfaceManager.liveValue)
                 .environment(\.socketServer, SocketServer.liveValue)
                 .environment(\.ghosttyConfig, .liveValue)
+                .background(SpacesBindingAttacher())
                 .frame(minWidth: 600, minHeight: 400)
                 .onAppear {
                     guard !Self.isTestMode else { return }
@@ -123,5 +124,38 @@ struct NexApp: App {
         }
         .windowResizability(.contentSize)
         .defaultPosition(.center)
+    }
+}
+
+/// Attaches the user's macOS Dock Spaces binding to the main window
+/// (issue #102). SwiftUI's WindowGroup creates the window early, before
+/// WindowServer applies the per-bundle binding after a system restart;
+/// reading it from `com.apple.spaces` and applying it ourselves makes
+/// "Assign To: All Desktops" survive reboots.
+///
+/// The hosting view's `viewDidMoveToWindow` is the only deterministic
+/// hook for "this view is now parented in a real NSWindow". `.onAppear`
+/// fires later and `makeNSView` fires earlier (when `view.window` is
+/// still nil). Each WindowGroup instance gets its own attacher, which
+/// is the right behaviour if SwiftUI ever opens multiple main windows.
+private struct SpacesBindingAttacher: NSViewRepresentable {
+    func makeNSView(context _: Context) -> SpacesBindingView {
+        SpacesBindingView()
+    }
+
+    func updateNSView(_: SpacesBindingView, context _: Context) {
+        // No-op: SpacesBindingView applies the binding once in
+        // viewDidMoveToWindow. Re-renders are intentionally ignored.
+    }
+}
+
+private final class SpacesBindingView: NSView {
+    private var didApply = false
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard !didApply, let window else { return }
+        didApply = true
+        WindowSpacesBinding.applyIfNeeded(to: window)
     }
 }

--- a/Nex/Services/WindowSpacesBinding.swift
+++ b/Nex/Services/WindowSpacesBinding.swift
@@ -1,0 +1,94 @@
+import AppKit
+import os.log
+
+/// Workaround for a SwiftUI WindowGroup quirk: after a system restart,
+/// macOS's per-bundle Spaces binding ("Assign To: All Desktops" via the
+/// Dock context menu) isn't reliably applied to the SwiftUI-managed
+/// window before it's first shown (issue #102). The window appears on
+/// only one desktop until the user toggles the Dock setting off and
+/// back on, which causes the Dock to re-push the binding to
+/// WindowServer.
+///
+/// We mirror what AppKit does for non-SwiftUI apps: read the user's
+/// per-bundle assignment from `com.apple.spaces` defaults and
+/// explicitly add `.canJoinAllSpaces` to the window's
+/// `collectionBehavior` when the user picked "All Desktops". Native
+/// AppKit apps only consult this binding at window creation, so we
+/// match that semantics — runtime changes to the Dock setting are
+/// still handled by the OS.
+///
+/// The `app-bindings` key in `com.apple.spaces` is undocumented Apple
+/// plumbing. If Apple changes the format, this helper silently no-ops
+/// (back to the bug it works around — not worse). The os_log line
+/// when bindings is non-empty but our bundle is absent is the only
+/// practical signal that the format has shifted.
+enum WindowSpacesBinding {
+    private static let log = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.benfriebe.nex",
+        category: "WindowSpacesBinding"
+    )
+
+    @MainActor
+    static func applyIfNeeded(to window: NSWindow) {
+        guard let bundleID = Bundle.main.bundleIdentifier else { return }
+        let bindings = systemAppBindings()
+        if isAssignedToAllDesktops(bundleID: bundleID, bindings: bindings) {
+            // Idempotent: insert is a no-op if .canJoinAllSpaces is already
+            // set (CollectionBehavior is an OptionSet).
+            window.collectionBehavior.insert(.canJoinAllSpaces)
+            os_log(
+                .info,
+                log: log,
+                "applied .canJoinAllSpaces from com.apple.spaces (bundle=%{public}@)",
+                bundleID
+            )
+        } else if !bindings.isEmpty {
+            // Surfaced at .info (not .debug) so it shows in Console.app
+            // by default. This is the canary that the plist format has
+            // shifted under us (Apple changed the entry shape and our
+            // matcher no longer recognises the user's binding).
+            os_log(
+                .info,
+                log: log,
+                "no all-desktops binding for %{public}@ in %d entries",
+                bundleID,
+                bindings.count
+            )
+        }
+    }
+
+    /// Pure parsing logic. The Dock writes one entry per bound app to
+    /// the `app-bindings` array. Observed entry shapes:
+    ///   - `<bundle-id>`                          — All Desktops
+    ///   - `<bundle-id> space:<UUID>`             — A specific desktop
+    ///   - `<bundle-id> display:<UUID>`           — All Desktops + this display
+    ///   - `<bundle-id> space:<UUID> display:...` — A specific desktop on this display
+    /// Apps not in the array have no per-app binding (system default).
+    ///
+    /// "All desktops" is true for the bare bundle ID and for the
+    /// display-only suffix (the user picked "All Desktops" alongside a
+    /// monitor pin). It's false when a `space:` segment is present.
+    ///
+    /// Exact-prefix matching is load-bearing. A different bundle ID like
+    /// `com.foo.helper` must not match when our bundle ID `com.foo` is
+    /// a string-prefix of it; we always require either an exact match or
+    /// a separator (space) before the suffix. Do not weaken to
+    /// `contains(where:)` substring checks.
+    static func isAssignedToAllDesktops(bundleID: String, bindings: [String]) -> Bool {
+        let displayOnlyPrefix = bundleID + " display:"
+        for entry in bindings {
+            if entry == bundleID { return true }
+            if entry.hasPrefix(displayOnlyPrefix), !entry.contains("space:") {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func systemAppBindings() -> [String] {
+        guard let defaults = UserDefaults(suiteName: "com.apple.spaces"),
+              let raw = defaults.array(forKey: "app-bindings") as? [String]
+        else { return [] }
+        return raw
+    }
+}

--- a/NexTests/WindowSpacesBindingTests.swift
+++ b/NexTests/WindowSpacesBindingTests.swift
@@ -1,0 +1,88 @@
+@testable import Nex
+import Testing
+
+struct WindowSpacesBindingTests {
+    private let bundleID = "com.benfriebe.nex"
+
+    @Test func emptyBindingsReturnsFalse() {
+        #expect(!WindowSpacesBinding.isAssignedToAllDesktops(
+            bundleID: bundleID,
+            bindings: []
+        ))
+    }
+
+    @Test func bundleAbsentReturnsFalse() {
+        #expect(!WindowSpacesBinding.isAssignedToAllDesktops(
+            bundleID: bundleID,
+            bindings: ["com.apple.dock", "com.example.other"]
+        ))
+    }
+
+    @Test func exactBundleMatchReturnsTrue() {
+        #expect(WindowSpacesBinding.isAssignedToAllDesktops(
+            bundleID: bundleID,
+            bindings: [bundleID]
+        ))
+    }
+
+    @Test func bundleWithSpaceSuffixReturnsFalse() {
+        #expect(!WindowSpacesBinding.isAssignedToAllDesktops(
+            bundleID: bundleID,
+            bindings: ["\(bundleID) space:11111111-2222-3333-4444-555555555555"]
+        ))
+    }
+
+    @Test func bundleWithDisplayOnlySuffixReturnsTrue() {
+        // "<bundle> display:UUID" with no space: segment means the user
+        // picked "All Desktops" alongside a monitor pin. Still all
+        // desktops semantically, so we should apply .canJoinAllSpaces.
+        #expect(WindowSpacesBinding.isAssignedToAllDesktops(
+            bundleID: bundleID,
+            bindings: ["\(bundleID) display:abcdef01-2345-6789-abcd-ef0123456789"]
+        ))
+    }
+
+    @Test func bundleWithCombinedSuffixReturnsFalse() {
+        #expect(!WindowSpacesBinding.isAssignedToAllDesktops(
+            bundleID: bundleID,
+            bindings: ["\(bundleID) space:aaa display:bbb"]
+        ))
+    }
+
+    @Test func longerBundleStringPrefixDoesNotMatch() {
+        // Regression guard: a different bundle ID like "<our>.helper"
+        // must not match. The matcher requires either an exact match
+        // or a space separator before any suffix; do not weaken to
+        // substring checks.
+        #expect(!WindowSpacesBinding.isAssignedToAllDesktops(
+            bundleID: bundleID,
+            bindings: [
+                "\(bundleID).helper",
+                "\(bundleID).helper display:abc"
+            ]
+        ))
+    }
+
+    @Test func mixedEntriesWithOurBundlePresentReturnsTrue() {
+        #expect(WindowSpacesBinding.isAssignedToAllDesktops(
+            bundleID: bundleID,
+            bindings: [
+                "com.apple.dock",
+                "com.example.other space:foo",
+                bundleID,
+                "com.example.third"
+            ]
+        ))
+    }
+
+    @Test func mixedEntriesWithOnlySuffixedOurBundleReturnsFalse() {
+        #expect(!WindowSpacesBinding.isAssignedToAllDesktops(
+            bundleID: bundleID,
+            bindings: [
+                "com.apple.dock",
+                "\(bundleID) space:foo",
+                "com.example.third"
+            ]
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- After macOS restart, "Assign To: All Desktops" set via the Dock context menu wasn't honoured for Nex's main window. The window appeared on only one desktop until the user toggled the Dock setting off and back on.
- Root cause: SwiftUI's `WindowGroup` creates the main window before WindowServer applies the per-bundle Spaces binding after a restart. SwiftUI-managed windows don't pick up the binding the way AppKit windows do.
- Fix: at first window appearance, read the user's per-bundle Spaces assignment from `com.apple.spaces` defaults and explicitly apply `.canJoinAllSpaces` to the window's `collectionBehavior` when the user picked "All Desktops". New `WindowSpacesBinding` helper, wired via a small `NSViewRepresentable` whose hosting view applies the binding in `viewDidMoveToWindow` (deterministic — no async race).

Closes #102

## Reviewer notes

Skipped from review feedback (with reasons):
- **Bundle-ID fallback string in `os_log` subsystem** — `Bundle.main.bundleIdentifier` is non-nil for an app bundle, so the fallback is effectively dead code. Left as-is for defensiveness.
- **Sandbox-aware comment** — Nex's entitlements have `app-sandbox = false` today; if that ever changes, `UserDefaults(suiteName: "com.apple.spaces")` will silently return empty and the workaround degrades to the original buggy behavior (not worse). Out of scope here.
- **Pre-existing `NSApp.windows.first` calls in `NexApp.swift:65,87`** — flagged as fragile during plan-review but pre-date this fix. The new code uses the NSViewRepresentable's hosting window directly and is unaffected.

## Validation

Validated in a sandboxed macOS VM via `cua/lume` (validator at `/Users/ben/code/cua/validate_issue_102.py`).

- **Smoke**: Nex launches cleanly, `nex pane list --json` returns the expected 1-pane workspace.
- **Helper-fired assertion**: pre-write a fake `com.apple.spaces` `app-bindings = (com.benfriebe.nex)` via `defaults write` BEFORE launching. After launch, scrape `log show` for the helper's `os_log` line and assert it contains `"applied .canJoinAllSpaces"`.
  ```
  2026-05-04 04:51:09.837  Nex  [com.benfriebe.nex:WindowSpacesBinding]
  applied .canJoinAllSpaces from com.apple.spaces (bundle=com.benfriebe.nex)
  ```
- The actual restart-then-launch cycle isn't reproducible in a fresh ephemeral VM, but the os_log entry proves the helper executed its success branch and called `window.collectionBehavior.insert(.canJoinAllSpaces)`.
- Screenshots: `/Users/ben/code/cua/out/branches/issue-102-spaces-assign-restart/issue-102/`

## Test plan

- [ ] Pull the branch, `xcodegen generate --spec project.yml`, `make check`.
- [ ] Build and launch Nex. Right-click the Dock tile → Options → Assign To → "All Desktops". Verify Nex still appears on the chosen desktop.
- [ ] Quit Nex. **Restart your Mac.** Launch Nex. Verify the window appears on all desktops (Mission Control should show it on each space) without needing the Dock toggle dance described in #102.
- [ ] Right-click the Dock tile → Options → Assign To → "This Desktop". Quit and relaunch (without restart). Verify Nex appears on only the active desktop. Confirms we don't override the user's "this desktop" choice.
- [ ] Open Settings (Cmd+,) and Help (Cmd+?) — these are separate windows that intentionally aren't bound; they should follow normal AppKit behaviour (typically: appear on the desktop where invoked).