### PR TITLE
fix: Respect Ghostty option-as-alt

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		ED79F70009D8C2A4A1A742F8 /* ResizeDimensionsOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6F950849E47A0BCC6DEAB5 /* ResizeDimensionsOverlay.swift */; };
 		EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */; };
 		EDF35E86B633BB1E8C3DE844 /* WindowSpacesBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */; };
+		EF4258CFC52EB748609C7F18 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */; };
 		EFDCA64CD227A833D2801893 /* CLIInstallService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EC869803E36C99B3653FF5 /* CLIInstallService.swift */; };
 		F01CDB667AE2A0CF2A825AD3 /* WorkspaceDropTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C66D4D59D04F6372D8AD7 /* WorkspaceDropTargetTests.swift */; };
 		F1139F84E35AF1181F136C9D /* KeyBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF3FB912BD029F17AF0AA25 /* KeyBinding.swift */; };
@@ -167,6 +168,7 @@
 		1C625959E287CE9896D5BA4D /* RepoRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoRegistryTests.swift; sourceTree = "<group>"; };
 		1CB2BCC7EBF45A4E50F314F2 /* DiffPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneView.swift; sourceTree = "<group>"; };
 		1E7D450881FC7318F58CB78F /* MarkdownHTMLRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownHTMLRenderer.swift; sourceTree = "<group>"; };
+		1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		1F71D541343DA67CDCADA821 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
 		200EB2588E40ABB7C51E24E6 /* MarkdownHTMLRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownHTMLRendererTests.swift; sourceTree = "<group>"; };
 		21064C4AB47888B6A02CCD73 /* DatabaseMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseMigrationTests.swift; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 				1C625959E287CE9896D5BA4D /* RepoRegistryTests.swift */,
 				ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */,
 				AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */,
+				1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */,
 				94D09D767C96B3F96E4DF7C5 /* WindowSpacesBindingTests.swift */,
 				28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */,
 				E01C66D4D59D04F6372D8AD7 /* WorkspaceDropTargetTests.swift */,
@@ -743,6 +746,7 @@
 				B5B3A5F0C2FA6509D37FA74A /* RepoRegistryTests.swift in Sources */,
 				EAF43DC55C5612F3AE83BF02 /* SettingsFeatureTests.swift in Sources */,
 				2B4533964D77117EE6D98690 /* SocketParsingTests.swift in Sources */,
+				EF4258CFC52EB748609C7F18 /* SurfaceViewKeyboardTests.swift in Sources */,
 				DDD05A3B3A535DEA66485A47 /* WindowSpacesBindingTests.swift in Sources */,
 				5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */,
 				F01CDB667AE2A0CF2A825AD3 /* WorkspaceDropTargetTests.swift in Sources */,

--- a/Nex/Ghostty/SurfaceView.swift
+++ b/Nex/Ghostty/SurfaceView.swift
@@ -238,11 +238,13 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
     }
 
     override func keyDown(with event: NSEvent) {
+        let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
+        let translationEvent = translationEvent(for: event)
         let markedTextBefore = hasMarkedText()
 
         keyTextAccumulator = []
         defer { keyTextAccumulator = nil }
-        interpretKeyEvents([event])
+        interpretKeyEvents([translationEvent])
 
         let accumulated = keyTextAccumulator ?? []
 
@@ -251,7 +253,11 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
             // with composing=false. This handles US International dead-key failure,
             // where AppKit fires insertText twice (e.g. "'" then "s") in a single keyDown.
             for text in accumulated {
-                var key = Self.keyEvent(from: event, action: GHOSTTY_ACTION_PRESS)
+                var key = Self.keyEvent(
+                    from: event,
+                    action: action,
+                    translationFlags: translationEvent.modifierFlags
+                )
                 key.composing = false
                 text.withCString { ptr in
                     key.text = ptr
@@ -262,9 +268,20 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
             // No committed text. Either a pure preedit update, a bare key (arrow, enter),
             // or a composing keypress. `composing` is true if we're still in preedit now,
             // or if marked text existed before and was cleared by this event.
-            var key = Self.keyEvent(from: event, action: GHOSTTY_ACTION_PRESS)
+            var key = Self.keyEvent(
+                from: event,
+                action: action,
+                translationFlags: translationEvent.modifierFlags
+            )
             key.composing = hasMarkedText() || markedTextBefore
-            _ = ghosttySurface?.sendKey(key)
+            if let text = Self.ghosttyCharacters(from: translationEvent) {
+                text.withCString { ptr in
+                    key.text = ptr
+                    _ = ghosttySurface?.sendKey(key)
+                }
+            } else {
+                _ = ghosttySurface?.sendKey(key)
+            }
         }
     }
 
@@ -287,7 +304,25 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
         if hasMarkedText() { return }
 
         let mods = Self.mods(from: event)
-        let action = (mods.rawValue & mod != 0) ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
+        var action = GHOSTTY_ACTION_RELEASE
+        if mods.rawValue & mod != 0 {
+            let sidePressed: Bool = switch event.keyCode {
+            case 0x3C:
+                event.modifierFlags.rawValue & UInt(NX_DEVICERSHIFTKEYMASK) != 0
+            case 0x3E:
+                event.modifierFlags.rawValue & UInt(NX_DEVICERCTLKEYMASK) != 0
+            case 0x3D:
+                event.modifierFlags.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0
+            case 0x36:
+                event.modifierFlags.rawValue & UInt(NX_DEVICERCMDKEYMASK) != 0
+            default:
+                true
+            }
+
+            if sidePressed {
+                action = GHOSTTY_ACTION_PRESS
+            }
+        }
 
         var key = ghostty_input_key_s()
         key.action = action
@@ -555,6 +590,43 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
 
     // MARK: - Helpers
 
+    private func translationEvent(for event: NSEvent) -> NSEvent {
+        guard let surface = ghosttySurface?.surface else { return event }
+
+        let translationMods = Self.eventModifierFlags(
+            fromMods: ghostty_surface_key_translation_mods(
+                surface,
+                Self.mods(from: event)
+            )
+        )
+
+        // Preserve hidden modifier bits that matter for AppKit/dead-key handling,
+        // only toggling the visible modifiers ghostty asked us to translate with.
+        var modifierFlags = event.modifierFlags
+        for flag in [NSEvent.ModifierFlags.shift, .control, .option, .command] {
+            if translationMods.contains(flag) {
+                modifierFlags.insert(flag)
+            } else {
+                modifierFlags.remove(flag)
+            }
+        }
+
+        guard modifierFlags != event.modifierFlags else { return event }
+
+        return NSEvent.keyEvent(
+            with: event.type,
+            location: event.locationInWindow,
+            modifierFlags: modifierFlags,
+            timestamp: event.timestamp,
+            windowNumber: event.windowNumber,
+            context: nil,
+            characters: event.characters(byApplyingModifiers: modifierFlags) ?? "",
+            charactersIgnoringModifiers: event.charactersIgnoringModifiers ?? "",
+            isARepeat: event.isARepeat,
+            keyCode: event.keyCode
+        ) ?? event
+    }
+
     static func mods(from event: NSEvent) -> ghostty_input_mods_e {
         mods(fromFlags: event.modifierFlags)
     }
@@ -566,10 +638,48 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
         if flags.contains(.option) { raw |= GHOSTTY_MODS_ALT.rawValue }
         if flags.contains(.command) { raw |= GHOSTTY_MODS_SUPER.rawValue }
         if flags.contains(.capsLock) { raw |= GHOSTTY_MODS_CAPS.rawValue }
+
+        let rawFlags = flags.rawValue
+        if rawFlags & UInt(NX_DEVICERSHIFTKEYMASK) != 0 { raw |= GHOSTTY_MODS_SHIFT_RIGHT.rawValue }
+        if rawFlags & UInt(NX_DEVICERCTLKEYMASK) != 0 { raw |= GHOSTTY_MODS_CTRL_RIGHT.rawValue }
+        if rawFlags & UInt(NX_DEVICERALTKEYMASK) != 0 { raw |= GHOSTTY_MODS_ALT_RIGHT.rawValue }
+        if rawFlags & UInt(NX_DEVICERCMDKEYMASK) != 0 { raw |= GHOSTTY_MODS_SUPER_RIGHT.rawValue }
+
         return ghostty_input_mods_e(rawValue: raw)
     }
 
-    static func keyEvent(from event: NSEvent, action: ghostty_input_action_e) -> ghostty_input_key_s {
+    static func eventModifierFlags(fromMods mods: ghostty_input_mods_e) -> NSEvent.ModifierFlags {
+        var flags = NSEvent.ModifierFlags(rawValue: 0)
+        if mods.rawValue & GHOSTTY_MODS_SHIFT.rawValue != 0 { flags.insert(.shift) }
+        if mods.rawValue & GHOSTTY_MODS_CTRL.rawValue != 0 { flags.insert(.control) }
+        if mods.rawValue & GHOSTTY_MODS_ALT.rawValue != 0 { flags.insert(.option) }
+        if mods.rawValue & GHOSTTY_MODS_SUPER.rawValue != 0 { flags.insert(.command) }
+        if mods.rawValue & GHOSTTY_MODS_CAPS.rawValue != 0 { flags.insert(.capsLock) }
+        return flags
+    }
+
+    static func ghosttyCharacters(from event: NSEvent) -> String? {
+        guard let characters = event.characters else { return nil }
+
+        if characters.count == 1,
+           let scalar = characters.unicodeScalars.first {
+            if scalar.value < 0x20 {
+                return event.characters(byApplyingModifiers: event.modifierFlags.subtracting(.control))
+            }
+
+            if scalar.value >= 0xF700, scalar.value <= 0xF8FF {
+                return nil
+            }
+        }
+
+        return characters
+    }
+
+    static func keyEvent(
+        from event: NSEvent,
+        action: ghostty_input_action_e,
+        translationFlags: NSEvent.ModifierFlags? = nil
+    ) -> ghostty_input_key_s {
         var key = ghostty_input_key_s()
         key.action = action
         key.mods = mods(from: event)
@@ -580,7 +690,7 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
         // consumed_mods tells ghostty which modifiers were already applied by the
         // platform's text input system. Control and command never contribute to text
         // translation, so exclude them — everything else (shift, option, caps) is consumed.
-        let consumedFlags = event.modifierFlags.subtracting([.control, .command])
+        let consumedFlags = (translationFlags ?? event.modifierFlags).subtracting([.control, .command])
         key.consumed_mods = mods(fromFlags: consumedFlags)
 
         // Unshifted codepoint: the character with no modifiers applied.

--- a/NexTests/SurfaceViewKeyboardTests.swift
+++ b/NexTests/SurfaceViewKeyboardTests.swift
@@ -84,4 +84,52 @@ struct SurfaceViewKeyboardTests {
         #expect(flags.contains(.command))
         #expect(flags.contains(.capsLock))
     }
+
+    @Test func ghosttyCharactersPassesThroughPrintableText() {
+        let event = keyEvent(
+            keyCode: 3,
+            characters: "f",
+            charactersIgnoringModifiers: "f"
+        )
+
+        #expect(SurfaceView.ghosttyCharacters(from: event) == "f")
+    }
+
+    @Test func ghosttyCharactersStripsControlForCtrlJ() {
+        // Ctrl+J produces U+000A (newline). ghostty handles control-character
+        // encoding internally, so we return the un-controlled character ("j")
+        // and let ghostty re-encode it based on terminal mode.
+        let event = keyEvent(
+            keyCode: 0x26,
+            modifierFlags: .control,
+            characters: "\n",
+            charactersIgnoringModifiers: "j"
+        )
+
+        #expect(SurfaceView.ghosttyCharacters(from: event) == "j")
+    }
+
+    @Test func ghosttyCharactersReturnsNilForPUAFunctionKey() {
+        // F1 lives in NSEvent's PUA range (U+F704). Returning it as text would
+        // poison ghostty's input; we expect nil so the keycode path handles it.
+        let event = keyEvent(
+            keyCode: 0x7A,
+            characters: "\u{F704}",
+            charactersIgnoringModifiers: "\u{F704}"
+        )
+
+        #expect(SurfaceView.ghosttyCharacters(from: event) == nil)
+    }
+
+    @Test func ghosttyCharactersPassesThroughMultiCharacterStrings() {
+        // Multi-scalar strings (dead-key composition, surrogate pairs, etc.)
+        // skip the single-character special cases and pass through verbatim.
+        let event = keyEvent(
+            keyCode: 0,
+            characters: "é",
+            charactersIgnoringModifiers: "e"
+        )
+
+        #expect(SurfaceView.ghosttyCharacters(from: event) == "é")
+    }
 }

--- a/NexTests/SurfaceViewKeyboardTests.swift
+++ b/NexTests/SurfaceViewKeyboardTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+@testable import Nex
+import Testing
+
+@MainActor
+struct SurfaceViewKeyboardTests {
+    private func keyEvent(
+        keyCode: UInt16,
+        modifierFlags: NSEvent.ModifierFlags = [],
+        characters: String = "",
+        charactersIgnoringModifiers: String = ""
+    ) -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: charactersIgnoringModifiers,
+            isARepeat: false,
+            keyCode: keyCode
+        )!
+    }
+
+    @Test func optionIsNotConsumedWhenTranslationDropsOption() {
+        let event = keyEvent(
+            keyCode: 3,
+            modifierFlags: .option,
+            characters: "ƒ",
+            charactersIgnoringModifiers: "f"
+        )
+
+        let key = SurfaceView.keyEvent(
+            from: event,
+            action: GHOSTTY_ACTION_PRESS,
+            translationFlags: []
+        )
+
+        #expect(key.mods.rawValue & GHOSTTY_MODS_ALT.rawValue != 0)
+        #expect(key.consumed_mods.rawValue & GHOSTTY_MODS_ALT.rawValue == 0)
+    }
+
+    @Test func optionIsConsumedWhenTranslationKeepsOption() {
+        let event = keyEvent(
+            keyCode: 3,
+            modifierFlags: .option,
+            characters: "ƒ",
+            charactersIgnoringModifiers: "f"
+        )
+
+        let key = SurfaceView.keyEvent(from: event, action: GHOSTTY_ACTION_PRESS)
+
+        #expect(key.mods.rawValue & GHOSTTY_MODS_ALT.rawValue != 0)
+        #expect(key.consumed_mods.rawValue & GHOSTTY_MODS_ALT.rawValue != 0)
+    }
+
+    @Test func rightOptionSetsAltSideBit() {
+        let rightOption = NSEvent.ModifierFlags(
+            rawValue: NSEvent.ModifierFlags.option.rawValue | UInt(NX_DEVICERALTKEYMASK)
+        )
+
+        let mods = SurfaceView.mods(fromFlags: rightOption)
+
+        #expect(mods.rawValue & GHOSTTY_MODS_ALT.rawValue != 0)
+        #expect(mods.rawValue & GHOSTTY_MODS_ALT_RIGHT.rawValue != 0)
+    }
+
+    @Test func eventModifierFlagsConvertsVisibleGhosttyMods() {
+        let mods = ghostty_input_mods_e(
+            rawValue: GHOSTTY_MODS_SHIFT.rawValue
+                | GHOSTTY_MODS_CTRL.rawValue
+                | GHOSTTY_MODS_ALT.rawValue
+                | GHOSTTY_MODS_SUPER.rawValue
+                | GHOSTTY_MODS_CAPS.rawValue
+        )
+
+        let flags = SurfaceView.eventModifierFlags(fromMods: mods)
+
+        #expect(flags.contains(.shift))
+        #expect(flags.contains(.control))
+        #expect(flags.contains(.option))
+        #expect(flags.contains(.command))
+        #expect(flags.contains(.capsLock))
+    }
+}


### PR DESCRIPTION
Respect Ghostty's `macos-option-as-alt` keyboard translation when forwarding macOS key events into embedded terminal surfaces. This keeps Option-based word navigation consistent with Ghostty when `alt+f` and `alt+b` are unbound.[^1]

- Users can use left or right Option as Alt according to their Ghostty `macos-option-as-alt` setting.
- Shell word navigation with `Alt+F` and `Alt+B` works when those Ghostty keybinds are unbound.
- Right Option handling follows Ghostty's sided modifier bits, so `left` and `right` settings stay distinct.

Fixes #89.

[^1]: Nex now asks libghostty which modifiers should be used for text translation, while still forwarding original modifiers for binding and terminal encoding.
