### PR TITLE
feat: confirm before quitting Nex (#129)

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0D7D8E5C230B6C98E7693D66 /* PaneListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */; };
 		0EAFF0FDB683293F95D8AB47 /* RenameWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */; };
 		0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B822ABF12B071E574E089BB4 /* GroupIconTests.swift */; };
+		1397C2AF47888F6A056F5970 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D5AF8FEB520FE55ADB0C59 /* AppDelegate.swift */; };
 		13CFD579791838D9D23C9613 /* WorkspaceLabelViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684EF74D8EC3F295B22944AB /* WorkspaceLabelViews.swift */; };
 		149E80DD671127055EF67F7F /* DiffHTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */; };
 		14C1E964B19A8C277D5EA5E4 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE56BB11F5C7C34821411297 /* QuartzCore.framework */; };
@@ -49,6 +50,7 @@
 		58D251ED7E3B564C9BA3AD91 /* NexGhosttyDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935FE280F97CB5A1DBD31113 /* NexGhosttyDefaults.swift */; };
 		59239C7AD0D26E390C647C46 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 98CF017F4F26916F63300A33 /* Yams */; };
 		5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */; };
+		5CFC8C5F96B371044A5ABE91 /* QuitConfirmationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD202733564AC92AEC00A0C /* QuitConfirmationTests.swift */; };
 		62564D224FD57BC3C02100EA /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191E820170ADF2ADB58B8079 /* GitServiceTests.swift */; };
 		62BC1CC522515C8E6A99F508 /* GitHeadWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281BB8BFA202B0E43FC1E2AE /* GitHeadWatcher.swift */; };
 		64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A24C1FEC6EA31096603326 /* SurfaceManager.swift */; };
@@ -138,6 +140,7 @@
 		FB45777E3BD181F04B322F93 /* ScratchpadEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A4C5D8F4C099C65A7EA890 /* ScratchpadEditorView.swift */; };
 		FD494AFC9E74F4C5D7E125B8 /* CommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FC5F004277851CEA0CFF3F /* CommandPaletteTests.swift */; };
 		FF162EE0EAF672FFFCFDF0BE /* PersistenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEA23E4C37CB5B7A6F4963C /* PersistenceService.swift */; };
+		FF3255F9A9213474DC14A2A0 /* QuitGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504C980131A9A777767EEB1 /* QuitGate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -206,8 +209,10 @@
 		6B4B95F852C737F18989F8FA /* WorkspaceColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceColor.swift; sourceTree = "<group>"; };
 		6BB526BDDE50E6C7948EE832 /* NexTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NexTheme.swift; sourceTree = "<group>"; };
 		6BB83805BDFAC2F7DB8FF064 /* GroupHeaderRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupHeaderRow.swift; sourceTree = "<group>"; };
+		6CD202733564AC92AEC00A0C /* QuitConfirmationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitConfirmationTests.swift; sourceTree = "<group>"; };
 		6FD9BCE4ABC267C7E34EAF09 /* PaneFocusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneFocusView.swift; sourceTree = "<group>"; };
 		75DCD589969583F84BFCE38B /* NexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		76D5AF8FEB520FE55ADB0C59 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		77FDA3FB200AA7846BCDC7A7 /* EditorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorServiceTests.swift; sourceTree = "<group>"; };
 		7DED98594372C8E34542A5C2 /* SplitDividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitDividerView.swift; sourceTree = "<group>"; };
 		7ED3289901F70616FC36F80B /* MarkdownEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownEditorView.swift; sourceTree = "<group>"; };
@@ -236,6 +241,7 @@
 		ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeatureTests.swift; sourceTree = "<group>"; };
 		B02A888F436610636F5A4D55 /* MarkdownPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPaneView.swift; sourceTree = "<group>"; };
 		B0F76E0BE2C08C77C58B1278 /* SidebarID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarID.swift; sourceTree = "<group>"; };
+		B504C980131A9A777767EEB1 /* QuitGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitGate.swift; sourceTree = "<group>"; };
 		B6CC74E2D5AA179FFCE3B825 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B822ABF12B071E574E089BB4 /* GroupIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupIconTests.swift; sourceTree = "<group>"; };
 		BB94DA665D3B322A44251454 /* PaneHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneHeaderView.swift; sourceTree = "<group>"; };
@@ -389,6 +395,7 @@
 				C4D5453E5B7EB4E8E7F11453 /* PaneSendReplyTests.swift */,
 				CAA7FF54B539D06E39903C41 /* PaneShortcutMonitorTests.swift */,
 				4DA17E3004A004E6B4DDDBF6 /* PersistenceTests.swift */,
+				6CD202733564AC92AEC00A0C /* QuitConfirmationTests.swift */,
 				1C625959E287CE9896D5BA4D /* RepoRegistryTests.swift */,
 				ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */,
 				AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */,
@@ -432,12 +439,14 @@
 		517D1FAA0B3B717E85EFDA2D /* Nex */ = {
 			isa = PBXGroup;
 			children = (
+				76D5AF8FEB520FE55ADB0C59 /* AppDelegate.swift */,
 				D9335AE3C92A37DD50A5715A /* AppReducer.swift */,
 				B6CC74E2D5AA179FFCE3B825 /* Assets.xcassets */,
 				1A198A2F5EA992907A3031ED /* ContentView.swift */,
 				BECB2222837AC350E94222BB /* Info.plist */,
 				F1A8D5B3446F6056F443CDB8 /* Nex.entitlements */,
 				3714AA1F15C85762BF36B1FE /* NexApp.swift */,
+				B504C980131A9A777767EEB1 /* QuitGate.swift */,
 				477C757108CEE52846121B1E /* Commands */,
 				5F485357D29F2C092501D735 /* Features */,
 				4FF05F1CABA6C0F391FCBFCF /* Ghostty */,
@@ -746,6 +755,7 @@
 				0A70A24697C96E83D6A201CE /* PaneSendReplyTests.swift in Sources */,
 				F6B537768D81B028C1B484B2 /* PaneShortcutMonitorTests.swift in Sources */,
 				B3FBC9276113E015DA08D41A /* PersistenceTests.swift in Sources */,
+				5CFC8C5F96B371044A5ABE91 /* QuitConfirmationTests.swift in Sources */,
 				B5B3A5F0C2FA6509D37FA74A /* RepoRegistryTests.swift in Sources */,
 				EAF43DC55C5612F3AE83BF02 /* SettingsFeatureTests.swift in Sources */,
 				2B4533964D77117EE6D98690 /* SocketParsingTests.swift in Sources */,
@@ -767,6 +777,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				759B67A4E8D35868EC6E2295 /* AppActivation.swift in Sources */,
+				1397C2AF47888F6A056F5970 /* AppDelegate.swift in Sources */,
 				EC6971D2E311C8903C373778 /* AppReducer.swift in Sources */,
 				EFDCA64CD227A833D2801893 /* CLIInstallService.swift in Sources */,
 				B23A46CD372F9E16C2C1D716 /* CheckForUpdatesView.swift in Sources */,
@@ -817,6 +828,7 @@
 				5883FFD10BE73F44EA8F4A5C /* PaneSearchOverlay.swift in Sources */,
 				1569F35B72EC7C133643190E /* PaneType.swift in Sources */,
 				FF162EE0EAF672FFFCFDF0BE /* PersistenceService.swift in Sources */,
+				FF3255F9A9213474DC14A2A0 /* QuitGate.swift in Sources */,
 				C052FE23BF089795BB04E10E /* RenamePaneSheet.swift in Sources */,
 				0EAFF0FDB683293F95D8AB47 /* RenameWorkspaceSheet.swift in Sources */,
 				550563B9BEDE841D3B7CE6B8 /* Repo.swift in Sources */,

--- a/Nex/AppDelegate.swift
+++ b/Nex/AppDelegate.swift
@@ -1,0 +1,31 @@
+import AppKit
+
+/// AppDelegate that intercepts Cmd+Q / "Quit Nex" so we can show a
+/// confirmation dialog before the app terminates (issue #129).
+///
+/// Hooks every termination path: menu-bar Quit, Cmd+Q, AppleScript quit,
+/// system logout, and `NSApp.terminate(_:)` calls (including Sparkle
+/// auto-update relaunches). The dialog fires unconditionally unless the
+/// user has disabled it; when active agents exist the dialog body names
+/// them so an accidental quit doesn't silently lose work.
+final class NexAppDelegate: NSObject, NSApplicationDelegate {
+    func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+        // Always flush pending markdown saves before we go anywhere
+        // near a termination decision. The editor's 500ms debounce can
+        // still have a write outstanding when Cmd+Q fires; if we don't
+        // flush here, a `.terminateNow` (e.g. dialog disabled) kills
+        // the process before the debounced Task can run (issue #129).
+        QuitGate.shared.flushPendingSaves()
+
+        // Skip the dialog during XCTest runs and when the user has
+        // disabled it via Settings or the suppression checkbox.
+        guard !NexApp.isTestMode, QuitGate.confirmQuitWhenActive else {
+            return .terminateNow
+        }
+
+        let summary = QuitGate.shared.summarize()
+        return QuitGate.shared.presentQuitConfirmation(summary: summary)
+            ? .terminateNow
+            : .terminateCancel
+    }
+}

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -59,6 +59,34 @@ struct AppReducer {
             return workspaces[id: id]
         }
 
+        /// Summary of in-progress agents across all workspaces, used by
+        /// the quit-confirmation dialog (issue #129). An "active agent"
+        /// is any pane whose status is `.running` or `.waitingForInput`.
+        /// Idle panes, markdown previews, scratchpads, and diff panes
+        /// always have `.idle` status and so are never counted.
+        ///
+        /// Parked panes (source shells hidden by `nex open --here`) are
+        /// included: their PTYs and agents are still alive and would be
+        /// terminated alongside the visible panes.
+        var activeAgentSummary: ActivitySummary {
+            var agentCount = 0
+            var workspaceCount = 0
+            for workspace in workspaces {
+                let visible = workspace.panes.reduce(into: 0) { acc, pane in
+                    if pane.status != .idle { acc += 1 }
+                }
+                let parked = workspace.parkedPanes.reduce(into: 0) { acc, pane in
+                    if pane.status != .idle { acc += 1 }
+                }
+                let count = visible + parked
+                if count > 0 {
+                    agentCount += count
+                    workspaceCount += 1
+                }
+            }
+            return ActivitySummary(agentCount: agentCount, workspaceCount: workspaceCount)
+        }
+
         /// Sidebar entry that the active workspace occupies, used as an
         /// insertion anchor for `.nearSelection` group placement. Returns
         /// the workspace's own entry when it's top-level, or its parent
@@ -1958,11 +1986,18 @@ struct AppReducer {
                     }
                 }
 
-                // Clear session IDs and reset status to prevent stale resumes on next restart
+                // Clear session IDs and reset status to prevent stale
+                // resumes on next restart. Status is tied to a live PTY,
+                // which never survives a restart, so reset all non-idle
+                // panes regardless of session — otherwise a persisted
+                // `.running` falsely triggers the quit dialog at the
+                // next Cmd+Q with no real agents in flight (issue #129).
                 for workspace in state.workspaces {
                     for pane in workspace.panes {
                         if pane.claudeSessionID != nil {
                             state.workspaces[id: workspace.id]?.panes[id: pane.id]?.claudeSessionID = nil
+                        }
+                        if pane.status != .idle {
                             state.workspaces[id: workspace.id]?.panes[id: pane.id]?.status = .idle
                         }
                     }

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -211,6 +211,9 @@ struct ContentView: View {
                     )
                 }
             }
+            .onReceive(NotificationCenter.default.publisher(for: QuitGate.confirmQuitChangedNotification)) { _ in
+                store.send(.settings(.refreshConfirmQuitWhenActive))
+            }
             .onReceive(NotificationCenter.default.publisher(for: SurfaceView.paneFocusedNotification)) { notification in
                 guard let paneID = notification.userInfo?["paneID"] as? UUID,
                       let activeID = store.activeWorkspaceID,

--- a/Nex/Features/MarkdownPane/MarkdownEditorView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownEditorView.swift
@@ -120,6 +120,11 @@ struct MarkdownEditorView: NSViewRepresentable {
         var lastIsFocused: Bool = false
         private var saveTask: Task<Void, Never>?
 
+        override init() {
+            super.init()
+            MarkdownEditorRegistry.shared.register(self)
+        }
+
         func loadFile() {
             guard !filePath.isEmpty else { return }
             do {
@@ -169,6 +174,16 @@ struct MarkdownEditorView: NSViewRepresentable {
             }
         }
 
+        /// Synchronously flush any pending debounced save. Called from
+        /// the quit gate so unsaved edits don't get truncated at the
+        /// 500ms debounce boundary when the user hits Cmd+Q (issue #129).
+        func flushPendingSave() {
+            guard let task = saveTask else { return }
+            saveTask = nil
+            task.cancel()
+            writeToDisk()
+        }
+
         private func writeToDisk() {
             guard !filePath.isEmpty, let content = textView?.string else { return }
             do {
@@ -180,6 +195,38 @@ struct MarkdownEditorView: NSViewRepresentable {
 
         deinit {
             NotificationCenter.default.removeObserver(self)
+            // No registry deregister here — deinit is non-isolated and
+            // the registry is @MainActor. Stale weak boxes are pruned
+            // lazily by `MarkdownEditorRegistry.register` / `flushAll`.
+        }
+    }
+}
+
+/// Weak registry of live `MarkdownEditorView.Coordinator` instances.
+/// `QuitGate.shared.flushPendingSaves` is wired to `flushAll()` at app
+/// launch so the AppDelegate can synchronously drain in-flight saves
+/// before letting the process exit (issue #129).
+@MainActor
+final class MarkdownEditorRegistry {
+    static let shared = MarkdownEditorRegistry()
+
+    private var coordinators: [WeakBox] = []
+
+    private struct WeakBox {
+        weak var value: MarkdownEditorView.Coordinator?
+    }
+
+    private init() {}
+
+    func register(_ coordinator: MarkdownEditorView.Coordinator) {
+        coordinators.removeAll { $0.value == nil }
+        coordinators.append(WeakBox(value: coordinator))
+    }
+
+    func flushAll() {
+        coordinators.removeAll { $0.value == nil }
+        for box in coordinators {
+            box.value?.flushPendingSave()
         }
     }
 }

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -33,6 +33,7 @@ struct SettingsFeature {
         var expandGroupOnWorkspaceDrop: Bool = true
         var newGroupPlacement: SidebarPlacement = .endOfList
         var newWorkspacePlacement: SidebarPlacement = .endOfList
+        var confirmQuitWhenActive: Bool = true
 
         /// The resolved absolute worktree base path. Expands ~ and substitutes
         /// the `<repo>` placeholder:
@@ -61,6 +62,8 @@ struct SettingsFeature {
         case setExpandGroupOnWorkspaceDrop(Bool)
         case setNewGroupPlacement(SidebarPlacement)
         case setNewWorkspacePlacement(SidebarPlacement)
+        case setConfirmQuitWhenActive(Bool)
+        case refreshConfirmQuitWhenActive
         case selectTheme(NexTheme?)
         case applyAppearance(opacity: Double, r: Double, g: Double, b: Double, theme: NexTheme?)
     }
@@ -79,6 +82,7 @@ struct SettingsFeature {
     static let defaultsKeyExpandGroupOnWorkspaceDrop = "settings.expandGroupOnWorkspaceDrop"
     static let defaultsKeyNewGroupPlacement = "settings.newGroupPlacement"
     static let defaultsKeyNewWorkspacePlacement = "settings.newWorkspacePlacement"
+    static let defaultsKeyConfirmQuitWhenActive = QuitGateDefaults.confirmQuit
 
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.userDefaults) var userDefaults
@@ -109,6 +113,9 @@ struct SettingsFeature {
                 if let raw = userDefaults.stringForKey(Self.defaultsKeyNewWorkspacePlacement),
                    let placement = SidebarPlacement(rawValue: raw) {
                     state.newWorkspacePlacement = placement
+                }
+                if userDefaults.hasKey(Self.defaultsKeyConfirmQuitWhenActive) {
+                    state.confirmQuitWhenActive = userDefaults.boolForKey(Self.defaultsKeyConfirmQuitWhenActive)
                 }
                 if userDefaults.boolForKey(Self.defaultsKeyHasCustomColor) {
                     state.backgroundColorR = userDefaults.doubleForKey(Self.defaultsKeyColorR)
@@ -187,6 +194,22 @@ struct SettingsFeature {
             case .setNewWorkspacePlacement(let placement):
                 state.newWorkspacePlacement = placement
                 userDefaults.setString(placement.rawValue, Self.defaultsKeyNewWorkspacePlacement)
+                return .none
+
+            case .setConfirmQuitWhenActive(let enabled):
+                state.confirmQuitWhenActive = enabled
+                userDefaults.setBool(enabled, Self.defaultsKeyConfirmQuitWhenActive)
+                return .none
+
+            case .refreshConfirmQuitWhenActive:
+                // Triggered when the dialog's "Don't ask again" checkbox
+                // writes UserDefaults from outside the reducer. Re-read
+                // so the Settings toggle doesn't go stale (issue #129).
+                if userDefaults.hasKey(Self.defaultsKeyConfirmQuitWhenActive) {
+                    state.confirmQuitWhenActive = userDefaults.boolForKey(Self.defaultsKeyConfirmQuitWhenActive)
+                } else {
+                    state.confirmQuitWhenActive = true
+                }
                 return .none
 
             case .selectTheme(let theme):

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -33,6 +33,13 @@ struct SettingsView: View {
                 minHeight: 440, idealHeight: 520, maxHeight: .infinity
             )
             .background(WindowResizabilityModifier())
+            // Listen here too: the main WindowGroup (and ContentView's
+            // observer) may be closed while the Settings scene stays
+            // open. Without this, the dialog's "Don't ask again" tick
+            // would leave the toggle stale until next launch (issue #129).
+            .onReceive(NotificationCenter.default.publisher(for: QuitGate.confirmQuitChangedNotification)) { _ in
+                store.send(.settings(.refreshConfirmQuitWhenActive))
+            }
         }
     }
 }

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -153,6 +153,16 @@ private struct GeneralSettingsView: View {
                     }
                 }
 
+                Section("Quit") {
+                    Toggle("Confirm before quitting", isOn: Binding(
+                        get: { settingsStore.confirmQuitWhenActive },
+                        set: { settingsStore.send(.setConfirmQuitWhenActive($0)) }
+                    ))
+                    Text("Show a confirmation dialog on Cmd+Q. When agents are running or waiting for input, the dialog calls them out so an accidental quit doesn't lose work.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
                 Section("Network") {
                     Toggle("TCP listener", isOn: Binding(
                         get: { appStore.tcpPort > 0 },

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -4,6 +4,8 @@ import SwiftUI
 
 @main
 struct NexApp: App {
+    @NSApplicationDelegateAdaptor(NexAppDelegate.self) private var appDelegate
+
     @State private var store = Store(initialState: AppReducer.State()) {
         AppReducer()
     }
@@ -100,6 +102,19 @@ struct NexApp: App {
                     }
 
                     store.send(.appLaunched)
+
+                    // Wire the quit-confirmation summary + the markdown save
+                    // flush. NexAppDelegate's applicationShouldTerminate calls
+                    // both synchronously to (a) decide whether to show the
+                    // dialog and (b) drain any in-flight debounced markdown
+                    // writes so the 500ms autosave window can't drop edits
+                    // when the user hits Cmd+Q (issue #129).
+                    QuitGate.shared.summarize = {
+                        store.withState { $0.activeAgentSummary }
+                    }
+                    QuitGate.shared.flushPendingSaves = {
+                        MarkdownEditorRegistry.shared.flushAll()
+                    }
 
                     let monitor = PaneShortcutMonitor(store: store)
                     monitor.start()

--- a/Nex/QuitGate.swift
+++ b/Nex/QuitGate.swift
@@ -1,0 +1,107 @@
+import AppKit
+import Foundation
+
+/// Snapshot of in-progress agent activity used to decide whether to
+/// show a quit-confirmation dialog.
+struct ActivitySummary: Equatable {
+    let agentCount: Int
+    let workspaceCount: Int
+
+    static let zero = ActivitySummary(agentCount: 0, workspaceCount: 0)
+
+    var isEmpty: Bool { agentCount == 0 }
+}
+
+/// UserDefaults keys shared by `QuitGate` and `SettingsFeature` so the
+/// suppression checkbox on the dialog and the toggle in Settings write
+/// the same value. Declared outside `@MainActor QuitGate` so non-
+/// isolated callers (like `SettingsFeature`) can reference them.
+enum QuitGateDefaults {
+    static let confirmQuit = "settings.confirmQuitWhenActive"
+}
+
+/// Bridge between the AppKit termination callback and the TCA store.
+/// `NexApp.onAppear` wires `summarize` to a closure that reads the
+/// store; `NexAppDelegate.applicationShouldTerminate` calls it.
+///
+/// Lives outside TCA because `applicationShouldTerminate(_:)` is
+/// invoked synchronously by AppKit before SwiftUI scenes get a chance
+/// to forward the event, and the decision needs to return immediately.
+@MainActor
+final class QuitGate {
+    static let shared = QuitGate()
+
+    var summarize: () -> ActivitySummary = { .zero }
+
+    /// Synchronously flush in-flight markdown auto-saves. Wired by
+    /// `MarkdownEditorView` so the AppDelegate doesn't need to know
+    /// about its internals.
+    var flushPendingSaves: () -> Void = {}
+
+    private init() {}
+
+    /// Whether the dialog should fire at all. `true` by default; the
+    /// suppression button on the alert and the Settings toggle both
+    /// flip this same key.
+    static var confirmQuitWhenActive: Bool {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: QuitGateDefaults.confirmQuit) == nil {
+            return true
+        }
+        return defaults.bool(forKey: QuitGateDefaults.confirmQuit)
+    }
+
+    /// Set the suppression flag from the AppKit side (i.e. the
+    /// dialog's "Don't ask again" checkbox). Persists to UserDefaults
+    /// AND broadcasts so `SettingsFeature.State.confirmQuitWhenActive`
+    /// can re-sync if the Settings window happens to be open.
+    static func setConfirmQuitWhenActive(_ value: Bool) {
+        UserDefaults.standard.set(value, forKey: QuitGateDefaults.confirmQuit)
+        NotificationCenter.default.post(
+            name: confirmQuitChangedNotification,
+            object: nil,
+            userInfo: ["value": value]
+        )
+    }
+
+    static let confirmQuitChangedNotification = Notification.Name("Nex.confirmQuitWhenActiveChanged")
+
+    /// Run the modal NSAlert. Returns true when the user confirms quit.
+    /// Updates `confirmQuitWhenActive` when the suppression box is ticked,
+    /// regardless of which button the user clicked (macOS HIG: suppression
+    /// state should be honoured even on Cancel).
+    func presentQuitConfirmation(summary: ActivitySummary) -> Bool {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Quit Nex?"
+        alert.informativeText = Self.message(for: summary)
+
+        // Cancel is the first/default button (Return key). Cmd+Q is the
+        // accidental keystroke we're guarding against, so the safe option
+        // wins by default. Issue #129 spec calls this out explicitly.
+        alert.addButton(withTitle: "Cancel")
+        let quitButton = alert.addButton(withTitle: "Quit")
+        quitButton.hasDestructiveAction = true
+
+        alert.showsSuppressionButton = true
+        alert.suppressionButton?.title = "Don't ask again"
+
+        let response = alert.runModal()
+        let confirmed = response == .alertSecondButtonReturn
+
+        if alert.suppressionButton?.state == .on {
+            Self.setConfirmQuitWhenActive(false)
+        }
+
+        return confirmed
+    }
+
+    static func message(for summary: ActivitySummary) -> String {
+        guard !summary.isEmpty else {
+            return "Are you sure you want to quit Nex?"
+        }
+        let agentNoun = summary.agentCount == 1 ? "agent" : "agents"
+        let workspaceNoun = summary.workspaceCount == 1 ? "workspace" : "workspaces"
+        return "Nex has \(summary.agentCount) active \(agentNoun) across \(summary.workspaceCount) \(workspaceNoun). Quitting will terminate all sessions."
+    }
+}

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -763,6 +763,28 @@ struct AppReducerTests {
         }
     }
 
+    @Test func stateLoadedResetsRunningStatusEvenWithoutClaudeSession() async {
+        // A pane that was .running without a Claude session ID (e.g. a
+        // non-Claude agent that emitted `nex event start`) used to keep
+        // its status across restart and falsely trigger the quit dialog
+        // on next launch. The reset is now unconditional (issue #129).
+        var ws = Self.makeWorkspace(id: Self.wsID1, name: "WS", paneID: Self.paneID1)
+        ws.panes[id: Self.paneID1]?.status = .waitingForInput
+
+        let store = makeStore()
+
+        await store.send(.stateLoaded(
+            [ws],
+            groups: [],
+            topLevelOrder: [],
+            activeWorkspaceID: Self.wsID1,
+            repoRegistry: []
+        )) { state in
+            #expect(state.workspaces[id: Self.wsID1]?.panes[id: Self.paneID1]?.claudeSessionID == nil)
+            #expect(state.workspaces[id: Self.wsID1]?.panes[id: Self.paneID1]?.status == .idle)
+        }
+    }
+
     @Test func stateLoadedHonoursPersistedTopLevelOrder() async {
         let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "A", paneID: Self.paneID1)
         let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "B", paneID: Self.paneID2)

--- a/NexTests/QuitConfirmationTests.swift
+++ b/NexTests/QuitConfirmationTests.swift
@@ -1,0 +1,136 @@
+import ComposableArchitecture
+import Foundation
+@testable import Nex
+import Testing
+
+@MainActor
+struct QuitConfirmationTests {
+    private static let wsID1 = UUID(uuidString: "20000000-0000-0000-0000-000000000001")!
+    private static let wsID2 = UUID(uuidString: "20000000-0000-0000-0000-000000000002")!
+
+    private static func workspace(
+        id: UUID,
+        paneStatuses: [PaneStatus],
+        paneTypes: [PaneType]? = nil
+    ) -> WorkspaceFeature.State {
+        let panes = paneStatuses.enumerated().map { index, status in
+            Pane(
+                id: UUID(),
+                type: paneTypes?[index] ?? .shell,
+                status: status
+            )
+        }
+        let layout: PaneLayout = panes.first.map { .leaf($0.id) } ?? .empty
+        return WorkspaceFeature.State(
+            id: id,
+            name: "ws-\(id.uuidString.prefix(4))",
+            slug: "ws",
+            color: .blue,
+            panes: IdentifiedArray(uniqueElements: panes),
+            layout: layout,
+            focusedPaneID: panes.first?.id,
+            createdAt: Date(timeIntervalSince1970: 0),
+            lastAccessedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    @Test func emptyStateHasNoActiveAgents() {
+        let state = AppReducer.State()
+        #expect(state.activeAgentSummary == .zero)
+        #expect(state.activeAgentSummary.isEmpty)
+    }
+
+    @Test func idleOnlyWorkspaceHasNoActiveAgents() {
+        var state = AppReducer.State()
+        state.workspaces = [Self.workspace(id: Self.wsID1, paneStatuses: [.idle, .idle])]
+        #expect(state.activeAgentSummary == .zero)
+    }
+
+    @Test func runningPaneCountsAsActive() {
+        var state = AppReducer.State()
+        state.workspaces = [Self.workspace(id: Self.wsID1, paneStatuses: [.running])]
+        let summary = state.activeAgentSummary
+        #expect(summary.agentCount == 1)
+        #expect(summary.workspaceCount == 1)
+    }
+
+    @Test func waitingForInputCountsAsActive() {
+        var state = AppReducer.State()
+        state.workspaces = [Self.workspace(id: Self.wsID1, paneStatuses: [.waitingForInput])]
+        let summary = state.activeAgentSummary
+        #expect(summary.agentCount == 1)
+        #expect(summary.workspaceCount == 1)
+    }
+
+    @Test func mixedStatusOnlyCountsNonIdle() {
+        var state = AppReducer.State()
+        state.workspaces = [
+            Self.workspace(id: Self.wsID1, paneStatuses: [.idle, .running, .waitingForInput, .idle])
+        ]
+        let summary = state.activeAgentSummary
+        #expect(summary.agentCount == 2)
+        #expect(summary.workspaceCount == 1)
+    }
+
+    @Test func workspaceWithoutActivePanesIsExcludedFromCount() {
+        var state = AppReducer.State()
+        state.workspaces = [
+            Self.workspace(id: Self.wsID1, paneStatuses: [.running, .idle]),
+            Self.workspace(id: Self.wsID2, paneStatuses: [.idle, .idle])
+        ]
+        let summary = state.activeAgentSummary
+        #expect(summary.agentCount == 1)
+        #expect(summary.workspaceCount == 1)
+    }
+
+    @Test func multipleWorkspacesWithActivePanesSumCorrectly() {
+        var state = AppReducer.State()
+        state.workspaces = [
+            Self.workspace(id: Self.wsID1, paneStatuses: [.running, .running]),
+            Self.workspace(id: Self.wsID2, paneStatuses: [.waitingForInput])
+        ]
+        let summary = state.activeAgentSummary
+        #expect(summary.agentCount == 3)
+        #expect(summary.workspaceCount == 2)
+    }
+
+    @Test func messageMatchesPluralization() {
+        let single = ActivitySummary(agentCount: 1, workspaceCount: 1)
+        let multiple = ActivitySummary(agentCount: 3, workspaceCount: 2)
+        #expect(QuitGate.message(for: single).contains("1 active agent across 1 workspace"))
+        #expect(QuitGate.message(for: multiple).contains("3 active agents across 2 workspaces"))
+    }
+
+    @Test func messageHandlesEmptySummary() {
+        // The dialog fires unconditionally when the user has the
+        // setting enabled; for the no-active-agent case the body
+        // falls back to a generic "are you sure" prompt.
+        let summary = ActivitySummary.zero
+        #expect(QuitGate.message(for: summary) == "Are you sure you want to quit Nex?")
+    }
+
+    @Test func parkedPanesAreCountedAlongsideVisiblePanes() {
+        var workspace = Self.workspace(id: Self.wsID1, paneStatuses: [.running])
+        workspace.parkedPanes = IdentifiedArray(uniqueElements: [
+            Pane(id: UUID(), type: .shell, status: .waitingForInput)
+        ])
+        var state = AppReducer.State()
+        state.workspaces = [workspace]
+        let summary = state.activeAgentSummary
+        #expect(summary.agentCount == 2)
+        #expect(summary.workspaceCount == 1)
+    }
+
+    @Test func parkedPaneAloneIsEnoughToTriggerDialog() {
+        var workspace = Self.workspace(id: Self.wsID1, paneStatuses: [.idle])
+        workspace.parkedPanes = IdentifiedArray(uniqueElements: [
+            Pane(id: UUID(), type: .shell, status: .running)
+        ])
+        var state = AppReducer.State()
+        state.workspaces = [workspace]
+        let summary = state.activeAgentSummary
+        #expect(summary.agentCount == 1)
+        #expect(summary.workspaceCount == 1)
+        #expect(!summary.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Cmd+Q (and every other termination path: menu Quit, AppleScript quit, Sparkle relaunch, system logout) now shows a modal confirmation. Cancel is the default button so the accidental keystroke is the safe path.
- Ticking "Don't ask again" persists the preference and is honoured on either Cancel or Quit (macOS HIG). The preference is also surfaced in Settings → General → Quit and stays in sync via a NotificationCenter broadcast.
- Pending markdown auto-saves are flushed synchronously before any quit decision, so the 500ms autosave debounce can't drop edits.
- Persisted `.running` pane statuses are reset to `.idle` on launch so a stale flag from a previous session can't falsely affect the dialog body.

Closes #129

## Reviewer notes

Triaged from parallel reviewer feedback (one general-purpose Claude + one Plan-style Claude + one Codex). Skipped with rationale:

- **libghostty `needsConfirmQuit`** for shell panes running non-agent processes (`vim`, `make`, etc.). Out of scope for V1; the issue's primary concern is agent loss, and broadening the activity check is a larger change. Filed as a follow-up consideration.
- **Scratchpad keystroke persistence**. Orthogonal feature - scratchpads not flushed on quit is a pre-existing condition unchanged by this PR.
- **`summarize` race during launch**. AppKit guarantees `applicationDidFinishLaunching` → `applicationShouldTerminate` ordering, and `ContentView.onAppear` runs synchronously during the former; the race window is theoretical.
- **Routing `QuitGate.confirmQuitWhenActive` through TCA's `userDefaults` dependency**. The AppKit-side code is non-TCA; tests use `NexApp.isTestMode` to skip the gate entirely.

After the first cua run we changed the dialog to fire on **every** Cmd+Q (not only when active agents exist) - the issue's "skip when nothing active" line was relaxed by the user to make the safety net unconditional. The dialog body adapts ("Are you sure you want to quit Nex?" vs "Nex has N active agents…").

## Validation

- 777 unit tests pass (`make check`). New `QuitConfirmationTests` covers the activity-summary computation (idle/running/waiting/parked panes, single + multiple workspaces) and the message helper's pluralization + empty-summary fallback. New `AppReducerTests.stateLoadedResetsRunningStatusEvenWithoutClaudeSession` covers the persisted-status reset.
- Validated end-to-end in a sandboxed macOS VM via cua/lume:
  - **T1** Idle pane + Cmd+Q → dialog appears ("Are you sure…"); app stays alive ✓
  - **T2** Active agent (`nex event start`) + Cmd+Q → dialog appears with agent-aware body ("Nex has 1 active agent across 1 workspace…"); app stays alive after Cancel ✓
  - **T3** Preference disabled + active agent + Cmd+Q → dialog skipped, app exits ✓
- Screenshots: `/Users/ben/code/cua/out/branches/issue-129-quit-confirmation/issue-129/`

## Test plan
- [x] Cmd+Q with idle pane → dialog with "Are you sure you want to quit Nex?". Cancel keeps app, Quit exits.
- [x] Start an agent in a pane (e.g. claude -p \"hi\"), Cmd+Q → dialog body names the agent count.
- [x] Tick "Don't ask again" + Quit → app exits, pref persists. Re-launch, Cmd+Q → no dialog.
- [x] Open Settings → General → Quit. Toggle reflects current state. Flip back on, Cmd+Q with agent → dialog returns.
- [x] In edit mode on a markdown pane, type some characters, immediately Cmd+Q (within 500ms). Edit should not be lost (synchronous flush before any termination).
- [x] Suppress via dialog with Settings open in another window → toggle updates within the open Settings scene without needing a relaunch.
- [x] Quit via menu bar (Nex → Quit Nex) → same dialog flow as Cmd+Q.

🤖 Generated with [Claude Code](https://claude.com/claude-code)