### PR TITLE
fix: shift+tab in terminal panes sends CSI Z, not raw 0x19 (#134)

### DIFF
--- a/Nex/Ghostty/SurfaceView.swift
+++ b/Nex/Ghostty/SurfaceView.swift
@@ -259,10 +259,7 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
                     translationFlags: translationEvent.modifierFlags
                 )
                 key.composing = false
-                text.withCString { ptr in
-                    key.text = ptr
-                    _ = ghosttySurface?.sendKey(key)
-                }
+                sendKey(key, text: Self.ghosttyText(from: text))
             }
         } else {
             // No committed text. Either a pure preedit update, a bare key (arrow, enter),
@@ -274,14 +271,19 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
                 translationFlags: translationEvent.modifierFlags
             )
             key.composing = hasMarkedText() || markedTextBefore
-            if let text = Self.ghosttyCharacters(from: translationEvent) {
-                text.withCString { ptr in
-                    key.text = ptr
-                    _ = ghosttySurface?.sendKey(key)
-                }
-            } else {
-                _ = ghosttySurface?.sendKey(key)
-            }
+            sendKey(key, text: Self.ghosttyText(from: Self.ghosttyCharacters(from: translationEvent)))
+        }
+    }
+
+    private func sendKey(_ key: ghostty_input_key_s, text: String?) {
+        guard let text else {
+            _ = ghosttySurface?.sendKey(key)
+            return
+        }
+        var keyWithText = key
+        text.withCString { ptr in
+            keyWithText.text = ptr
+            _ = ghosttySurface?.sendKey(keyWithText)
         }
     }
 
@@ -673,6 +675,23 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
         }
 
         return characters
+    }
+
+    /// Final filter on the text passed into a libghostty key event's `key.text`.
+    /// Returns nil for empty input or for strings whose first UTF-8 byte is a C0
+    /// control code (< 0x20). When nil, the caller should send the key without
+    /// `text` set so libghostty's keymap encodes the proper escape sequence
+    /// (e.g. ESC [ Z for Shift+Tab, where macOS otherwise hands us 0x19).
+    ///
+    /// Mirrors upstream Ghostty's `keyAction` filter in SurfaceView_AppKit.swift.
+    /// Note: this checks the first UTF-8 byte (not Unicode scalar), so emoji /
+    /// astral chars and ZWJ sequences pass through unchanged.
+    static func ghosttyText(from text: String?) -> String? {
+        guard let text, !text.isEmpty else { return nil }
+        if let firstByte = text.utf8.first, firstByte < 0x20 {
+            return nil
+        }
+        return text
     }
 
     static func keyEvent(

--- a/NexTests/SurfaceViewKeyboardTests.swift
+++ b/NexTests/SurfaceViewKeyboardTests.swift
@@ -132,4 +132,73 @@ struct SurfaceViewKeyboardTests {
 
         #expect(SurfaceView.ghosttyCharacters(from: event) == "é")
     }
+
+    // MARK: - ghosttyText (text filter for libghostty key.text)
+
+    @Test func ghosttyTextFiltersBackTabControlByte() {
+        // Shift+Tab gives us NSBackTabCharacter (0x19). libghostty's keymap must
+        // encode it as CSI Z, so we strip the raw text and rely on keycode+mods.
+        #expect(SurfaceView.ghosttyText(from: "\u{19}") == nil)
+    }
+
+    @Test func ghosttyTextFiltersReturnControlByte() {
+        // Ctrl+Enter's text (0x0D) — upstream's motivating example for this filter.
+        #expect(SurfaceView.ghosttyText(from: "\r") == nil)
+    }
+
+    @Test func ghosttyTextFiltersTabControlByte() {
+        // Plain Tab (0x09). Pre-filter we'd send "\t" as text; post-filter we
+        // rely on the keymap, which produces the same byte on the PTY.
+        #expect(SurfaceView.ghosttyText(from: "\t") == nil)
+    }
+
+    @Test func ghosttyTextPassesThroughDelete() {
+        // 0x7F (DEL) is not < 0x20 and intentionally flows through as text.
+        // Matches upstream Ghostty's threshold — pinning to document the choice.
+        #expect(SurfaceView.ghosttyText(from: "\u{7F}") == "\u{7F}")
+    }
+
+    @Test func ghosttyTextPassesThroughSpace() {
+        // Ctrl+Space lands here as " " (after ghosttyCharacters strips control).
+        // 0x20 is the threshold, so space passes through.
+        #expect(SurfaceView.ghosttyText(from: " ") == " ")
+    }
+
+    @Test func ghosttyTextPassesThroughPrintable() {
+        #expect(SurfaceView.ghosttyText(from: "f") == "f")
+    }
+
+    @Test func ghosttyTextPassesThroughMultiByteUnicode() {
+        #expect(SurfaceView.ghosttyText(from: "é") == "é")
+    }
+
+    @Test func ghosttyTextPassesThroughEmojiAndZWJ() {
+        // Astral / surrogate-pair / ZWJ sequences start with high UTF-8
+        // bytes (0xF0+ for astral, 0xE2 for ZWJ U+200D). The filter checks
+        // first UTF-8 byte (not first scalar), so they pass through.
+        #expect(SurfaceView.ghosttyText(from: "🎉") == "🎉")
+        #expect(SurfaceView.ghosttyText(from: "👨‍👩‍👧") == "👨‍👩‍👧")
+    }
+
+    @Test func ghosttyTextReturnsNilForNilInput() {
+        #expect(SurfaceView.ghosttyText(from: nil) == nil)
+    }
+
+    @Test func ghosttyTextReturnsNilForEmptyInput() {
+        #expect(SurfaceView.ghosttyText(from: "") == nil)
+    }
+
+    @Test func shiftTabRoundTripFiltersToNil() {
+        // End-to-end regression check for issue #134: Shift+Tab through both
+        // helpers should yield nil so the keymap encodes CSI Z.
+        let event = keyEvent(
+            keyCode: 48,
+            modifierFlags: .shift,
+            characters: "\u{19}",
+            charactersIgnoringModifiers: "\t"
+        )
+
+        let text = SurfaceView.ghosttyText(from: SurfaceView.ghosttyCharacters(from: event))
+        #expect(text == nil)
+    }
 }


### PR DESCRIPTION
## Summary

- Restores Shift+Tab in Nex terminal panes to produce the standard `ESC [ Z` (CSI Z) sequence, fixing Claude Code's permission-mode toggle, vim's `<S-Tab>`, and anything else that expects the proper escape.
- Regression introduced in `0a297ca` (#122): the new keyDown path set `key.text = "\u{19}"` for Shift+Tab, bypassing libghostty's keymap and writing the raw NSBackTabCharacter byte to the PTY.
- Fix mirrors upstream Ghostty's `keyAction` guard at `ghostty/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift:1424-1435`: skip `key.text` when the first UTF-8 byte is < 0x20, letting libghostty's keymap encode the proper escape.

Implemented as a small static helper `ghosttyText(from:)` plus a private `sendKey(_:text:)` that both branches of `keyDown` share. 11 unit tests added covering the new helper (BackTab, Return, Tab, Space, DEL passthrough, printable, multi-byte, emoji+ZWJ, nil/empty, end-to-end Shift+Tab round trip).

Closes #134

## Reviewer notes

- Plan reviewed via `plan-review`; refinements applied (DEL/Space/Tab/Ctrl+Enter test pins, emoji+ZWJ pin, doc comment distinguishing `ghosttyText` from `ghosttyCharacters`).
- Code reviewed by `codex` against `git diff main` — PASS, zero must/should-fix findings. The independent Claude reviewer pane was unreachable due to upstream API 529 Overloaded throughout the session; the in-process \`Agent\` fallback also returned 529, so the second-opinion lane is skipped here.

## Validation

- Validated in a sandboxed macOS VM via \`cua/lume\` (\`validate_issue_134.py\`).
- Assertions all PASS:
  - Shift+Tab through a focused terminal pane wrote \`1b 5b 5a\` (CSI Z) to the PTY.
  - Plain Tab wrote \`09\`.
  - Printable \`a\` wrote \`61\`.
- Screenshots: \`/Users/ben/code/cua/out/branches/issue-134-shift-tab-csi-z/issue-134/\`

## Test plan

- [x] Launch Nex, open a terminal pane, run \`claude\` (or any TUI), press Shift+Tab — should trigger the chord.
- [x] In the pane: \`python3 -c 'import sys,tty,termios,os; fd=sys.stdin.fileno(); old=termios.tcgetattr(fd); tty.setraw(fd); print(os.read(fd,8).hex())'\`, then press Shift+Tab — should print \`1b5b5a\`.
- [x] In \`vim\`: \`:imap <S-Tab> ZZZ<Esc>\`, then \`i\` + Shift+Tab — should insert \`ZZZ\`.
- [x] Regression spot-checks:
  - [x] Plain Tab autocompletion in zsh/bash still works.
  - [ ] Dead-key sequence on US International keyboard (apostrophe + s → \`'s\`).
  - [ ] Cmd+key keybindings still fire (⌘D split, ⌘W close, ⌘E markdown toggle, etc.).
  - [ ] Printable ASCII / multi-byte unicode / emoji input still flows through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)