### PR TITLE
fix: defer group rename focus so filter input doesn't steal it (#132)

### DIFF
--- a/Nex/Features/Workspace/GroupHeaderRow.swift
+++ b/Nex/Features/Workspace/GroupHeaderRow.swift
@@ -45,7 +45,12 @@ struct GroupHeaderRow: View {
                     .focused($renameFieldFocused)
                     .onAppear {
                         renameText = name
-                        renameFieldFocused = true
+                        // Defer the focus assignment so the TextField's
+                        // NSTextField is attached to the window first.
+                        // Without this, SwiftUI's focus binding silently
+                        // no-ops and the keyView chain hands focus to the
+                        // sidebar's filter input instead (issue #132).
+                        DispatchQueue.main.async { renameFieldFocused = true }
                     }
                     .onExitCommand { onCancelRename() }
                     .onSubmit {


### PR DESCRIPTION
## Summary
- `GroupHeaderRow` set `renameFieldFocused = true` synchronously inside `.onAppear`, before SwiftUI had attached the rename `TextField`'s `NSTextField` to the window. The focus binding silently no-opped and AppKit's keyView chain handed focus to the always-mounted sidebar filter input.
- Defer the assignment to the next runloop tick via `DispatchQueue.main.async`. Mirrors the same workaround already in `NewWorkspaceSheet.swift:157` and `CommandPaletteView.swift:90`.

Closes #132

## Reviewer notes
- Both reviewers (correctness + scope) said ship-ready, no must-fix items.
- Reviewer 2 flagged `GroupCustomEmojiSheet.swift:49` as a latent twin of this pattern (synchronous focus in `.onAppear` on a sheet TextField). No reported bug there and it's a sheet (different timing profile), so it's left as a follow-up rather than scope creep on this PR.

## Validation
- Validated in a sandboxed macOS VM via cua/lume.
- Per-issue assertions (`validate_issue_132.py`):
  - Create a sentinel group `FOCUS_TEST_OLD` via the CLI.
  - Right-click the group header → navigate to "Rename..." → type `FOCUS_TEST_NEW` → press Enter (no extra click between activating rename and typing).
  - Read `workspace_group.name` from the SQLite DB. Fix working iff the name committed to `FOCUS_TEST_NEW` (the killer signal — if focus had been stolen by the filter, the rename would never commit).
- Screenshots: `/Users/ben/code/cua/out/branches/fix-132-group-rename-focus/issue-132/`

## Test plan
- [ ] Right-click a group → click "Rename..." → start typing immediately → expect the typed text to land in the group's inline TextField, not the filter at the top.
- [ ] ESC mid-rename cancels cleanly (existing behaviour, regression check).
- [ ] Click off the rename field → expect focus-loss commit (existing behaviour, regression check).
- [ ] Bulk-create groups (\`nex group create A; nex group create B\`), trigger rename on each in turn → focus always lands on the right one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)