### PR TITLE
fix: multi-select workspace context menu acts on whole selection

### DIFF
--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -526,44 +526,84 @@ struct WorkspaceListView: View {
         let isBulkTarget = selection.contains(workspaceID) && selection.count > 1
         if isBulkTarget {
             Text("\(selection.count) workspaces selected")
-            Menu("Color All Selected") {
+            Menu("Color \(selection.count) Workspaces") {
                 ForEach(WorkspaceColor.allCases) { color in
                     Button(color.displayName) {
                         store.send(.setBulkColor(color))
                     }
                 }
             }
-            Button("Group Selected Workspaces...") {
+            Button("Group \(selection.count) Workspaces...") {
                 store.send(.requestBulkCreateGroup)
             }
+            moveToGroupBulkMenu(selection: selection)
+            Divider()
+            Button("Select All Workspaces") { store.send(.selectAllWorkspaces) }
+                .disabled(store.selectedWorkspaceIDs.count >= store.workspaces.count)
+            Button("Deselect All") { store.send(.clearWorkspaceSelection) }
+            Divider()
             Button("Delete \(selection.count) Workspaces...", role: .destructive) {
                 store.send(.requestBulkDelete)
             }
             .disabled(selection.count >= store.workspaces.count)
+        } else {
+            Button("Rename...") {
+                store.send(.setRenamingWorkspaceID(workspaceID))
+            }
+            Menu("Color") {
+                ForEach(WorkspaceColor.allCases) { color in
+                    Button(color.displayName) {
+                        workspaceStore.send(.setColor(color))
+                    }
+                }
+            }
+            moveToGroupMenu(workspaceID: workspaceID)
             Divider()
+            Button("Select All Workspaces") { store.send(.selectAllWorkspaces) }
+                .disabled(store.selectedWorkspaceIDs.count >= store.workspaces.count)
+            if !store.selectedWorkspaceIDs.isEmpty {
+                Button("Deselect All") { store.send(.clearWorkspaceSelection) }
+            }
+            Divider()
+            Button("Delete", role: .destructive) {
+                store.send(.deleteWorkspace(workspaceID))
+            }
+            .disabled(store.workspaces.count <= 1)
         }
-        Button("Rename...") {
-            store.send(.setRenamingWorkspaceID(workspaceID))
-        }
-        Menu("Color") {
-            ForEach(WorkspaceColor.allCases) { color in
-                Button(color.displayName) {
-                    workspaceStore.send(.setColor(color))
+    }
+
+    /// Bulk "Move to Group ▸" submenu used when 2+ workspaces are selected.
+    /// Routes through `.moveWorkspacesToGroup` so the move is atomic and
+    /// preserves the same insertion semantics as multi-select drag-and-drop.
+    @ViewBuilder
+    private func moveToGroupBulkMenu(selection: Set<UUID>) -> some View {
+        let inAnyGroup = selection.contains { store.state.groupID(forWorkspace: $0) != nil }
+        if !store.groups.isEmpty || inAnyGroup {
+            let ordered = workspaceIDs(sortedBySidebar: selection)
+            Menu("Move \(selection.count) Workspaces to Group") {
+                if inAnyGroup {
+                    Button("Remove from Group") {
+                        store.send(.moveWorkspacesToGroup(
+                            ids: ordered, groupID: nil, index: nil
+                        ))
+                    }
+                    Divider()
+                }
+                if !store.groups.isEmpty {
+                    ForEach(store.groups) { group in
+                        let allInThisGroup = selection.allSatisfy {
+                            store.state.groupID(forWorkspace: $0) == group.id
+                        }
+                        Button(group.name) {
+                            store.send(.moveWorkspacesToGroup(
+                                ids: ordered, groupID: group.id, index: nil
+                            ))
+                        }
+                        .disabled(allInThisGroup)
+                    }
                 }
             }
         }
-        moveToGroupMenu(workspaceID: workspaceID)
-        Divider()
-        Button("Select All Workspaces") { store.send(.selectAllWorkspaces) }
-            .disabled(store.selectedWorkspaceIDs.count >= store.workspaces.count)
-        if !store.selectedWorkspaceIDs.isEmpty {
-            Button("Deselect All") { store.send(.clearWorkspaceSelection) }
-        }
-        Divider()
-        Button("Delete", role: .destructive) {
-            store.send(.deleteWorkspace(workspaceID))
-        }
-        .disabled(store.workspaces.count <= 1)
     }
 
     /// "Move to Group ▸" submenu attached to a workspace row's context menu.


### PR DESCRIPTION
## Summary
- When 2+ workspaces are multi-selected and the user right-clicks on one of them, the context menu now shows only bulk-relevant actions (Color N Workspaces, Group N Workspaces, Move N Workspaces to Group, Select All / Deselect All, Delete N Workspaces). The standalone single-target "Delete" entry no longer appears alongside the bulk one.
- Right-clicking a workspace that is NOT in the multi-selection still shows the single-target menu (Rename, Color, Move to Group, Select All / Deselect All, Delete) for that one workspace, matching macOS convention.
- Added a bulk "Move N Workspaces to Group" submenu routed through the existing `.moveWorkspacesToGroup` reducer action - the same atomic path that multi-select drag-and-drop already uses.

Closes #120

## Reviewer notes
- Rename is intentionally hidden in bulk mode (no bulk-rename semantics).
- "Move to Group" in single mode still routes through `.moveWorkspaceToGroup` (per-id); the bulk variant uses `.moveWorkspacesToGroup` (atomic, sidebar-ordered).
- `.disabled(selection.count >= store.workspaces.count)` guards the bulk Delete button; the reducer (`AppReducer.swift:1507, 1518`) already refuses to delete every workspace, so the disabled state matches the reducer guard.

## Validation
- Validated in a sandboxed macOS VM via cua/lume.
- CLI assertions:
  - Build, launch, and initial pane count.
  - `nex workspace create` creates two extra workspaces (Default + alpha + beta).
  - `nex pane split --direction horizontal` still works (smoke check for the surrounding view path).
- Screenshots: `/Users/ben/code/cua/out/branches/ship-issue-120-multiselect-delete/issue-120/`
- The actual context-menu structure is visual; verified manually in the keep-alive VM (`eerie-hyena`).

## Test plan
- [x] Cmd-click two workspace rows; right-click one selected row -> menu shows "N workspaces selected" header, bulk-labelled entries, no standalone Delete.
- [x] Right-click a workspace NOT in the selection -> single-target menu for that workspace.
- [x] Trigger "Delete N Workspaces..." -> confirmation alert -> all selected workspaces are removed.
- [x] Trigger "Color N Workspaces" -> pick a colour -> every selected workspace recolours.
- [x] Create a group, then "Move N Workspaces to Group" -> every selected workspace moves to the group atomically; sidebar order preserved.
- [x] With every workspace selected, the bulk Delete button is disabled (reducer also refuses).
- [x] Single-selected workspace still shows the legacy single-target menu.