### PR TITLE
feat: right-click copy in markdown preview pane (#118)

### DIFF
--- a/Nex/Features/MarkdownPane/MarkdownPaneView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownPaneView.swift
@@ -2,8 +2,23 @@ import AppKit
 import SwiftUI
 import WebKit
 
+/// `userInfo` keys for `MarkdownPaneView.copyRequestNotification`:
+/// `paneID` (UUID) identifies the target pane and `kind`
+/// (`MarkdownPaneView.CopyKind` raw value) selects markdown vs. rich.
+enum MarkdownCopyKind: String {
+    case markdown
+    case richText
+}
+
 /// Renders a markdown file in a WKWebView with live file watching.
 struct MarkdownPaneView: NSViewRepresentable {
+    /// Posted by the pane header's Copy button to ask the matching
+    /// Coordinator to write the file's contents to the pasteboard.
+    /// userInfo: `{"paneID": UUID, "kind": MarkdownCopyKind.rawValue}`.
+    static let copyRequestNotification = Notification.Name(
+        "MarkdownPaneView.copyRequest"
+    )
+
     let paneID: UUID
     let filePath: String
     let isFocused: Bool
@@ -34,7 +49,8 @@ struct MarkdownPaneView: NSViewRepresentable {
             forMainFrameOnly: true
         ))
 
-        let webView = WKWebView(frame: .zero, configuration: config)
+        let webView = MarkdownPreviewWebView(frame: .zero, configuration: config)
+        webView.coordinator = context.coordinator
         webView.setValue(false, forKey: "drawsBackground")
         webView.underPageBackgroundColor = .clear
         webView.navigationDelegate = context.coordinator
@@ -48,6 +64,7 @@ struct MarkdownPaneView: NSViewRepresentable {
         context.coordinator.fontSize = fontSize
         context.coordinator.loadFile()
         context.coordinator.startWatching()
+        context.coordinator.startObservingCopyRequests()
 
         container.embed(webView)
 
@@ -89,6 +106,7 @@ struct MarkdownPaneView: NSViewRepresentable {
 
     static func dismantleNSView(_: PaneFocusView, coordinator: Coordinator) {
         coordinator.stopWatching()
+        coordinator.stopObservingCopyRequests()
         coordinator.webView = nil
     }
 
@@ -104,6 +122,10 @@ struct MarkdownPaneView: NSViewRepresentable {
         var fontSize: Double = Pane.defaultMarkdownFontSize
         var lastIsFocused: Bool = false
         private var currentContent: String = ""
+        /// Tracks whether the last `loadFile` actually read the file. When
+        /// false, `currentContent` is the synthetic "Failed to load…"
+        /// blockquote and the copy actions should bail.
+        private var didLoadSuccessfully: Bool = false
         /// Monotonic token: incremented before each render, checked after
         /// the async `window.scrollY` round-trip to drop stale reloads when
         /// the user holds Cmd+= / Cmd+- and multiple renders are in flight.
@@ -111,17 +133,26 @@ struct MarkdownPaneView: NSViewRepresentable {
         var pendingScrollFraction: CGFloat?
         nonisolated(unsafe) var fileWatcher: DispatchSourceFileSystemObject?
         nonisolated(unsafe) var fileDescriptor: Int32 = -1
+        private var copyObserver: NSObjectProtocol?
 
         func loadFile() {
             guard !filePath.isEmpty else { return }
 
             let content: String
+            let loaded: Bool
             do {
                 content = try String(contentsOfFile: filePath, encoding: .utf8)
+                loaded = true
             } catch {
                 content = "> Failed to load file: \(filePath)\n>\n> \(error.localizedDescription)"
+                loaded = false
             }
 
+            // Set the load-success flag before the unchanged-content
+            // guard so an initially-empty file (where content == "" ==
+            // currentContent) is still marked loaded — otherwise the
+            // copy actions would silently bail.
+            didLoadSuccessfully = loaded
             guard content != currentContent else { return }
             currentContent = content
             renderAndReload(content: content)
@@ -228,6 +259,38 @@ struct MarkdownPaneView: NSViewRepresentable {
             fileDescriptor = -1
         }
 
+        // MARK: - Copy request observer
+
+        func startObservingCopyRequests() {
+            copyObserver = NotificationCenter.default.addObserver(
+                forName: MarkdownPaneView.copyRequestNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] note in
+                guard let self,
+                      let target = note.userInfo?["paneID"] as? UUID,
+                      target == paneID,
+                      let raw = note.userInfo?["kind"] as? String,
+                      let kind = MarkdownCopyKind(rawValue: raw)
+                else { return }
+                MainActor.assumeIsolated {
+                    switch kind {
+                    case .markdown:
+                        self.copyAsMarkdown()
+                    case .richText:
+                        self.copyAsRichText()
+                    }
+                }
+            }
+        }
+
+        func stopObservingCopyRequests() {
+            if let copyObserver {
+                NotificationCenter.default.removeObserver(copyObserver)
+            }
+            copyObserver = nil
+        }
+
         // MARK: - WKNavigationDelegate
 
         /// Intercept link clicks — open in default browser instead of navigating in-place.
@@ -245,5 +308,117 @@ struct MarkdownPaneView: NSViewRepresentable {
             }
             decisionHandler(.allow)
         }
+
+        // MARK: - Copy actions
+
+        /// Copy the whole document's source markdown (front-matter
+        /// stripped) to the pasteboard. Selection-aware copy was
+        /// abandoned — the block-level source map couldn't represent
+        /// partial-block selections faithfully, and the resulting
+        /// behaviour was inconsistent enough that the simpler
+        /// whole-file contract is preferable.
+        func copyAsMarkdown() {
+            guard didLoadSuccessfully else { return }
+            let body = FrontMatterExtractor.extract(currentContent).body
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(body, forType: .string)
+        }
+
+        /// Copy the whole rendered document as rich text. Front-matter
+        /// is stripped (its table makes `NSAttributedString.rtf(from:)`
+        /// return nil, which silently drops RTF from the pasteboard).
+        ///
+        /// Relative URLs in the rendered HTML (e.g. `src="diagram.png"`
+        /// for an inline image alongside the markdown file) are
+        /// resolved against the file's parent directory before the
+        /// HTML→RTF import, so the resulting rich-text paste keeps
+        /// working image and link references. Without this rewrite,
+        /// AppKit's HTML importer treats relative paths as relative to
+        /// nothing and the resources disappear in the paste target.
+        func copyAsRichText() {
+            guard didLoadSuccessfully else { return }
+            let baseURL = filePath.isEmpty
+                ? nil
+                : URL(fileURLWithPath: filePath).deletingLastPathComponent()
+            let js = """
+            (function() {
+                var content = document.getElementById('content');
+                if (!content) { return document.body.innerHTML; }
+                var clone = content.cloneNode(true);
+                var fm = clone.querySelectorAll(
+                    '.frontmatter, .frontmatter-raw, .frontmatter-nested'
+                );
+                for (var i = 0; i < fm.length; i++) {
+                    fm[i].parentNode.removeChild(fm[i]);
+                }
+                return clone.innerHTML;
+            })();
+            """
+            webView?.evaluateJavaScript(js) { result, _ in
+                guard let html = result as? String, !html.isEmpty,
+                      let data = html.data(using: .utf8) else { return }
+                var options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue
+                ]
+                if let baseURL {
+                    options[.baseURL] = baseURL
+                }
+                guard let attr = try? NSAttributedString(
+                    data: data, options: options, documentAttributes: nil
+                ) else { return }
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(attr.string, forType: .string)
+                if let rtf = attr.rtf(from: NSRange(location: 0, length: attr.length)) {
+                    pasteboard.setData(rtf, forType: .rtf)
+                }
+                pasteboard.setString(html, forType: .html)
+            }
+        }
+    }
+}
+
+// MARK: - MarkdownPreviewWebView
+
+/// `WKWebView` subclass that augments the macOS context menu with
+/// "Copy as Markdown" and "Copy as Rich Text" entries at the top.
+final class MarkdownPreviewWebView: WKWebView {
+    weak var coordinator: MarkdownPaneView.Coordinator?
+
+    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
+        super.willOpenMenu(menu, with: event)
+
+        // Defensive: WKWebView is expected to hand us a fresh menu per
+        // invocation, but if the same NSMenu is ever reused across openings
+        // we don't want our items duplicated on each right-click.
+        if menu.item(withTitle: "Copy as Markdown") != nil { return }
+
+        let copyMd = NSMenuItem(
+            title: "Copy as Markdown",
+            action: #selector(copyAsMarkdownAction(_:)),
+            keyEquivalent: ""
+        )
+        copyMd.target = self
+
+        let copyRtf = NSMenuItem(
+            title: "Copy as Rich Text",
+            action: #selector(copyAsRichTextAction(_:)),
+            keyEquivalent: ""
+        )
+        copyRtf.target = self
+
+        menu.insertItem(copyMd, at: 0)
+        menu.insertItem(copyRtf, at: 1)
+        menu.insertItem(NSMenuItem.separator(), at: 2)
+    }
+
+    @objc private func copyAsMarkdownAction(_: Any?) {
+        coordinator?.copyAsMarkdown()
+    }
+
+    @objc private func copyAsRichTextAction(_: Any?) {
+        coordinator?.copyAsRichText()
     }
 }

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -104,6 +104,12 @@ struct PaneGridView: View {
                 onToggleZoom: onToggleZoom,
                 isEditing: pane.isEditing,
                 onToggleEdit: pane.type == .markdown ? { onToggleMarkdownEdit(pane.id) } : nil,
+                onCopyMarkdown: pane.type == .markdown
+                    ? { postMarkdownCopy(pane.id, kind: .markdown) }
+                    : nil,
+                onCopyRichText: pane.type == .markdown
+                    ? { postMarkdownCopy(pane.id, kind: .richText) }
+                    : nil,
                 onRefreshDiff: pane.type == .diff
                     ? { diffRefreshTokens[pane.id, default: 0] &+= 1 }
                     : nil,
@@ -303,6 +309,14 @@ struct PaneGridView: View {
             .frame(width: overlayRect.width, height: overlayRect.height)
             .offset(x: overlayRect.origin.x, y: overlayRect.origin.y)
             .allowsHitTesting(false)
+    }
+
+    private func postMarkdownCopy(_ paneID: UUID, kind: MarkdownCopyKind) {
+        NotificationCenter.default.post(
+            name: MarkdownPaneView.copyRequestNotification,
+            object: nil,
+            userInfo: ["paneID": paneID, "kind": kind.rawValue]
+        )
     }
 
     private var emptyView: some View {

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -15,6 +15,8 @@ struct PaneHeaderView: View {
     var onToggleZoom: (() -> Void)?
     var isEditing: Bool = false
     var onToggleEdit: (() -> Void)?
+    var onCopyMarkdown: (() -> Void)?
+    var onCopyRichText: (() -> Void)?
     var onRefreshDiff: (() -> Void)?
     var onDragChanged: ((CGPoint) -> Void)?
     var onDragEnded: (() -> Void)?
@@ -100,6 +102,25 @@ struct PaneHeaderView: View {
                 .padding(.horizontal, 4)
                 .padding(.vertical, 1)
                 .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 3))
+            }
+
+            if pane.type == .markdown, !isEditing,
+               let onCopyMarkdown, let onCopyRichText {
+                Button(action: {
+                    showCopyMenu(
+                        onCopyMarkdown: onCopyMarkdown,
+                        onCopyRichText: onCopyRichText
+                    )
+                }) {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20, height: 20)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .opacity(0.6)
+                .help("Copy whole file")
             }
 
             if pane.type == .markdown, let onToggleEdit {
@@ -244,6 +265,55 @@ struct PaneHeaderView: View {
         NSPasteboard.general.setString(pane.workingDirectory, forType: .string)
     }
 
+    /// Show a popup menu at the current mouse location. Using an
+    /// NSMenu rather than SwiftUI's `Menu` lets the button match the
+    /// visual size of the surrounding plain Buttons — `Menu` adds
+    /// chrome padding that makes its hit target taller than its peers.
+    ///
+    /// `popUp(positioning:at:in:)` is used instead of
+    /// `popUpContextMenu(_:with:for:)` because the latter relies on
+    /// `NSApp.currentEvent`, which by the time SwiftUI's button action
+    /// fires is no longer the originating click — that produced a
+    /// noticeable (~1 second) delay before the menu appeared.
+    private func showCopyMenu(
+        onCopyMarkdown: @escaping () -> Void,
+        onCopyRichText: @escaping () -> Void
+    ) {
+        let menu = NSMenu()
+        let mdItem = NSMenuItem(
+            title: "Copy as Markdown",
+            action: nil,
+            keyEquivalent: ""
+        )
+        mdItem.representedObject = ClosureBox(onCopyMarkdown)
+        mdItem.target = MenuActionTarget.shared
+        mdItem.action = #selector(MenuActionTarget.invoke(_:))
+
+        let rtfItem = NSMenuItem(
+            title: "Copy as Rich Text",
+            action: nil,
+            keyEquivalent: ""
+        )
+        rtfItem.representedObject = ClosureBox(onCopyRichText)
+        rtfItem.target = MenuActionTarget.shared
+        rtfItem.action = #selector(MenuActionTarget.invoke(_:))
+
+        menu.addItem(mdItem)
+        menu.addItem(rtfItem)
+
+        // Position the menu under the cursor in view-local coordinates.
+        guard let window = NSApp.keyWindow,
+              let contentView = window.contentView
+        else {
+            menu.popUp(positioning: nil, at: .zero, in: nil)
+            return
+        }
+        let screenPoint = NSEvent.mouseLocation
+        let windowPoint = window.convertPoint(fromScreen: screenPoint)
+        let viewPoint = contentView.convert(windowPoint, from: nil)
+        menu.popUp(positioning: nil, at: viewPoint, in: contentView)
+    }
+
     private var displayPath: String {
         if pane.type == .scratchpad {
             return "Scratchpad"
@@ -264,5 +334,27 @@ struct PaneHeaderView: View {
             return "~" + path.dropFirst(home.count)
         }
         return path
+    }
+}
+
+// MARK: - NSMenu closure dispatch
+
+/// Box for invoking a `() -> Void` closure from an NSMenuItem's
+/// `representedObject`. NSMenuItem.action needs an @objc target, so we
+/// route through a shared dispatcher that pulls the closure off the
+/// menu item that fired the action.
+private final class ClosureBox {
+    let closure: () -> Void
+    init(_ closure: @escaping () -> Void) {
+        self.closure = closure
+    }
+}
+
+@MainActor
+private final class MenuActionTarget: NSObject {
+    static let shared = MenuActionTarget()
+
+    @objc func invoke(_ sender: NSMenuItem) {
+        (sender.representedObject as? ClosureBox)?.closure()
     }
 }


### PR DESCRIPTION
## Summary
- Right-click in a markdown preview pane to copy the whole file as markdown source or as rich text (RTF + HTML).
- doc.on.doc icon in the pane header (preview mode only) pops a popup menu with the same two options.
- YAML front matter is stripped from both outputs; relative image/link URLs survive into the rich-text paste via `baseURL`.

Closes #118.

## Reviewer notes
- Selection-aware copy (only copying the highlighted text as source markdown) was explored but abandoned — the block-level source map can't represent partial-block selections faithfully and the behaviour surprised users. Both copy paths now always operate on the whole file.
- The header button uses an `NSMenu` triggered via `popUp(positioning:at:in:)`. SwiftUI's `Menu` adds chrome padding that visibly enlarges the button vs its siblings; `popUpContextMenu(_:with:for:)` reads `NSApp.currentEvent` which is stale by the time SwiftUI dispatches the Button action, producing a ~1s lag.
- The Coordinator listens for `MarkdownPaneView.copyRequestNotification` keyed on paneID, so the header callback can reach the Coordinator (which owns the WKWebView) without threading a reference through the reducer.

## Validation
- Validated in a sandboxed macOS VM via cua/lume.
- Per-issue assertions:
  - TEST 1: right-click in whitespace → Copy as Markdown → clipboard = whole body (front matter stripped).
  - TEST 2: right-click in whitespace → Copy as Rich Text → plain-text view = rendered text; pasteboard carries `class HTML` + `class RTF` flavours.
  - TEST 3: double-click a word → right-click → Copy as Markdown → clipboard = whole body (V2 contract: selection ignored).
- Screenshots: `/Users/ben/code/cua/out/branches/feat-markdown-pane-right-click-copy/issue-118/`

## Test plan
- [ ] Open a `.md` file with front matter, right-click in preview, run both Copy actions, paste into TextEdit and a rich-text target (Mail / Notes).
- [ ] Click the doc.on.doc icon in the header; menu appears instantly under the cursor.
- [ ] Toggle ⌘E to edit mode → header copy button disappears.
- [ ] Open an empty markdown file; both Copy actions succeed (clipboard cleared / empty body written).
- [ ] Open a markdown file with a relative `![alt](image.png)` next to it; Copy as Rich Text → paste into Mail → image renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)