### PR TITLE
feat: workspace labels with sidebar filter (#93)

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0D7D8E5C230B6C98E7693D66 /* PaneListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */; };
 		0EAFF0FDB683293F95D8AB47 /* RenameWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */; };
 		0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B822ABF12B071E574E089BB4 /* GroupIconTests.swift */; };
+		13CFD579791838D9D23C9613 /* WorkspaceLabelViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684EF74D8EC3F295B22944AB /* WorkspaceLabelViews.swift */; };
 		149E80DD671127055EF67F7F /* DiffHTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */; };
 		14C1E964B19A8C277D5EA5E4 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE56BB11F5C7C34821411297 /* QuartzCore.framework */; };
 		1569F35B72EC7C133643190E /* PaneType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377C07C6C4B00D0699682EA3 /* PaneType.swift */; };
@@ -201,6 +202,7 @@
 		5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingTests.swift; sourceTree = "<group>"; };
 		61D6AE6635332105A3C18A03 /* VibrancyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrancyView.swift; sourceTree = "<group>"; };
 		67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameWorkspaceSheet.swift; sourceTree = "<group>"; };
+		684EF74D8EC3F295B22944AB /* WorkspaceLabelViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLabelViews.swift; sourceTree = "<group>"; };
 		6B4B95F852C737F18989F8FA /* WorkspaceColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceColor.swift; sourceTree = "<group>"; };
 		6BB526BDDE50E6C7948EE832 /* NexTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NexTheme.swift; sourceTree = "<group>"; };
 		6BB83805BDFAC2F7DB8FF064 /* GroupHeaderRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupHeaderRow.swift; sourceTree = "<group>"; };
@@ -513,6 +515,7 @@
 				0C975C89EC3EAA135F52A7AD /* WorkspaceDropTarget.swift */,
 				1BA6AA9E98405375983902BD /* WorkspaceFeature.swift */,
 				57C59BDCBA03302FC7FDE16B /* WorkspaceInspectorView.swift */,
+				684EF74D8EC3F295B22944AB /* WorkspaceLabelViews.swift */,
 				F7F9C43CA9B19E7281082913 /* WorkspaceListView.swift */,
 				C58BE92A0878D9CCC786A657 /* WorkspaceRowView.swift */,
 			);
@@ -841,6 +844,7 @@
 				E62618BAC6927017CC4ECC44 /* WorkspaceFeature.swift in Sources */,
 				A33EF4059D3F3479ED5C9EE2 /* WorkspaceGroup.swift in Sources */,
 				E89E89193A52010164900B00 /* WorkspaceInspectorView.swift in Sources */,
+				13CFD579791838D9D23C9613 /* WorkspaceLabelViews.swift in Sources */,
 				3B60C0FC48A2AAF6282CAB40 /* WorkspaceListView.swift in Sources */,
 				8043643CBDD85AF3315BBFE2 /* WorkspaceRowView.swift in Sources */,
 			);

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -44,6 +44,11 @@ struct WorkspaceFeature {
         var currentLayoutIndex: Int?
         var createdAt: Date
         var lastAccessedAt: Date
+        /// Free-form tags attached to this workspace. Ordered (preserves
+        /// add order), deduplicated case-sensitively. Empty by default.
+        /// Drives the sidebar filter — see `WorkspaceListView` filter
+        /// field and `WorkspaceInspectorView` label editor.
+        var labels: [String] = []
 
         init(
             id: UUID = UUID(),
@@ -76,7 +81,8 @@ struct WorkspaceFeature {
             focusedPaneID: UUID?,
             repoAssociations: IdentifiedArrayOf<RepoAssociation> = [],
             createdAt: Date,
-            lastAccessedAt: Date
+            lastAccessedAt: Date,
+            labels: [String] = []
         ) {
             self.id = id
             self.name = name
@@ -88,6 +94,7 @@ struct WorkspaceFeature {
             self.repoAssociations = repoAssociations
             self.createdAt = createdAt
             self.lastAccessedAt = lastAccessedAt
+            self.labels = labels
         }
 
         /// Read a pane wherever it lives — visible layout or the
@@ -153,6 +160,9 @@ struct WorkspaceFeature {
     enum Action: Equatable {
         case rename(String)
         case setColor(WorkspaceColor)
+        case addLabel(String)
+        case removeLabel(String)
+        case setLabels([String])
         case createPane
         case splitPaneAtPath(String, label: String? = nil, direction: PaneLayout.SplitDirection = .horizontal)
         case splitPane(direction: PaneLayout.SplitDirection, sourcePaneID: UUID?, label: String? = nil)
@@ -199,6 +209,20 @@ struct WorkspaceFeature {
 
     private enum SearchDebounceID: Hashable { case debounce }
 
+    /// Maximum label length after trimming. Generous enough for any
+    /// reasonable status/tag string while preventing a multi-KB paste
+    /// from blowing up row/inspector layout.
+    static let maxLabelLength = 64
+
+    /// Trim whitespace and clamp to `maxLabelLength`. Returns `""` for
+    /// labels that are empty after trimming; callers should treat an
+    /// empty result as "ignore".
+    static func normalizeLabel(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count <= maxLabelLength { return trimmed }
+        return String(trimmed.prefix(maxLabelLength))
+    }
+
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.ghosttyConfig) var ghosttyConfig
     @Dependency(\.gitService) var gitService
@@ -216,6 +240,29 @@ struct WorkspaceFeature {
 
             case .setColor(let color):
                 state.color = color
+                return .none
+
+            case .addLabel(let raw):
+                let normalized = WorkspaceFeature.normalizeLabel(raw)
+                guard !normalized.isEmpty else { return .none }
+                if !state.labels.contains(normalized) {
+                    state.labels.append(normalized)
+                }
+                return .none
+
+            case .removeLabel(let label):
+                state.labels.removeAll { $0 == label }
+                return .none
+
+            case .setLabels(let raw):
+                var seen = Set<String>()
+                var deduped: [String] = []
+                for entry in raw {
+                    let normalized = WorkspaceFeature.normalizeLabel(entry)
+                    guard !normalized.isEmpty, seen.insert(normalized).inserted else { continue }
+                    deduped.append(normalized)
+                }
+                state.labels = deduped
                 return .none
 
             case .createPane:

--- a/Nex/Features/Workspace/WorkspaceInspectorView.swift
+++ b/Nex/Features/Workspace/WorkspaceInspectorView.swift
@@ -13,6 +13,8 @@ struct WorkspaceInspectorView: View {
     @State private var worktreeRepoID: UUID?
     @State private var worktreeName = ""
     @State private var worktreeBranchName = ""
+    @State private var newLabelText = ""
+    @FocusState private var isLabelFieldFocused: Bool
 
     var body: some View {
         WithPerceptionTracking {
@@ -38,6 +40,11 @@ struct WorkspaceInspectorView: View {
                         VStack(alignment: .leading, spacing: 16) {
                             // Workspace metadata
                             workspaceSection(workspace)
+
+                            Divider()
+
+                            // Labels
+                            labelsSection(workspace, activeID: activeID)
 
                             Divider()
 
@@ -139,6 +146,67 @@ struct WorkspaceInspectorView: View {
                 .font(.caption)
                 .foregroundStyle(.tertiary)
         }
+    }
+
+    private func labelsSection(_ workspace: WorkspaceFeature.State, activeID: UUID) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Labels", systemImage: "tag")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("inspector.labels.heading")
+
+            if !workspace.labels.isEmpty {
+                LabelFlowLayout(spacing: 4) {
+                    ForEach(workspace.labels, id: \.self) { label in
+                        LabelChip(text: label) {
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .removeLabel(label)
+                            )))
+                        }
+                    }
+                }
+            }
+
+            HStack(spacing: 6) {
+                TextField("Add label", text: $newLabelText)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12))
+                    .focused($isLabelFieldFocused)
+                    .accessibilityIdentifier("inspector.labels.field")
+                    .onSubmit { commitNewLabel(activeID: activeID) }
+
+                let isEmpty = newLabelText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                Button {
+                    commitNewLabel(activeID: activeID)
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundStyle(isEmpty ? AnyShapeStyle(.secondary) : AnyShapeStyle(Color.accentColor))
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("inspector.labels.add")
+                .disabled(isEmpty)
+            }
+        }
+    }
+
+    private func commitNewLabel(activeID: UUID) {
+        // Split on commas/newlines so users can paste comma-separated
+        // tags ("backend, priority, blocked") in one shot. Single
+        // entries (no separator) still flow through unchanged.
+        let parts = newLabelText
+            .split(whereSeparator: { $0 == "," || $0 == "\n" })
+            .map { String($0) }
+        var sentAny = false
+        for part in parts {
+            let normalized = WorkspaceFeature.normalizeLabel(part)
+            guard !normalized.isEmpty else { continue }
+            store.send(.workspaces(.element(id: activeID, action: .addLabel(normalized))))
+            sentAny = true
+        }
+        guard sentAny else { return }
+        newLabelText = ""
+        isLabelFieldFocused = true
     }
 
     private func repoSection(_ workspace: WorkspaceFeature.State, activeID: UUID) -> some View {

--- a/Nex/Features/Workspace/WorkspaceLabelViews.swift
+++ b/Nex/Features/Workspace/WorkspaceLabelViews.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+/// Pill-style label chip with an optional remove (✕) button. Used by
+/// the workspace inspector (with onRemove) and by the workspace row
+/// (read-only, onRemove == nil).
+struct LabelChip: View {
+    let text: String
+    var onRemove: (() -> Void)?
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Text(text)
+                .font(.system(size: 10, weight: .medium))
+                .lineLimit(1)
+
+            if let onRemove {
+                Button(action: onRemove) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .bold))
+                        .frame(width: 14, height: 14)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remove label \(text)")
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(
+            Capsule()
+                .fill(Color.secondary.opacity(0.18))
+        )
+        .overlay(
+            Capsule()
+                .stroke(Color.secondary.opacity(0.25), lineWidth: 0.5)
+        )
+        .foregroundStyle(.primary)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Label: \(text)")
+    }
+}
+
+/// Compact read-only chip used inside workspace rows. Smaller padding +
+/// font than `LabelChip` so several fit on one line under the row
+/// metadata without crowding the agent status dot.
+struct RowLabelChip: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 9, weight: .medium))
+            .lineLimit(1)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(
+                Capsule()
+                    .fill(Color.secondary.opacity(0.18))
+            )
+            .foregroundStyle(.secondary)
+    }
+}
+
+/// Wrap-on-overflow horizontal flow layout. Lays children left-to-right
+/// and wraps to the next line when the proposed width is exceeded. Used
+/// for chip clouds (labels in the inspector). Keeps each row's height
+/// at the tallest child in that row.
+struct LabelFlowLayout: Layout {
+    var spacing: CGFloat = 4
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache _: inout ()
+    ) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = computeRows(maxWidth: maxWidth, subviews: subviews)
+        let height = rows.reduce(CGFloat(0)) { acc, row in
+            acc + row.height + (acc > 0 ? spacing : 0)
+        }
+        let width = rows.map(\.width).max() ?? 0
+        return CGSize(width: min(width, maxWidth), height: height)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache _: inout ()
+    ) {
+        let maxWidth = proposal.width ?? bounds.width
+        let rows = computeRows(maxWidth: maxWidth, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            var x = bounds.minX
+            for entry in row.entries {
+                subviews[entry.index].place(
+                    at: CGPoint(x: x, y: y),
+                    proposal: ProposedViewSize(width: entry.size.width, height: entry.size.height)
+                )
+                x += entry.size.width + spacing
+            }
+            y += row.height + spacing
+        }
+    }
+
+    private struct Row {
+        var entries: [Entry] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private struct Entry {
+        let index: Int
+        let size: CGSize
+    }
+
+    private func computeRows(maxWidth: CGFloat, subviews: Subviews) -> [Row] {
+        var rows: [Row] = [Row()]
+        for (index, subview) in subviews.enumerated() {
+            let size = subview.sizeThatFits(.unspecified)
+            let lastIndex = rows.count - 1
+            let needsNewRow = !rows[lastIndex].entries.isEmpty
+                && rows[lastIndex].width + spacing + size.width > maxWidth
+            if needsNewRow {
+                rows.append(Row())
+            }
+            let i = rows.count - 1
+            let entry = Entry(index: index, size: size)
+            if rows[i].entries.isEmpty {
+                rows[i].width = size.width
+            } else {
+                rows[i].width += spacing + size.width
+            }
+            rows[i].height = max(rows[i].height, size.height)
+            rows[i].entries.append(entry)
+        }
+        return rows
+    }
+}

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -48,6 +48,14 @@ struct WorkspaceListView: View {
     /// the other selected rows behind in their original slots.
     @State private var hiddenMultiDragIDs: Set<UUID> = []
 
+    /// Case-insensitive substring filter for the sidebar. Matches
+    /// against workspace name AND any of its labels. View-local —
+    /// neither persisted nor in AppReducer state — so keyboard
+    /// shortcuts (Cmd+1..9, Cmd+Shift+] / [) still address the full
+    /// workspace set.
+    @State private var filterText: String = ""
+    @FocusState private var isFilterFieldFocused: Bool
+
     /// Post-release "land into collapsed group" override. When dropping a
     /// row onto a collapsed group that stays collapsed, the default
     /// release (offset → 0 + entries-change fade) makes the row visually
@@ -102,6 +110,24 @@ struct WorkspaceListView: View {
     private static let autoScrollIntervalMillis: Int = 15
 
     var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                // Render once at the top so the TextField keeps its
+                // SwiftUI identity (and `@FocusState`) as `filterText`
+                // toggles between empty and non-empty — otherwise the
+                // field's responder is torn down on the first keystroke
+                // and the caret disappears mid-type.
+                filterField
+                if filterText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    mainListBody
+                } else {
+                    filteredListBody
+                }
+            }
+        }
+    }
+
+    private var mainListBody: some View {
         WithPerceptionTracking {
             GeometryReader { outer in
                 ScrollView {
@@ -481,6 +507,181 @@ struct WorkspaceListView: View {
         return ids
     }
 
+    private var filterField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+            TextField("Filter workspaces or labels", text: $filterText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11))
+                .focused($isFilterFieldFocused)
+                .accessibilityIdentifier("sidebar.filter.field")
+                .onSubmit {
+                    // Enter activates the first match and closes the
+                    // filter — the textbook type-to-find UX.
+                    if let firstID = filteredWorkspaceIDs.first {
+                        store.send(.clearWorkspaceSelection)
+                        store.send(.setActiveWorkspace(firstID))
+                        filterText = ""
+                        isFilterFieldFocused = false
+                    }
+                }
+                .onExitCommand {
+                    // Esc clears the field and yields focus back to the
+                    // window so the next keystroke goes to the active
+                    // pane, not back into the field.
+                    filterText = ""
+                    isFilterFieldFocused = false
+                }
+
+            if !filterText.isEmpty {
+                Button {
+                    filterText = ""
+                    isFilterFieldFocused = false
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("sidebar.filter.clear")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.6))
+    }
+
+    /// Workspaces whose name OR any label contains `filterText`
+    /// (case-insensitive, leading/trailing whitespace trimmed).
+    /// Preserves the order they appear in the sidebar (walks
+    /// `topLevelOrder`, descending into groups regardless of collapse
+    /// state — when filtering, the user wants to find rows, not
+    /// respect collapse).
+    private var filteredWorkspaceIDs: [UUID] {
+        let needle = filterText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return [] }
+        var ordered: [UUID] = []
+        for item in store.topLevelOrder {
+            switch item {
+            case .workspace(let wsID):
+                if matches(workspaceID: wsID, needle: needle) {
+                    ordered.append(wsID)
+                }
+            case .group(let gID):
+                guard let group = store.groups[id: gID] else { continue }
+                for childID in group.childOrder where matches(workspaceID: childID, needle: needle) {
+                    ordered.append(childID)
+                }
+            }
+        }
+        return ordered
+    }
+
+    private func matches(workspaceID: UUID, needle: String) -> Bool {
+        guard let workspace = store.workspaces[id: workspaceID] else { return false }
+        if workspace.name.lowercased().contains(needle) { return true }
+        return workspace.labels.contains { $0.lowercased().contains(needle) }
+    }
+
+    private var filteredListBody: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                selectionHeader
+
+                ScrollView {
+                    let ids = filteredWorkspaceIDs
+                    if ids.isEmpty {
+                        VStack(spacing: 4) {
+                            Text("No matches")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.secondary)
+                            Text("Try a different filter or clear the field.")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 24)
+                        .accessibilityIdentifier("sidebar.filter.empty")
+                    } else {
+                        LazyVStack(spacing: 0) {
+                            ForEach(ids, id: \.self) { workspaceID in
+                                filteredWorkspaceRow(workspaceID: workspaceID)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                        .padding(.trailing, 8)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func filteredWorkspaceRow(workspaceID: UUID) -> some View {
+        if let workspaceStore = store.scope(state: \.workspaces[id: workspaceID], action: \.workspaces[id: workspaceID]) {
+            let aggregateStatus = aggregateGitStatus(for: workspaceStore.state)
+            let waiting = workspaceStore.panes.count(where: { $0.status == .waitingForInput })
+            let running = workspaceStore.panes.contains { $0.status == .running }
+            let parentGroupName = store.state.groupID(forWorkspace: workspaceID)
+                .flatMap { store.groups[id: $0]?.name }
+
+            VStack(alignment: .leading, spacing: 0) {
+                WorkspaceRowView(
+                    name: workspaceStore.name,
+                    color: workspaceStore.color,
+                    paneCount: workspaceStore.panes.count,
+                    repoCount: workspaceStore.repoAssociations.count,
+                    gitStatus: aggregateStatus,
+                    isActive: workspaceID == store.activeWorkspaceID,
+                    // Negative index suppresses the `⌘N` badge in
+                    // `WorkspaceRowView` (the badge is gated on `index <
+                    // 9 && index >= 0`). The filter walks workspaces
+                    // inside collapsed groups too, where the badge would
+                    // either be wrong or meaningless, so we hide it
+                    // wholesale in filtered rows.
+                    index: -1,
+                    waitingPaneCount: waiting,
+                    hasRunningPanes: running,
+                    isSelected: store.selectedWorkspaceIDs.contains(workspaceID),
+                    leadingInset: 0,
+                    labels: workspaceStore.labels
+                )
+
+                if let parentGroupName {
+                    Text("in \(parentGroupName)")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                        .padding(.leading, 20)
+                        .padding(.bottom, 2)
+                }
+            }
+            .padding(.horizontal, 8)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                let modifiers = NSEvent.modifierFlags
+                if modifiers.contains(.command) {
+                    store.send(.toggleWorkspaceSelection(workspaceID))
+                } else if modifiers.contains(.shift) {
+                    store.send(.rangeSelectWorkspace(workspaceID))
+                } else {
+                    store.send(.clearWorkspaceSelection)
+                    store.send(.setActiveWorkspace(workspaceID))
+                    // Drop the filter once the user has clicked through
+                    // to a workspace — the filter UI is a find-then-go
+                    // interaction, not a persistent view.
+                    filterText = ""
+                    isFilterFieldFocused = false
+                }
+            }
+            .contextMenu {
+                contextMenuContents(workspaceID: workspaceID, workspaceStore: workspaceStore)
+            }
+        }
+    }
+
     @ViewBuilder
     private var selectionHeader: some View {
         let count = store.selectedWorkspaceIDs.count
@@ -555,6 +756,17 @@ struct WorkspaceListView: View {
                     Button(color.displayName) {
                         workspaceStore.send(.setColor(color))
                     }
+                }
+            }
+            // Edit labels — opens the inspector so the user can find
+            // the label editor. Without this entry, the labels feature
+            // is buried behind: open inspector → scroll past
+            // Workspace + Repos → find "Labels". One click here
+            // bypasses the hunt.
+            Button("Edit Labels...") {
+                store.send(.setActiveWorkspace(workspaceID))
+                if !store.isInspectorVisible {
+                    store.send(.toggleInspector)
                 }
             }
             moveToGroupMenu(workspaceID: workspaceID)
@@ -772,7 +984,8 @@ struct WorkspaceListView: View {
                 // Use a single interpolated value so the depth change
                 // slides smoothly. 24pt matches the old layout's
                 // 16pt Spacer + 8pt HStack spacing.
-                leadingInset: effectiveDepth > 0 ? 24 : 0
+                leadingInset: effectiveDepth > 0 ? 24 : 0,
+                labels: workspaceStore.labels
             )
             .padding(.horizontal, 8)
             .background(

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -124,6 +124,88 @@ struct WorkspaceListView: View {
                     filteredListBody
                 }
             }
+            // Bulk-action dialogs and sheets are attached at the body
+            // level (not inside `mainListBody`) so they remain mounted
+            // while the filter is active. Otherwise a "Delete N
+            // Workspaces..." invoked from a filtered-list context menu
+            // would set the confirmation state but have no presenter,
+            // leaving a stale destructive prompt that fires the
+            // moment the filter is cleared.
+            .confirmationDialog(
+                bulkDeleteTitle,
+                isPresented: Binding(
+                    get: { store.bulkDeleteConfirmationIDs != nil },
+                    set: { if !$0 { store.send(.cancelBulkDelete) } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button("Delete", role: .destructive) { store.send(.confirmBulkDelete) }
+                Button("Cancel", role: .cancel) { store.send(.cancelBulkDelete) }
+            } message: {
+                Text("This cannot be undone. Panes and surfaces in these workspaces will be closed.")
+            }
+            .confirmationDialog(
+                groupDeleteTitle,
+                isPresented: Binding(
+                    get: { store.groupDeleteConfirmation != nil },
+                    set: { if !$0 { store.send(.cancelGroupDelete) } }
+                ),
+                titleVisibility: .visible
+            ) {
+                if let confirmation = store.groupDeleteConfirmation {
+                    if confirmation.workspaceCount == 0 {
+                        Button("Delete Group", role: .destructive) {
+                            store.send(.deleteGroup(id: confirmation.groupID, cascade: false))
+                        }
+                    } else {
+                        Button("Move Workspaces to Top Level", role: .destructive) {
+                            store.send(.deleteGroup(id: confirmation.groupID, cascade: false))
+                        }
+                        Button(
+                            "Delete Group and \(confirmation.workspaceCount) Workspace\(confirmation.workspaceCount == 1 ? "" : "s")",
+                            role: .destructive
+                        ) {
+                            store.send(.deleteGroup(id: confirmation.groupID, cascade: true))
+                        }
+                    }
+                    Button("Cancel", role: .cancel) { store.send(.cancelGroupDelete) }
+                }
+            } message: {
+                if let confirmation = store.groupDeleteConfirmation, confirmation.workspaceCount > 0 {
+                    Text("Choose whether to also delete the \(confirmation.workspaceCount) workspace\(confirmation.workspaceCount == 1 ? "" : "s") inside this group. Moving them to the top level is the safer option.")
+                } else {
+                    Text("This group is empty and will be removed.")
+                }
+            }
+            .sheet(isPresented: Binding(
+                get: { store.groupBulkCreatePrompt != nil },
+                set: { if !$0 { store.send(.cancelBulkCreateGroup) } }
+            )) {
+                if let prompt = store.groupBulkCreatePrompt {
+                    NewGroupSheet(
+                        workspaceCount: prompt.workspaceIDs.count,
+                        defaultName: defaultGroupName(existing: store.groups),
+                        onCreate: { name, color in
+                            store.send(.confirmBulkCreateGroup(name: name, color: color))
+                        },
+                        onCancel: { store.send(.cancelBulkCreateGroup) }
+                    )
+                }
+            }
+            .sheet(isPresented: Binding(
+                get: { store.groupCustomEmojiPrompt != nil },
+                set: { if !$0 { store.send(.cancelGroupCustomEmoji) } }
+            )) {
+                if let prompt = store.groupCustomEmojiPrompt {
+                    GroupCustomEmojiSheet(
+                        groupName: prompt.groupName,
+                        onConfirm: { emoji in
+                            store.send(.confirmGroupCustomEmoji(emoji))
+                        },
+                        onCancel: { store.send(.cancelGroupCustomEmoji) }
+                    )
+                }
+            }
         }
     }
 
@@ -232,83 +314,6 @@ struct WorkspaceListView: View {
                 }
                 .menuStyle(.borderlessButton)
                 .padding(12)
-            }
-            .confirmationDialog(
-                bulkDeleteTitle,
-                isPresented: Binding(
-                    get: { store.bulkDeleteConfirmationIDs != nil },
-                    set: { if !$0 { store.send(.cancelBulkDelete) } }
-                ),
-                titleVisibility: .visible
-            ) {
-                Button("Delete", role: .destructive) { store.send(.confirmBulkDelete) }
-                Button("Cancel", role: .cancel) { store.send(.cancelBulkDelete) }
-            } message: {
-                Text("This cannot be undone. Panes and surfaces in these workspaces will be closed.")
-            }
-            .confirmationDialog(
-                groupDeleteTitle,
-                isPresented: Binding(
-                    get: { store.groupDeleteConfirmation != nil },
-                    set: { if !$0 { store.send(.cancelGroupDelete) } }
-                ),
-                titleVisibility: .visible
-            ) {
-                if let confirmation = store.groupDeleteConfirmation {
-                    if confirmation.workspaceCount == 0 {
-                        // Empty group: no workspaces to move or cascade.
-                        // A single "Delete Group" is the only meaningful action.
-                        Button("Delete Group", role: .destructive) {
-                            store.send(.deleteGroup(id: confirmation.groupID, cascade: false))
-                        }
-                    } else {
-                        Button("Move Workspaces to Top Level", role: .destructive) {
-                            store.send(.deleteGroup(id: confirmation.groupID, cascade: false))
-                        }
-                        Button(
-                            "Delete Group and \(confirmation.workspaceCount) Workspace\(confirmation.workspaceCount == 1 ? "" : "s")",
-                            role: .destructive
-                        ) {
-                            store.send(.deleteGroup(id: confirmation.groupID, cascade: true))
-                        }
-                    }
-                    Button("Cancel", role: .cancel) { store.send(.cancelGroupDelete) }
-                }
-            } message: {
-                if let confirmation = store.groupDeleteConfirmation, confirmation.workspaceCount > 0 {
-                    Text("Choose whether to also delete the \(confirmation.workspaceCount) workspace\(confirmation.workspaceCount == 1 ? "" : "s") inside this group. Moving them to the top level is the safer option.")
-                } else {
-                    Text("This group is empty and will be removed.")
-                }
-            }
-            .sheet(isPresented: Binding(
-                get: { store.groupBulkCreatePrompt != nil },
-                set: { if !$0 { store.send(.cancelBulkCreateGroup) } }
-            )) {
-                if let prompt = store.groupBulkCreatePrompt {
-                    NewGroupSheet(
-                        workspaceCount: prompt.workspaceIDs.count,
-                        defaultName: defaultGroupName(existing: store.groups),
-                        onCreate: { name, color in
-                            store.send(.confirmBulkCreateGroup(name: name, color: color))
-                        },
-                        onCancel: { store.send(.cancelBulkCreateGroup) }
-                    )
-                }
-            }
-            .sheet(isPresented: Binding(
-                get: { store.groupCustomEmojiPrompt != nil },
-                set: { if !$0 { store.send(.cancelGroupCustomEmoji) } }
-            )) {
-                if let prompt = store.groupCustomEmojiPrompt {
-                    GroupCustomEmojiSheet(
-                        groupName: prompt.groupName,
-                        onConfirm: { emoji in
-                            store.send(.confirmGroupCustomEmoji(emoji))
-                        },
-                        onCancel: { store.send(.cancelGroupCustomEmoji) }
-                    )
-                }
             }
         }
     }
@@ -662,10 +667,18 @@ struct WorkspaceListView: View {
             .contentShape(Rectangle())
             .onTapGesture {
                 let modifiers = NSEvent.modifierFlags
-                if modifiers.contains(.command) {
+                if modifiers.contains(.command) || modifiers.contains(.shift) {
+                    // In the filtered view, both Cmd+click and
+                    // Shift+click toggle the row's selection. The
+                    // unfiltered list uses Shift for range select, but
+                    // the underlying `.rangeSelectWorkspace` reducer
+                    // builds its range from `state.visibleWorkspaceOrder`
+                    // — which skips collapsed groups and includes
+                    // workspaces not in the filter. Reusing it here
+                    // would select rows the user can't see and miss
+                    // rows in collapsed groups. Treat Shift as toggle
+                    // until a filter-aware range action exists.
                     store.send(.toggleWorkspaceSelection(workspaceID))
-                } else if modifiers.contains(.shift) {
-                    store.send(.rangeSelectWorkspace(workspaceID))
                 } else {
                     store.send(.clearWorkspaceSelection)
                     store.send(.setActiveWorkspace(workspaceID))

--- a/Nex/Features/Workspace/WorkspaceRowView.swift
+++ b/Nex/Features/Workspace/WorkspaceRowView.swift
@@ -32,12 +32,18 @@ struct WorkspaceRowView: View {
     var hasRunningPanes: Bool = false
     var isSelected: Bool = false
     var leadingInset: CGFloat = 0
+    var labels: [String] = []
+
+    /// Maximum chips rendered inline before collapsing into a `+N` more
+    /// indicator. Three keeps rows visually compact in the narrow
+    /// sidebar; the inspector shows the full set.
+    private static let maxInlineLabels = 3
 
     var body: some View {
         HStack(spacing: 8) {
             RoundedRectangle(cornerRadius: 3)
                 .fill(color.color)
-                .frame(width: 4, height: 24)
+                .frame(width: 4, height: rowAccentHeight)
 
             VStack(alignment: .leading, spacing: 1) {
                 // Always semibold so a long name doesn't re-wrap when
@@ -63,6 +69,20 @@ struct WorkspaceRowView: View {
                         }
                     }
                 }
+
+                if !labels.isEmpty {
+                    HStack(spacing: 3) {
+                        ForEach(Array(labels.prefix(Self.maxInlineLabels)), id: \.self) { label in
+                            RowLabelChip(text: label)
+                        }
+                        if labels.count > Self.maxInlineLabels {
+                            Text("+\(labels.count - Self.maxInlineLabels)")
+                                .font(.system(size: 9, weight: .medium))
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .padding(.top, 1)
+                }
             }
 
             Spacer()
@@ -73,7 +93,10 @@ struct WorkspaceRowView: View {
                 AgentStatusDot(color: .green)
             }
 
-            if index < 9 {
+            // Negative indices opt out of the badge entirely. Used by
+            // the filtered sidebar where workspace indices into
+            // `visibleWorkspaceOrder` are either wrong or meaningless.
+            if index >= 0, index < 9 {
                 Text("⌘\(index + 1)")
                     .font(.system(size: 10, design: .monospaced))
                     .foregroundStyle(.secondary)
@@ -105,6 +128,12 @@ struct WorkspaceRowView: View {
         // spanning the full width.
         .padding(.leading, leadingInset)
         .contentShape(Rectangle())
+    }
+
+    /// The color bar grows when label chips are visible so it stays
+    /// roughly aligned with the row's full content height.
+    private var rowAccentHeight: CGFloat {
+        labels.isEmpty ? 24 : 36
     }
 
     @ViewBuilder

--- a/Nex/Services/DatabaseService.swift
+++ b/Nex/Services/DatabaseService.swift
@@ -171,6 +171,15 @@ final class DatabaseService: Sendable {
             }
         }
 
+        migrator.registerMigration("v11_workspace_labels") { db in
+            let columns = try db.columns(in: "workspace").map(\.name)
+            if !columns.contains("labelsJSON") {
+                try db.alter(table: "workspace") { t in
+                    t.add(column: "labelsJSON", .text).notNull().defaults(to: "[]")
+                }
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }
@@ -189,6 +198,7 @@ struct WorkspaceRecord: Codable, FetchableRecord, PersistableRecord {
     var createdAt: Double
     var lastAccessedAt: Double
     var sortOrder: Int
+    var labelsJSON: String
 }
 
 struct PaneRecord: Codable, FetchableRecord, PersistableRecord {

--- a/Nex/Services/PersistenceService.swift
+++ b/Nex/Services/PersistenceService.swift
@@ -167,6 +167,10 @@ actor PersistenceService {
                         ? WorkspaceFeature.State.makeSlug(from: record.name, id: wsID)
                         : record.slug
 
+                    let labels: [String] = (record.labelsJSON.data(using: .utf8))
+                        .flatMap { try? JSONDecoder().decode([String].self, from: $0) }
+                        ?? []
+
                     let workspace = WorkspaceFeature.State(
                         id: wsID,
                         name: record.name,
@@ -177,7 +181,8 @@ actor PersistenceService {
                         focusedPaneID: focusedID,
                         repoAssociations: repoAssociations,
                         createdAt: Date(timeIntervalSince1970: record.createdAt),
-                        lastAccessedAt: Date(timeIntervalSince1970: record.lastAccessedAt)
+                        lastAccessedAt: Date(timeIntervalSince1970: record.lastAccessedAt),
+                        labels: labels
                     )
                     workspaces.append(workspace)
                 }
@@ -271,6 +276,8 @@ struct PersistenceSnapshot {
             let layoutToSave = workspace.savedLayout ?? workspace.layout
             let layoutData = (try? JSONEncoder().encode(layoutToSave)) ?? Data()
             let layoutJSON = String(data: layoutData, encoding: .utf8) ?? "null"
+            let labelsData = (try? JSONEncoder().encode(workspace.labels)) ?? Data()
+            let labelsJSON = String(data: labelsData, encoding: .utf8) ?? "[]"
             return WorkspaceRecord(
                 id: workspace.id.uuidString,
                 name: workspace.name,
@@ -280,7 +287,8 @@ struct PersistenceSnapshot {
                 focusedPaneID: workspace.focusedPaneID?.uuidString,
                 createdAt: workspace.createdAt.timeIntervalSince1970,
                 lastAccessedAt: workspace.lastAccessedAt.timeIntervalSince1970,
-                sortOrder: index
+                sortOrder: index,
+                labelsJSON: labelsJSON
             )
         }
 

--- a/NexTests/DatabaseMigrationTests.swift
+++ b/NexTests/DatabaseMigrationTests.swift
@@ -100,7 +100,8 @@ struct DatabaseMigrationTests {
                 focusedPaneID: nil,
                 createdAt: 1000,
                 lastAccessedAt: 1000,
-                sortOrder: 0
+                sortOrder: 0,
+                labelsJSON: "[]"
             )
             try ws.insert(db)
 
@@ -214,7 +215,8 @@ struct DatabaseMigrationTests {
                 focusedPaneID: nil,
                 createdAt: 1000,
                 lastAccessedAt: 1000,
-                sortOrder: 0
+                sortOrder: 0,
+                labelsJSON: "[]"
             )
             try ws.insert(db)
 

--- a/NexTests/WorkspaceFeatureTests.swift
+++ b/NexTests/WorkspaceFeatureTests.swift
@@ -2170,4 +2170,97 @@ struct WorkspaceFeatureTests {
             #expect(created?.title == "diff: Foo.swift")
         }
     }
+
+    // MARK: - Labels
+
+    @Test func addLabelAppendsAndDedupes() async {
+        let workspace = WorkspaceFeature.State(name: "Labelled")
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.addLabel("backend")) { state in
+            #expect(state.labels == ["backend"])
+        }
+        await store.send(.addLabel("priority")) { state in
+            #expect(state.labels == ["backend", "priority"])
+        }
+        // Duplicate: no change.
+        await store.send(.addLabel("backend"))
+        #expect(store.state.labels == ["backend", "priority"])
+    }
+
+    @Test func addLabelTrimsAndRejectsEmpty() async {
+        let workspace = WorkspaceFeature.State(name: "Labelled")
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.addLabel("  blocked  ")) { state in
+            #expect(state.labels == ["blocked"])
+        }
+        await store.send(.addLabel("   "))
+        #expect(store.state.labels == ["blocked"])
+        await store.send(.addLabel(""))
+        #expect(store.state.labels == ["blocked"])
+    }
+
+    @Test func removeLabelDropsMatch() async {
+        var workspace = WorkspaceFeature.State(name: "Labelled")
+        workspace.labels = ["a", "b", "c"]
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.removeLabel("b")) { state in
+            #expect(state.labels == ["a", "c"])
+        }
+        // Removing a missing label is a no-op.
+        await store.send(.removeLabel("z"))
+        #expect(store.state.labels == ["a", "c"])
+    }
+
+    @Test func setLabelsReplacesAndDedupes() async {
+        var workspace = WorkspaceFeature.State(name: "Labelled")
+        workspace.labels = ["old"]
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.setLabels(["one", " two ", "one", "", "three"])) { state in
+            #expect(state.labels == ["one", "two", "three"])
+        }
+    }
+
+    @Test func setLabelsWithAllEmptyClearsAllLabels() async {
+        var workspace = WorkspaceFeature.State(name: "Labelled")
+        workspace.labels = ["alpha", "beta"]
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.setLabels(["", "  ", "\n"])) { state in
+            #expect(state.labels == [])
+        }
+    }
+
+    @Test func addLabelClampsLengthToMax() async {
+        let workspace = WorkspaceFeature.State(name: "Labelled")
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        let oversized = String(repeating: "x", count: 500)
+        await store.send(.addLabel(oversized)) { state in
+            #expect(state.labels.count == 1)
+            #expect(state.labels.first?.count == WorkspaceFeature.maxLabelLength)
+        }
+    }
+
+    @Test func addLabelTreatsCaseAsDistinct() async {
+        let workspace = WorkspaceFeature.State(name: "Labelled")
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.addLabel("Backend")) { state in
+            #expect(state.labels == ["Backend"])
+        }
+        await store.send(.addLabel("backend")) { state in
+            #expect(state.labels == ["Backend", "backend"])
+        }
+    }
 }

--- a/NexTests/WorkspaceGroupPersistenceTests.swift
+++ b/NexTests/WorkspaceGroupPersistenceTests.swift
@@ -41,6 +41,72 @@ struct WorkspaceGroupPersistenceTests {
         #expect(result.topLevelOrder == [.workspace(ws1.id), .group(groupID)])
     }
 
+    @Test func workspaceLabelsRoundTrip() async throws {
+        let db = try DatabaseService(inMemory: true)
+        let persistence = PersistenceService(db: db)
+
+        var ws1 = WorkspaceFeature.State(name: "Tagged", color: .blue)
+        ws1.labels = ["backend", "priority", "blocked"]
+        let ws2 = WorkspaceFeature.State(name: "Untagged", color: .green)
+
+        let state = AppReducer.State(
+            workspaces: [ws1, ws2],
+            groups: [],
+            topLevelOrder: [.workspace(ws1.id), .workspace(ws2.id)],
+            activeWorkspaceID: ws1.id
+        )
+
+        await persistence.save(snapshot: PersistenceSnapshot(state: state))
+        try await Task.sleep(for: .seconds(1))
+
+        let result = await persistence.load()
+        let loaded1 = result.workspaces[id: ws1.id]
+        let loaded2 = result.workspaces[id: ws2.id]
+        #expect(loaded1?.labels == ["backend", "priority", "blocked"])
+        #expect(loaded2?.labels == [])
+    }
+
+    @Test func v11AddsLabelsJSONColumnWithEmptyDefault() throws {
+        let db = try DatabaseService(inMemory: true)
+        try db.writer.read { db in
+            let columns = try db.columns(in: "workspace")
+            let labelsCol = columns.first { $0.name == "labelsJSON" }
+            #expect(labelsCol != nil)
+            #expect(labelsCol?.isNotNull == true)
+            // Default values in SQLite are stored as their literal SQL
+            // representation. `'[]'` (quoted) is what GRDB writes for
+            // `.defaults(to: "[]")`.
+            #expect(labelsCol?.defaultValueSQL == "'[]'")
+        }
+    }
+
+    @Test func malformedLabelsJSONDegradesToEmptyArray() async throws {
+        let db = try DatabaseService(inMemory: true)
+        let persistence = PersistenceService(db: db)
+        let wsID = UUID().uuidString
+
+        try await db.writer.write { db in
+            let ws = WorkspaceRecord(
+                id: wsID,
+                name: "Corrupt",
+                slug: "corrupt",
+                color: "blue",
+                layoutJSON: "{\"empty\":{}}",
+                focusedPaneID: nil,
+                createdAt: 1000,
+                lastAccessedAt: 1000,
+                sortOrder: 0,
+                labelsJSON: "not valid json"
+            )
+            try ws.insert(db)
+        }
+
+        let result = await persistence.load()
+        let loaded = result.workspaces[id: UUID(uuidString: wsID)!]
+        #expect(loaded != nil)
+        #expect(loaded?.labels == [])
+    }
+
     @Test func legacyDatabaseHasEmptyTopLevelOrder() async throws {
         let db = try DatabaseService(inMemory: true)
         let persistence = PersistenceService(db: db)
@@ -59,7 +125,8 @@ struct WorkspaceGroupPersistenceTests {
                     focusedPaneID: nil,
                     createdAt: 1000,
                     lastAccessedAt: 1000,
-                    sortOrder: idx
+                    sortOrder: idx,
+                    labelsJSON: "[]"
                 )
                 try ws.insert(db)
             }


### PR DESCRIPTION
## Summary

- Workspaces gain a free-form `labels: [String]` field, persisted via a new GRDB `labelsJSON` column (migration v11). Trimmed, deduplicated, length-clamped at 64 chars per label.
- Labels render as pill chips inline in the sidebar row (up to 3, then `+N`), and are edited from a new "Labels" section in the workspace inspector — chip cloud + text field with comma/newline-separated batch entry.
- A filter field at the top of the sidebar filters workspaces by name or label (case-insensitive substring). When active, the sidebar switches to a flat filtered list with a small "in <group>" hint where a match lives inside a group. Enter activates the first match; Esc clears.
- The filter is view-local (not persisted, not in `AppReducer.State`). Keyboard shortcuts (Cmd+1..9, cycling) still address the full unfiltered set.
- Discoverability: new "Edit Labels..." context-menu entry per workspace row.

Closes #93

## Reviewer notes

Implementation reviewed by three reviewers in series:
- An in-process correctness pass + a design/scope pass on the initial implementation surfaced four must-fix items (FocusState reset on filter, missing selection state in filtered rows, wrong `Cmd+N` badge index in filtered rows, missing selection header). All applied before commit.
- A Codex review on the committed HEAD surfaced two P2 bugs specific to the filtered-list path (bulk-action dialogs detached when filter active; range-select in filtered context selected unfiltered/hidden rows). Both fixed in commit \`5662af6\`.

Deferred (tracked but out of scope for V1):
- CLI commands for label CRUD (`nex workspace add-label`, etc.).
- Bulk label operations (`Add Label to N Workspaces`).
- Label autocomplete from the workspace-wide label set.
- Per-window filter persistence.
- Multi-label AND filter (`label:foo label:bar`).
- Labels in the New Workspace sheet.
- Case-insensitive label canonicalisation (current dedup is case-sensitive; the filter is case-insensitive — intentional asymmetry, tested).

## Validation

Validated in a sandboxed macOS VM via the cua/lume harness (`validate_issue_93.py`). Re-run against final HEAD (\`5662af6\`):

- TEST 1: v11 migration adds `labelsJSON` column on first launch.
- TEST 2: new workspaces default to `labelsJSON='[]'` (migration default).
- TEST 3: labels written directly to the DB load into the UI on relaunch (chip pills visible in `02_with_labels.png`).
- TEST 4: app round-trip — labels survive quit + relaunch unchanged (the persistence path writes them back unchanged).

Plus existing test suite (765 tests) passes, including 5 new tests covering: addLabel append/dedupe/trim/empty/length-clamp/case-sensitivity, removeLabel, setLabels replace/dedupe/all-empty, persistence round-trip, v11 migration default, malformed JSON degrades to `[]`.

Screenshots: `/Users/ben/code/cua/out/branches/ship-93-workspace-labels/issue-93/`

## Test plan

- [x] Type into the filter field at the top of the sidebar; matching rows narrow as you type, name and labels both match.
- [x] Enter activates the first match and closes the filter; Esc clears the field; ✕ button clears.
- [x] Tap a filtered row in a collapsed group; the group expands and focuses that workspace, filter clears.
- [x] Open the workspace inspector; the new "Labels" section is visible after the workspace metadata.
- [x] Type a label and press Enter; chip appears below. Click ✕ on a chip; chip is removed.
- [x] Type `backend, priority, blocked` in the inspector field, press Enter; three chips are added in one shot (comma-split).
- [x] Add three or more labels; the sidebar row shows pill chips capped at three with a `+N` indicator for the rest.
- [x] Right-click a workspace row → "Edit Labels..."; inspector opens scoped to that workspace.
- [x] Quit and relaunch Nex; labels persist.
- [x] With the filter active, right-click a row and choose "Delete N Workspaces..." (when multi-selected); the confirmation dialog still presents correctly (was a Codex P2 regression).
- [ ] With the filter active, Shift+click toggles single-row selection (does not wrongly range-select hidden rows).