### PR TITLE
feat: support cmd+f find in the markdown preview pane (#116)

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		550563B9BEDE841D3B7CE6B8 /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221A3B0170CFD708F3B03A84 /* Repo.swift */; };
 		5883FFD10BE73F44EA8F4A5C /* PaneSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE917FD003D3FFD196DBF77 /* PaneSearchOverlay.swift */; };
 		58B6A951A34B2ED1516194C4 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08D39F8F87D7505CD32D25D /* WebKit.framework */; };
+		58D251ED7E3B564C9BA3AD91 /* NexGhosttyDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935FE280F97CB5A1DBD31113 /* NexGhosttyDefaults.swift */; };
 		59239C7AD0D26E390C647C46 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 98CF017F4F26916F63300A33 /* Yams */; };
 		5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */; };
 		62564D224FD57BC3C02100EA /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191E820170ADF2ADB58B8079 /* GitServiceTests.swift */; };
@@ -215,6 +216,7 @@
 		8C693AF419763177AE1CEA0F /* UserDefaultsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsClient.swift; sourceTree = "<group>"; };
 		92E85EE83A315989753EADF1 /* DiffHTMLRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffHTMLRenderer.swift; sourceTree = "<group>"; };
 		933D5B5E664E30B2E88EE3C7 /* WorkspaceGroupPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupPersistenceTests.swift; sourceTree = "<group>"; };
+		935FE280F97CB5A1DBD31113 /* NexGhosttyDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NexGhosttyDefaults.swift; sourceTree = "<group>"; };
 		93D45D65A66C475B0CEEC53C /* KeybindingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingService.swift; sourceTree = "<group>"; };
 		94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceView.swift; sourceTree = "<group>"; };
 		96AD7A8D7E6592B90FBB7D24 /* GhosttyConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfig.swift; sourceTree = "<group>"; };
@@ -411,6 +413,7 @@
 				96AD7A8D7E6592B90FBB7D24 /* GhosttyConfig.swift */,
 				A47FF7FB9A9C29221EAD089E /* GhosttyConfigClient.swift */,
 				DDD03468B083223FF50F68E0 /* GhosttySurface.swift */,
+				935FE280F97CB5A1DBD31113 /* NexGhosttyDefaults.swift */,
 				94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */,
 			);
 			path = Ghostty;
@@ -789,6 +792,7 @@
 				4985E51407DE646EB856C28A /* NewWorkspaceSheet.swift in Sources */,
 				C276E6F9F7B46ED43FF491D5 /* NexApp.swift in Sources */,
 				8132EF9FB6ACF51F7AEB57CE /* NexCommands.swift in Sources */,
+				58D251ED7E3B564C9BA3AD91 /* NexGhosttyDefaults.swift in Sources */,
 				F408865A1C0FC2282DD6F271 /* NexTheme.swift in Sources */,
 				A0056823B88DEBC5006159A2 /* NotificationService.swift in Sources */,
 				27D6386295651D4FE9A3DF6B /* Pane.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		62564D224FD57BC3C02100EA /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191E820170ADF2ADB58B8079 /* GitServiceTests.swift */; };
 		62BC1CC522515C8E6A99F508 /* GitHeadWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281BB8BFA202B0E43FC1E2AE /* GitHeadWatcher.swift */; };
 		64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A24C1FEC6EA31096603326 /* SurfaceManager.swift */; };
+		692A08796F7DF555CFAF0653 /* MarkdownFindScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4FA41668CB28EB0FFA7911 /* MarkdownFindScript.swift */; };
 		696312BB96D35569F48B7CAE /* MarkdownFrontMatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43F769C33118440222BF5FA /* MarkdownFrontMatter.swift */; };
 		6ACFF31A3875EBE87E78C587 /* RepoAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A1CB3D7653911EF93F8F5 /* RepoAssociation.swift */; };
 		6C50041FBB0F31598067D4FA /* LineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */; };
@@ -125,6 +126,7 @@
 		F232D23668E3159B6EA5FC37 /* NewGroupSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3E3CD750CB1CDEC2F35ED1 /* NewGroupSheet.swift */; };
 		F408865A1C0FC2282DD6F271 /* NexTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB526BDDE50E6C7948EE832 /* NexTheme.swift */; };
 		F4E3D6023E3546EC2908C4D6 /* WorkspaceGroupPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933D5B5E664E30B2E88EE3C7 /* WorkspaceGroupPersistenceTests.swift */; };
+		F4F95104BEADCDD6F5C79CF2 /* MarkdownFindController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DDBBE36E6F9BC00B9EB07E /* MarkdownFindController.swift */; };
 		F6B537768D81B028C1B484B2 /* PaneShortcutMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA7FF54B539D06E39903C41 /* PaneShortcutMonitorTests.swift */; };
 		F8173E6D656996539D3DFD5B /* SidebarID.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F76E0BE2C08C77C58B1278 /* SidebarID.swift */; };
 		F9EF0D090461E0518C6EB23F /* EditorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77FDA3FB200AA7846BCDC7A7 /* EditorServiceTests.swift */; };
@@ -177,9 +179,11 @@
 		30D306AA2907696B7A28F9DA /* PaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayout.swift; sourceTree = "<group>"; };
 		3714AA1F15C85762BF36B1FE /* NexApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NexApp.swift; sourceTree = "<group>"; };
 		377C07C6C4B00D0699682EA3 /* PaneType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneType.swift; sourceTree = "<group>"; };
+		37DDBBE36E6F9BC00B9EB07E /* MarkdownFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFindController.swift; sourceTree = "<group>"; };
 		3879BA745F8737CA5872F80D /* DatabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseService.swift; sourceTree = "<group>"; };
 		396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffHTMLRendererTests.swift; sourceTree = "<group>"; };
 		3B2687F4D886D153C83D8A60 /* WorkspaceGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroup.swift; sourceTree = "<group>"; };
+		3B4FA41668CB28EB0FFA7911 /* MarkdownFindScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFindScript.swift; sourceTree = "<group>"; };
 		42A24C1FEC6EA31096603326 /* SurfaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceManager.swift; sourceTree = "<group>"; };
 		439174A029FAFE2C252A1B8B /* KeybindingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingsSettingsView.swift; sourceTree = "<group>"; };
 		452A1B196F8438AD7A7DAC0A /* PaneSendKeyReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSendKeyReplyTests.swift; sourceTree = "<group>"; };
@@ -541,6 +545,8 @@
 			children = (
 				852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */,
 				7ED3289901F70616FC36F80B /* MarkdownEditorView.swift */,
+				37DDBBE36E6F9BC00B9EB07E /* MarkdownFindController.swift */,
+				3B4FA41668CB28EB0FFA7911 /* MarkdownFindScript.swift */,
 				F43F769C33118440222BF5FA /* MarkdownFrontMatter.swift */,
 				1E7D450881FC7318F58CB78F /* MarkdownHTMLRenderer.swift */,
 				B02A888F436610636F5A4D55 /* MarkdownPaneView.swift */,
@@ -774,6 +780,8 @@
 				6CF210BA0C7BFE62B90844F7 /* KeybindingsSettingsView.swift in Sources */,
 				6C50041FBB0F31598067D4FA /* LineNumberRulerView.swift in Sources */,
 				291A22061671351813971551 /* MarkdownEditorView.swift in Sources */,
+				F4F95104BEADCDD6F5C79CF2 /* MarkdownFindController.swift in Sources */,
+				692A08796F7DF555CFAF0653 /* MarkdownFindScript.swift in Sources */,
 				696312BB96D35569F48B7CAE /* MarkdownFrontMatter.swift in Sources */,
 				AC234A5AAADE90A7EC7BB5F8 /* MarkdownHTMLRenderer.swift in Sources */,
 				E56B0EC49D7AC553B5CDC2CC /* MarkdownPaneView.swift in Sources */,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -2671,9 +2671,17 @@ struct AppReducer {
                         let popped = state.workspaces[id: sourceWSID]?.popFocusFromHistory(excluding: paneID) ?? nil
                         state.workspaces[id: sourceWSID]?.focusedPaneID = popped ?? newSourceLayout.allPaneIDs.first
                     }
+                    var dropMarkdownFind = false
                     if state.workspaces[id: sourceWSID]?.searchingPaneID == paneID {
                         state.workspaces[id: sourceWSID]?.searchingPaneID = nil
                         state.workspaces[id: sourceWSID]?.searchNeedle = ""
+                        state.workspaces[id: sourceWSID]?.searchTotal = nil
+                        state.workspaces[id: sourceWSID]?.searchSelected = nil
+                        // Drop any in-DOM find marks on a markdown pane being
+                        // moved across workspaces (the WKWebView/coordinator
+                        // travels with the pane, but its workspace-level
+                        // search context does not).
+                        dropMarkdownFind = pane.type == .markdown
                     }
                     if state.workspaces[id: sourceWSID]?.zoomedPaneID == paneID {
                         if let saved = state.workspaces[id: sourceWSID]?.savedLayout {
@@ -2704,6 +2712,16 @@ struct AppReducer {
                     state.workspaces[id: targetWSID]?.currentLayoutIndex = nil
                     state.activeWorkspaceID = targetWSID
 
+                    if dropMarkdownFind {
+                        return .merge(
+                            .run { _ in
+                                await MainActor.run {
+                                    MarkdownFindController.shared.close(paneID: paneID)
+                                }
+                            },
+                            .send(.persistState)
+                        )
+                    }
                     return .send(.persistState)
 
                 // MARK: Workspace commands

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -294,6 +294,16 @@ struct ContentView: View {
                       let paneID = surfaceManager.paneID(for: surface) else { return }
                 store.send(.searchSelectedUpdated(paneID: paneID, selected: selected))
             }
+            .onReceive(NotificationCenter.default.publisher(for: .markdownFindResult)) { notification in
+                guard let paneID = notification.userInfo?["paneID"] as? UUID,
+                      let total = notification.userInfo?["total"] as? Int,
+                      let current = notification.userInfo?["current"] as? Int else { return }
+                store.send(.searchTotalUpdated(paneID: paneID, total: total))
+                // current is -1 when there are no matches; only forward a real index.
+                if current >= 0 {
+                    store.send(.searchSelectedUpdated(paneID: paneID, selected: current))
+                }
+            }
             .onAppear {
                 // The xcodebuild test host instantiates ContentView; skip the
                 // socket listener so `xcodebuild test` never touches

--- a/Nex/Features/MarkdownPane/MarkdownFindController.swift
+++ b/Nex/Features/MarkdownPane/MarkdownFindController.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Foundation
+
+/// Routes find-in-page commands from the workspace reducer to the
+/// `MarkdownPaneView.Coordinator` that owns the WKWebView for a given
+/// pane. Mirrors the role `SurfaceManager` plays for terminal scrollback
+/// search, but for markdown panes.
+///
+/// Coordinators register on `makeNSView` and unregister on
+/// `dismantleNSView`. Results from JS land back in the workspace via the
+/// `markdownFindResult` notification, which `ContentView` translates to
+/// `searchTotalUpdated` / `searchSelectedUpdated` actions.
+@MainActor
+final class MarkdownFindController {
+    static let shared = MarkdownFindController()
+
+    private var coordinators: [UUID: WeakCoordinator] = [:]
+    private var lastNeedles: [UUID: String] = [:]
+
+    private init() {}
+
+    func register(paneID: UUID, coordinator: MarkdownPaneView.Coordinator) {
+        coordinators[paneID] = WeakCoordinator(value: coordinator)
+    }
+
+    func unregister(paneID: UUID) {
+        coordinators[paneID] = nil
+        lastNeedles[paneID] = nil
+    }
+
+    /// Re-run the active find after a content reload (file watcher firing,
+    /// font-size change, etc.) blew the marks out of the DOM.
+    func reapply(paneID: UUID) {
+        guard let needle = lastNeedles[paneID], !needle.isEmpty else { return }
+        coordinators[paneID]?.value?.runFindUpdate(needle: needle)
+    }
+
+    func update(paneID: UUID, needle: String) {
+        lastNeedles[paneID] = needle
+        coordinators[paneID]?.value?.runFindUpdate(needle: needle)
+    }
+
+    func navigateNext(paneID: UUID) {
+        coordinators[paneID]?.value?.runFindNavigate(forward: true)
+    }
+
+    func navigatePrevious(paneID: UUID) {
+        coordinators[paneID]?.value?.runFindNavigate(forward: false)
+    }
+
+    func close(paneID: UUID) {
+        lastNeedles[paneID] = nil
+        coordinators[paneID]?.value?.runFindClose()
+    }
+
+    private struct WeakCoordinator {
+        weak var value: MarkdownPaneView.Coordinator?
+    }
+}
+
+extension Notification.Name {
+    /// Fired by `MarkdownPaneView.Coordinator` after the JS find pass
+    /// completes. `userInfo`: `paneID: UUID`, `total: Int`, `current: Int`
+    /// (`current` is `-1` when there is no active match).
+    static let markdownFindResult = Notification.Name("nex.markdownFindResult")
+}

--- a/Nex/Features/MarkdownPane/MarkdownFindScript.swift
+++ b/Nex/Features/MarkdownPane/MarkdownFindScript.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+/// JavaScript injected into every markdown preview WKWebView. Defines
+/// `window.__nexFind` with `search(needle)`, `next()`, `prev()`, and
+/// `clear()`. Each call posts a result back via the `nexFind` script
+/// message: `{ total: Int, current: Int }` (current is `-1` when there
+/// is no active match).
+enum MarkdownFindScript {
+    static let source: String = """
+    (function() {
+      if (window.__nexFind) { return; }
+      var ns = {};
+      window.__nexFind = ns;
+      ns.matches = [];
+      ns.currentIndex = -1;
+
+      var styleEl = document.createElement('style');
+      styleEl.textContent = (
+        "mark.nex-find-match { background: rgba(255, 217, 0, 0.55); color: inherit; border-radius: 2px; padding: 0; }" +
+        "mark.nex-find-match.nex-find-current { background: rgba(255, 138, 0, 0.85); outline: 1px solid rgba(255, 80, 0, 0.9); }"
+      );
+      // Defer until <head> exists. Inject CSS via JS so that the
+      // markdown HTML renderer doesn't need to know about find styling.
+      function injectStyle() {
+        if (document.head) {
+          document.head.appendChild(styleEl);
+        } else {
+          requestAnimationFrame(injectStyle);
+        }
+      }
+      injectStyle();
+
+      function postResult() {
+        if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.nexFind) {
+          window.webkit.messageHandlers.nexFind.postMessage({
+            total: ns.matches.length,
+            current: ns.matches.length === 0 ? -1 : ns.currentIndex
+          });
+        }
+      }
+
+      function clearMarks() {
+        var marks = document.querySelectorAll('mark.nex-find-match');
+        for (var i = 0; i < marks.length; i++) {
+          var m = marks[i];
+          var parent = m.parentNode;
+          if (!parent) continue;
+          while (m.firstChild) parent.insertBefore(m.firstChild, m);
+          parent.removeChild(m);
+          parent.normalize();
+        }
+        ns.matches = [];
+        ns.currentIndex = -1;
+      }
+
+      function setCurrent(scroll) {
+        var prev = document.querySelectorAll('mark.nex-find-match.nex-find-current');
+        for (var i = 0; i < prev.length; i++) prev[i].classList.remove('nex-find-current');
+        if (ns.currentIndex >= 0 && ns.currentIndex < ns.matches.length) {
+          var m = ns.matches[ns.currentIndex];
+          m.classList.add('nex-find-current');
+          if (scroll) m.scrollIntoView({ block: 'center', inline: 'nearest' });
+        }
+      }
+
+      function shouldSkipNode(node) {
+        var p = node.parentNode;
+        while (p) {
+          if (p.nodeType !== 1) { p = p.parentNode; continue; }
+          var tag = p.tagName;
+          if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT') return true;
+          if (p.classList && p.classList.contains('nex-find-match')) return true;
+          p = p.parentNode;
+        }
+        return false;
+      }
+
+      function escapeRegex(s) {
+        return s.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&');
+      }
+
+      function search(needle) {
+        clearMarks();
+        if (!needle) { postResult(); return; }
+        // Use a regex with the `i` flag so case folding is done by the
+        // engine itself. This avoids the offset drift that bites
+        // `text.toLowerCase().indexOf(needle.toLowerCase())` when
+        // `toLowerCase()` changes string length (e.g. Turkish dotted I,
+        // German eszett) — the regex always returns offsets that line
+        // up with the original text.
+        var rx;
+        try {
+          rx = new RegExp(escapeRegex(needle), 'gi');
+        } catch (e) {
+          postResult();
+          return;
+        }
+
+        var walker = document.createTreeWalker(
+          document.body,
+          NodeFilter.SHOW_TEXT,
+          {
+            acceptNode: function(node) {
+              if (!node.nodeValue) return NodeFilter.FILTER_REJECT;
+              if (shouldSkipNode(node)) return NodeFilter.FILTER_REJECT;
+              return NodeFilter.FILTER_ACCEPT;
+            }
+          }
+        );
+        var textNodes = [];
+        var n;
+        while ((n = walker.nextNode())) textNodes.push(n);
+
+        var matches = [];
+        for (var t = 0; t < textNodes.length; t++) {
+          var node = textNodes[t];
+          var text = node.nodeValue;
+          rx.lastIndex = 0;
+          var first = rx.exec(text);
+          if (!first) continue;
+          var parent = node.parentNode;
+          if (!parent) continue;
+          var cursor = 0;
+          var fragments = [];
+          var m = first;
+          while (m) {
+            var idx = m.index;
+            var len = m[0].length;
+            if (len === 0) { rx.lastIndex = idx + 1; m = rx.exec(text); continue; }
+            if (idx > cursor) {
+              fragments.push(document.createTextNode(text.slice(cursor, idx)));
+            }
+            var mark = document.createElement('mark');
+            mark.className = 'nex-find-match';
+            mark.appendChild(document.createTextNode(text.slice(idx, idx + len)));
+            fragments.push(mark);
+            matches.push(mark);
+            cursor = idx + len;
+            m = rx.exec(text);
+          }
+          if (cursor < text.length) {
+            fragments.push(document.createTextNode(text.slice(cursor)));
+          }
+          for (var f = 0; f < fragments.length; f++) {
+            parent.insertBefore(fragments[f], node);
+          }
+          parent.removeChild(node);
+        }
+
+        ns.matches = matches;
+        ns.currentIndex = matches.length > 0 ? 0 : -1;
+        setCurrent(true);
+        postResult();
+      }
+
+      function navigate(delta) {
+        if (ns.matches.length === 0) { postResult(); return; }
+        ns.currentIndex = (ns.currentIndex + delta + ns.matches.length) % ns.matches.length;
+        setCurrent(true);
+        postResult();
+      }
+
+      ns.search = search;
+      ns.next = function() { navigate(1); };
+      ns.prev = function() { navigate(-1); };
+      ns.clear = function() { clearMarks(); postResult(); };
+    })();
+    """
+
+    /// JSON-encode the needle so it can be inlined inside `JS.search(...)`.
+    /// Falls back to `""` on encoding failure.
+    static func encodeNeedle(_ needle: String) -> String {
+        guard let data = try? JSONEncoder().encode(needle),
+              let s = String(data: data, encoding: .utf8)
+        else { return "\"\"" }
+        return s
+    }
+}

--- a/Nex/Features/MarkdownPane/MarkdownFindScript.swift
+++ b/Nex/Features/MarkdownPane/MarkdownFindScript.swift
@@ -15,9 +15,12 @@ enum MarkdownFindScript {
       ns.currentIndex = -1;
 
       var styleEl = document.createElement('style');
+      // Colors mirror ghostty's `search-background` /
+      // `search-selected-background` (set by NexGhosttyDefaults) so
+      // terminal find and markdown find share a palette.
       styleEl.textContent = (
-        "mark.nex-find-match { background: rgba(255, 217, 0, 0.55); color: inherit; border-radius: 2px; padding: 0; }" +
-        "mark.nex-find-match.nex-find-current { background: rgba(255, 138, 0, 0.85); outline: 1px solid rgba(255, 80, 0, 0.9); }"
+        "mark.nex-find-match { background: #F2D027; color: #000; border-radius: 2px; padding: 0; }" +
+        "mark.nex-find-match.nex-find-current { background: #FF7A00; color: #000; }"
       );
       // Defer until <head> exists. Inject CSS via JS so that the
       // markdown HTML renderer doesn't need to know about find styling.

--- a/Nex/Features/MarkdownPane/MarkdownPaneView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownPaneView.swift
@@ -20,8 +20,9 @@ struct MarkdownPaneView: NSViewRepresentable {
         let container = PaneFocusView(paneID: paneID)
 
         let config = WKWebViewConfiguration()
-        let scrollHandler = context.coordinator
-        config.userContentController.add(scrollHandler, name: "scrollHandler")
+        let handler = context.coordinator
+        config.userContentController.add(handler, name: "scrollHandler")
+        config.userContentController.add(handler, name: "nexFind")
         config.userContentController.addUserScript(WKUserScript(
             source: """
             window.addEventListener('scroll', function() {
@@ -30,6 +31,11 @@ struct MarkdownPaneView: NSViewRepresentable {
                 window.webkit.messageHandlers.scrollHandler.postMessage(fraction);
             });
             """,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        ))
+        config.userContentController.addUserScript(WKUserScript(
+            source: MarkdownFindScript.source,
             injectionTime: .atDocumentEnd,
             forMainFrameOnly: true
         ))
@@ -48,6 +54,7 @@ struct MarkdownPaneView: NSViewRepresentable {
         context.coordinator.fontSize = fontSize
         context.coordinator.loadFile()
         context.coordinator.startWatching()
+        MarkdownFindController.shared.register(paneID: paneID, coordinator: context.coordinator)
 
         container.embed(webView)
 
@@ -89,6 +96,9 @@ struct MarkdownPaneView: NSViewRepresentable {
 
     static func dismantleNSView(_: PaneFocusView, coordinator: Coordinator) {
         coordinator.stopWatching()
+        if let id = coordinator.paneID {
+            MarkdownFindController.shared.unregister(paneID: id)
+        }
         coordinator.webView = nil
     }
 
@@ -167,8 +177,42 @@ struct MarkdownPaneView: NSViewRepresentable {
             _: WKUserContentController,
             didReceive message: WKScriptMessage
         ) {
-            guard let fraction = message.body as? Double, let paneID else { return }
-            PaneFocusView.saveScrollFraction(CGFloat(fraction), for: paneID)
+            guard let paneID else { return }
+            switch message.name {
+            case "scrollHandler":
+                guard let fraction = message.body as? Double else { return }
+                PaneFocusView.saveScrollFraction(CGFloat(fraction), for: paneID)
+            case "nexFind":
+                guard let payload = message.body as? [String: Any],
+                      let total = payload["total"] as? Int,
+                      let current = payload["current"] as? Int else { return }
+                NotificationCenter.default.post(
+                    name: .markdownFindResult,
+                    object: nil,
+                    userInfo: ["paneID": paneID, "total": total, "current": current]
+                )
+            default:
+                break
+            }
+        }
+
+        // MARK: - Find-in-page (called by MarkdownFindController)
+
+        func runFindUpdate(needle: String) {
+            guard let webView else { return }
+            let escaped = MarkdownFindScript.encodeNeedle(needle)
+            webView.evaluateJavaScript("window.__nexFind && window.__nexFind.search(\(escaped));")
+        }
+
+        func runFindNavigate(forward: Bool) {
+            guard let webView else { return }
+            let fn = forward ? "next" : "prev"
+            webView.evaluateJavaScript("window.__nexFind && window.__nexFind.\(fn)();")
+        }
+
+        func runFindClose() {
+            guard let webView else { return }
+            webView.evaluateJavaScript("window.__nexFind && window.__nexFind.clear();")
         }
 
         // MARK: - WKNavigationDelegate (scroll restore)
@@ -184,6 +228,8 @@ struct MarkdownPaneView: NSViewRepresentable {
                     "window.scrollTo(0, \(fraction) * Math.max(1, document.body.scrollHeight - window.innerHeight))"
                 )
             }
+            // The reload wiped any active find marks. Re-apply if a needle is still set.
+            MarkdownFindController.shared.reapply(paneID: paneID)
         }
 
         func startWatching() {

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -963,6 +963,11 @@ struct WorkspaceFeature {
             case .searchTotalUpdated(let paneID, let total):
                 guard state.searchingPaneID == paneID else { return .none }
                 state.searchTotal = total
+                // Drop any stale selection when matches go to zero (e.g.
+                // a markdown live-reload turns a doc with hits into one
+                // without). Otherwise the overlay would render a count
+                // like "3/0".
+                if total == 0 { state.searchSelected = nil }
                 return .none
 
             case .searchSelectedUpdated(let paneID, let selected):

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -697,6 +697,18 @@ struct WorkspaceFeature {
                     return .none
                 }
 
+                // Entering edit mode: dismiss any active find on this pane.
+                // The MarkdownPaneView is about to be replaced by the editor,
+                // so the overlay would otherwise float over a non-functional
+                // host (no coordinator → typed needles silently no-op).
+                let wasSearching = state.searchingPaneID == paneID
+                if wasSearching {
+                    state.searchingPaneID = nil
+                    state.searchNeedle = ""
+                    state.searchTotal = nil
+                    state.searchSelected = nil
+                }
+
                 // If we can resolve the user's $EDITOR, host it inside a
                 // ghostty surface bound to this pane; otherwise fall back to
                 // the built-in NSTextView editor.
@@ -707,6 +719,11 @@ struct WorkspaceFeature {
                     let opacity = ghosttyConfig.backgroundOpacity
                     let cwd = pane.workingDirectory
                     return .run { _ in
+                        if wasSearching {
+                            await MainActor.run {
+                                MarkdownFindController.shared.close(paneID: paneID)
+                            }
+                        }
                         await surfaceManager.createSurface(
                             paneID: paneID,
                             workingDirectory: cwd,
@@ -718,6 +735,13 @@ struct WorkspaceFeature {
 
                 state.panes[id: paneID]?.isEditing = true
                 state.panes[id: paneID]?.externalEditorCommand = nil
+                if wasSearching {
+                    return .run { _ in
+                        await MainActor.run {
+                            MarkdownFindController.shared.close(paneID: paneID)
+                        }
+                    }
+                }
                 return .none
 
             case .increaseMarkdownFontSize(let paneID):
@@ -827,7 +851,9 @@ struct WorkspaceFeature {
 
             case .toggleSearch:
                 guard let focusedID = state.focusedPaneID,
-                      state.panes[id: focusedID]?.type == .shell else { return .none }
+                      let pane = state.panes[id: focusedID],
+                      pane.type == .shell || (pane.type == .markdown && !pane.isEditing)
+                else { return .none }
                 if state.searchingPaneID != nil {
                     return .send(.searchClose)
                 }
@@ -857,6 +883,17 @@ struct WorkspaceFeature {
                 state.searchNeedle = needle
                 state.searchSelected = nil
                 guard let paneID = state.searchingPaneID else { return .none }
+                let isMarkdown = state.panes[id: paneID]?.type == .markdown
+                if isMarkdown {
+                    // WKWebView find runs locally in JS; no backend round-trip
+                    // to debounce. Drive it directly so typing feels responsive.
+                    return .run { _ in
+                        await MainActor.run {
+                            MarkdownFindController.shared.update(paneID: paneID, needle: needle)
+                        }
+                    }
+                    .cancellable(id: SearchDebounceID.debounce, cancelInFlight: true)
+                }
                 let mgr = surfaceManager
                 if needle.isEmpty {
                     return .run { _ in
@@ -878,6 +915,13 @@ struct WorkspaceFeature {
 
             case .searchNavigateNext:
                 guard let paneID = state.searchingPaneID else { return .none }
+                if state.panes[id: paneID]?.type == .markdown {
+                    return .run { _ in
+                        await MainActor.run {
+                            MarkdownFindController.shared.navigateNext(paneID: paneID)
+                        }
+                    }
+                }
                 let mgr = surfaceManager
                 return .run { _ in
                     await mgr.performBindingAction(on: paneID, action: "navigate_search:next")
@@ -885,6 +929,13 @@ struct WorkspaceFeature {
 
             case .searchNavigatePrevious:
                 guard let paneID = state.searchingPaneID else { return .none }
+                if state.panes[id: paneID]?.type == .markdown {
+                    return .run { _ in
+                        await MainActor.run {
+                            MarkdownFindController.shared.navigatePrevious(paneID: paneID)
+                        }
+                    }
+                }
                 let mgr = surfaceManager
                 return .run { _ in
                     await mgr.performBindingAction(on: paneID, action: "navigate_search:previous")
@@ -892,10 +943,18 @@ struct WorkspaceFeature {
 
             case .searchClose:
                 guard let paneID = state.searchingPaneID else { return .none }
+                let isMarkdown = state.panes[id: paneID]?.type == .markdown
                 state.searchingPaneID = nil
                 state.searchNeedle = ""
                 state.searchTotal = nil
                 state.searchSelected = nil
+                if isMarkdown {
+                    return .run { _ in
+                        await MainActor.run {
+                            MarkdownFindController.shared.close(paneID: paneID)
+                        }
+                    }
+                }
                 let mgr = surfaceManager
                 return .run { _ in
                     await mgr.performBindingAction(on: paneID, action: "end_search")

--- a/Nex/Ghostty/GhosttyConfig.swift
+++ b/Nex/Ghostty/GhosttyConfig.swift
@@ -7,8 +7,8 @@ final class GhosttyConfig {
 
     init() {
         rawConfig = ghostty_config_new()
-        ghostty_config_load_default_files(rawConfig)
         Self.loadNexDefaults(rawConfig)
+        ghostty_config_load_default_files(rawConfig)
         ghostty_config_load_recursive_files(rawConfig)
     }
 
@@ -17,24 +17,24 @@ final class GhosttyConfig {
     /// values take precedence.
     init(overrideFile path: String) {
         rawConfig = ghostty_config_new()
-        ghostty_config_load_default_files(rawConfig)
         Self.loadNexDefaults(rawConfig)
+        ghostty_config_load_default_files(rawConfig)
         ghostty_config_load_recursive_files(rawConfig)
         path.withCString { ghostty_config_load_file(rawConfig, $0) }
     }
 
     /// Apply Nex's opinionated tweaks on top of ghostty's compiled-in
     /// defaults but BEFORE the user's `~/.config/ghostty/config` so any
-    /// of these can still be overridden by the user.
+    /// of these can still be overridden by the user. Order matters:
+    /// `loadDefaultFiles` reads the user's XDG / app-support config, so
+    /// our defaults must run first to keep user overrides winning.
     private static func loadNexDefaults(_ raw: ghostty_config_t) {
         let path = NSTemporaryDirectory() + "nex-ghostty-defaults"
-        if !FileManager.default.fileExists(atPath: path) {
-            try? NexGhosttyDefaults.source.write(
-                toFile: path,
-                atomically: true,
-                encoding: .utf8
-            )
-        }
+        try? NexGhosttyDefaults.source.write(
+            toFile: path,
+            atomically: true,
+            encoding: .utf8
+        )
         path.withCString { ghostty_config_load_file(raw, $0) }
     }
 

--- a/Nex/Ghostty/GhosttyConfig.swift
+++ b/Nex/Ghostty/GhosttyConfig.swift
@@ -8,6 +8,7 @@ final class GhosttyConfig {
     init() {
         rawConfig = ghostty_config_new()
         ghostty_config_load_default_files(rawConfig)
+        Self.loadNexDefaults(rawConfig)
         ghostty_config_load_recursive_files(rawConfig)
     }
 
@@ -17,8 +18,24 @@ final class GhosttyConfig {
     init(overrideFile path: String) {
         rawConfig = ghostty_config_new()
         ghostty_config_load_default_files(rawConfig)
+        Self.loadNexDefaults(rawConfig)
         ghostty_config_load_recursive_files(rawConfig)
         path.withCString { ghostty_config_load_file(rawConfig, $0) }
+    }
+
+    /// Apply Nex's opinionated tweaks on top of ghostty's compiled-in
+    /// defaults but BEFORE the user's `~/.config/ghostty/config` so any
+    /// of these can still be overridden by the user.
+    private static func loadNexDefaults(_ raw: ghostty_config_t) {
+        let path = NSTemporaryDirectory() + "nex-ghostty-defaults"
+        if !FileManager.default.fileExists(atPath: path) {
+            try? NexGhosttyDefaults.source.write(
+                toFile: path,
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        path.withCString { ghostty_config_load_file(raw, $0) }
     }
 
     func finalize() {

--- a/Nex/Ghostty/NexGhosttyDefaults.swift
+++ b/Nex/Ghostty/NexGhosttyDefaults.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Nex-managed ghostty config defaults applied between the compiled-in
+/// zig defaults and the user's `~/.config/ghostty/config`. Anything set
+/// here can still be overridden by the user's own config — this is just
+/// Nex's preferred starting point.
+///
+/// Currently used to give the in-pane scrollback search higher-contrast
+/// match colors that align with the markdown find overlay (see
+/// `MarkdownFindScript.matchBackgroundCSS`).
+enum NexGhosttyDefaults {
+    /// Hex string suitable for ghostty's `key = #RRGGBB` syntax.
+    static let matchBackgroundHex = "#F2D027"
+    static let matchForegroundHex = "#000000"
+    static let currentMatchBackgroundHex = "#FF7A00"
+    static let currentMatchForegroundHex = "#000000"
+
+    static let source: String = """
+    # Nex-managed defaults. Applied after ghostty's compiled-in defaults
+    # but before the user's own config, so any of these stay overridable
+    # by ~/.config/ghostty/config.
+    search-background = \(matchBackgroundHex)
+    search-foreground = \(matchForegroundHex)
+    search-selected-background = \(currentMatchBackgroundHex)
+    search-selected-foreground = \(currentMatchForegroundHex)
+    """
+}

--- a/NexTests/WorkspaceFeatureTests.swift
+++ b/NexTests/WorkspaceFeatureTests.swift
@@ -1373,6 +1373,78 @@ struct WorkspaceFeatureTests {
         }
     }
 
+    @Test func toggleSearchOpensForMarkdownPaneInViewMode() async {
+        let paneID = UUID()
+        var workspace = WorkspaceFeature.State(name: "Test")
+        workspace.panes = [
+            Pane(id: paneID, type: .markdown, workingDirectory: "/tmp", filePath: "/tmp/x.md")
+        ]
+        workspace.layout = .leaf(paneID)
+        workspace.focusedPaneID = paneID
+
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+
+        await store.send(.toggleSearch) { state in
+            state.searchingPaneID = paneID
+            state.searchNeedle = ""
+            state.searchTotal = nil
+            state.searchSelected = nil
+        }
+    }
+
+    @Test func toggleSearchIgnoredOnMarkdownPaneInEditMode() async {
+        let paneID = UUID()
+        var workspace = WorkspaceFeature.State(name: "Test")
+        workspace.panes = [
+            Pane(
+                id: paneID,
+                type: .markdown,
+                workingDirectory: "/tmp",
+                filePath: "/tmp/x.md",
+                isEditing: true
+            )
+        ]
+        workspace.layout = .leaf(paneID)
+        workspace.focusedPaneID = paneID
+
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+
+        await store.send(.toggleSearch)
+        // No state change asserted: state.searchingPaneID stays nil.
+    }
+
+    @Test func toggleMarkdownEditDismissesActiveSearch() async {
+        let paneID = UUID()
+        var workspace = WorkspaceFeature.State(name: "Test")
+        workspace.panes = [
+            Pane(id: paneID, type: .markdown, workingDirectory: "/tmp", filePath: nil)
+        ]
+        workspace.layout = .leaf(paneID)
+        workspace.focusedPaneID = paneID
+        workspace.searchingPaneID = paneID
+        workspace.searchNeedle = "foo"
+        workspace.searchTotal = 3
+        workspace.searchSelected = 1
+
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.editorService = stubbedEditorService(command: "nvim ''")
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.toggleMarkdownEdit(paneID)) { state in
+            state.panes[id: paneID]?.isEditing = true
+            state.searchingPaneID = nil
+            state.searchNeedle = ""
+            state.searchTotal = nil
+            state.searchSelected = nil
+        }
+    }
+
     @Test func toggleMarkdownEditExitingExternalModeClearsCommand() async {
         let paneID = UUID()
         var workspace = WorkspaceFeature.State(name: "Test")


### PR DESCRIPTION
## Summary
- Wires Cmd+F into the markdown preview pane: reuses the existing `PaneSearchOverlay`, adds `MarkdownFindController` + injected JS that walks visible text via TreeWalker and a case-insensitive regex, wraps matches in `<mark>`, and routes results back through a `NotificationCenter` bridge into the existing `searchTotalUpdated` / `searchSelectedUpdated` actions.
- Aligns terminal scrollback search and markdown find on a single high-contrast palette (`#F2D027` gold + `#FF7A00` orange) via a Nex-managed ghostty defaults file loaded between zig defaults and the user's `~/.config/ghostty/config` (so user overrides still win).
- Edge cases: `toggleMarkdownEdit` dismisses an active find before flipping into edit mode; cross-workspace pane move closes the controller for markdown panes; `searchTotalUpdated(0)` clears any stale `searchSelected` so the overlay can't render `3/0`.

Closes #116

## Reviewer notes
- Reviewed by two parallel Claude agents (correctness + scope) and Codex. All MUST FIX / SHOULD FIX items applied:
  - Edit-mode toggle leaving stuck overlay
  - Unicode `toLowerCase()` length drift (switched JS to `RegExp` with `gi`)
  - Cross-workspace move leaking find marks
  - `encodeNeedle` simplified to `JSONEncoder().encode`
  - Codex caught: ghostty config precedence inversion (Nex defaults must run BEFORE `loadDefaultFiles` since that loads user config) and stale `searchSelected` on zero-match live reload.
- Cross-element-boundary matches are intentionally not supported (parity with browser find; out of scope).

## Validation
- Validated in a sandboxed macOS VM via cua/lume. All 7 assertions passed.
- Per-issue assertions:
  - Initial state has 1 shell pane.
  - `nex open /tmp/find_test.md` produces a markdown pane with `file_path` set correctly.
  - Cmd+F opens the search overlay.
  - Typing `needle` highlights all 4 matches; counter reads `1/4`.
  - Enter advances counter to `2/4` and shifts the orange highlight.
  - Esc closes the overlay and clears all marks.
  - Pane survives the entire sequence.
  - Cmd+F twice (open/close toggle) leaves the pane intact.
- Screenshots: `/Users/ben/code/cua/out/branches/fix-116-markdown-find/issue-116/`

## Test plan
- [x] Open a long markdown file, Cmd+F, type a phrase, verify all matches highlighted in gold and current in orange.
- [x] Enter / Shift+Enter cycle through matches; counter updates.
- [x] Esc closes the overlay; marks vanish.
- [x] Cmd+F twice toggles open/close.
- [x] With overlay open, ⌘E flips into edit mode without leaving a stuck overlay floating over the editor.
- [x] In a terminal pane, run `for i in 1 2 3 4; do echo "needle $i"; done` then Cmd+F → confirm same gold/orange palette as markdown.
- [x] Live reload: with overlay open and matches visible, edit the file externally → marks re-apply on reload.
- [x] Live reload to a doc with zero matches → counter shows total 0, no stale `N/0`.
- [x] User with their own `search-background = ...` in `~/.config/ghostty/config` still wins over Nex defaults (config precedence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)