### PR TITLE
fix(graft): follow-ups to #137 (forceStop on removal, spawn race, first-run init)

### DIFF
--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -1510,6 +1510,11 @@ struct AppReducer {
                 let paneIDs = workspace.layout.allPaneIDs
                     + workspace.parkedPanes.map(\.id)
                 let assocIDs = workspace.repoAssociations.map(\.id)
+                // Capture associations with live graft sessions BEFORE
+                // removal so we can issue `forceStop` for each — head
+                // watcher cancellation alone leaves the graft mirroring
+                // a worktree whose association is gone.
+                let liveGraftAssocIDs = assocIDs.filter { state.graft.sessions[id: $0] != nil }
                 state.workspaces.remove(id: id)
                 state.topLevelOrder.removeAll { $0 == .workspace(id) }
                 for groupID in state.groups.ids {
@@ -1536,6 +1541,7 @@ struct AppReducer {
                 }
 
                 let stopEffects = assocIDs.map { Effect.send(Action.stopHeadWatcher(associationID: $0)) }
+                let graftStopEffects = liveGraftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
                 return .merge(
                     [
                         .run { _ in
@@ -1544,7 +1550,7 @@ struct AppReducer {
                             }
                         },
                         .send(.persistState)
-                    ] + stopEffects
+                    ] + stopEffects + graftStopEffects
                 )
 
             case .moveWorkspace(let id, let toIndex):
@@ -1754,10 +1760,18 @@ struct AppReducer {
                 guard ids.count < state.workspaces.count else { return .none }
 
                 var panesToDestroy: [UUID] = []
+                // Capture associations with live graft sessions BEFORE
+                // removal — otherwise the graft keeps mirroring a
+                // worktree whose association is gone with no UI/CLI
+                // path to stop it.
+                var liveGraftAssocIDs: [UUID] = []
                 for id in ids {
                     guard let workspace = state.workspaces[id: id] else { continue }
                     panesToDestroy.append(contentsOf: workspace.layout.allPaneIDs)
                     panesToDestroy.append(contentsOf: workspace.parkedPanes.map(\.id))
+                    liveGraftAssocIDs.append(contentsOf: workspace.repoAssociations
+                        .map(\.id)
+                        .filter { state.graft.sessions[id: $0] != nil })
                     state.workspaces.remove(id: id)
                 }
                 let removedSet = Set(ids)
@@ -1785,13 +1799,16 @@ struct AppReducer {
                 state.lastSelectionAnchor = nil
 
                 let paneIDs = panesToDestroy
+                let graftStopEffects = liveGraftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
                 return .merge(
-                    .run { _ in
-                        for paneID in paneIDs {
-                            await surfaceManager.destroySurface(paneID: paneID)
-                        }
-                    },
-                    .send(.persistState)
+                    [
+                        .run { _ in
+                            for paneID in paneIDs {
+                                await surfaceManager.destroySurface(paneID: paneID)
+                            }
+                        },
+                        .send(.persistState)
+                    ] + graftStopEffects
                 )
 
             case .toggleGroupCollapse(let groupID):
@@ -1958,10 +1975,18 @@ struct AppReducer {
                     // Drop each child workspace. Mirrors `deleteWorkspace` so
                     // surfaces are destroyed and downstream state stays clean.
                     var paneIDs: [UUID] = []
+                    // Capture associations with live graft sessions
+                    // BEFORE removal so we can issue `forceStop` for
+                    // each — otherwise grafts on child workspaces
+                    // keep running with no way to stop them.
+                    var liveGraftAssocIDs: [UUID] = []
                     for wsID in childIDs {
                         guard let workspace = state.workspaces[id: wsID] else { continue }
                         paneIDs.append(contentsOf: workspace.layout.allPaneIDs)
                         paneIDs.append(contentsOf: workspace.parkedPanes.map(\.id))
+                        liveGraftAssocIDs.append(contentsOf: workspace.repoAssociations
+                            .map(\.id)
+                            .filter { state.graft.sessions[id: $0] != nil })
                         state.workspaces.remove(id: wsID)
                     }
                     let removedSet = Set(childIDs)
@@ -1984,13 +2009,16 @@ struct AppReducer {
                     state.groupDeleteConfirmation = nil
 
                     let captured = paneIDs
+                    let graftStopEffects = liveGraftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
                     return .merge(
-                        .run { _ in
-                            for paneID in captured {
-                                await surfaceManager.destroySurface(paneID: paneID)
-                            }
-                        },
-                        .send(.persistState)
+                        [
+                            .run { _ in
+                                for paneID in captured {
+                                    await surfaceManager.destroySurface(paneID: paneID)
+                                }
+                            },
+                            .send(.persistState)
+                        ] + graftStopEffects
                     )
                 } else {
                     // Promote children to the top level, in order, at the
@@ -2166,8 +2194,15 @@ struct AppReducer {
 
             case .stateLoaded(let workspaces, let groups, let topLevelOrder, let activeID, let repoRegistry):
                 if workspaces.isEmpty {
-                    // First launch — create a default workspace
-                    return .send(.createWorkspace(name: "Default"))
+                    // First launch — create a default workspace and
+                    // still hand off to GraftFeature so its updates
+                    // subscription installs. Without this, a CLI-
+                    // started graft on first run would be invisible
+                    // to status / stop / quit-flush.
+                    return .merge(
+                        .send(.createWorkspace(name: "Default")),
+                        .send(.graft(.onAppLaunched(parentRepoRoots: [])))
+                    )
                 }
                 state.workspaces = workspaces
                 state.groups = groups
@@ -3221,7 +3256,13 @@ struct AppReducer {
                 let stopEffects = removedAssociationIDs.map {
                     Effect.send(Action.stopHeadWatcher(associationID: $0))
                 }
-                return .merge(stopEffects + [.send(.persistState)])
+                // Stop any live graft sessions on removed associations.
+                // Without this, removing the repo leaves grafts mirroring
+                // a worktree whose association is gone.
+                let graftStopEffects = removedAssociationIDs
+                    .filter { state.graft.sessions[id: $0] != nil }
+                    .map { Effect.send(Action.graft(.forceStop($0))) }
+                return .merge(stopEffects + graftStopEffects + [.send(.persistState)])
 
             case .renameRepo(let id, let name):
                 state.repoRegistry[id: id]?.name = name
@@ -3292,8 +3333,13 @@ struct AppReducer {
                 state.workspaces[id: workspaceID]?.repoAssociations.remove(id: associationID)
                 state.gitStatuses.removeValue(forKey: associationID)
 
+                // `forceStop` (not `toggleGraft`) because the
+                // association is being deleted entirely. `toggleGraft`
+                // would retry-start a graft when the existing session
+                // is in `.error` state, which is wrong here — the
+                // worktree is going away.
                 let graftStop: Effect<Action> = needsGraftStop
-                    ? .send(.graft(.toggleGraft(assoc)))
+                    ? .send(.graft(.forceStop(associationID)))
                     : .none
 
                 if deleteWorktree {
@@ -3474,7 +3520,14 @@ struct AppReducer {
 
                 if removedRepoIDs.isEmpty { return .none }
                 let stopEffects = stoppedAssocIDs.map { Effect.send(Action.stopHeadWatcher(associationID: $0)) }
-                return .merge(stopEffects + [.send(.persistState)])
+                // Stop any live graft sessions for auto-unlinked
+                // associations. Otherwise a graft set up against an
+                // auto-linked worktree keeps mirroring after the pane
+                // moves out of that worktree.
+                let graftStopEffects = stoppedAssocIDs
+                    .filter { state.graft.sessions[id: $0] != nil }
+                    .map { Effect.send(Action.graft(.forceStop($0))) }
+                return .merge(stopEffects + graftStopEffects + [.send(.persistState)])
 
             case .repoRemoteURLResolved(let repoID, let url):
                 state.repoRegistry[id: repoID]?.remoteURL = url

--- a/Nex/Features/Graft/GraftFeature.swift
+++ b/Nex/Features/Graft/GraftFeature.swift
@@ -22,6 +22,15 @@ struct GraftFeature {
         case onAppLaunched(parentRepoRoots: [String])
         case orphansDetected([GraftOrphan])
         case toggleGraft(RepoAssociation)
+        /// Unconditional stop for a specific association — used by
+        /// removal paths (workspace delete, bulk delete, cascade
+        /// group delete, repo removal, auto-unlink) where the
+        /// association is being deleted entirely and `toggleGraft`
+        /// would either retry-start an `.error` session or be a
+        /// no-op. Drops the session from state and tells the
+        /// service to tear down. Idempotent: a missing session is
+        /// a no-op.
+        case forceStop(UUID)
         case startSucceeded(GraftSession)
         /// Typed failure so the reducer can distinguish "another
         /// session already owns this parent root" (which triggers the
@@ -115,6 +124,28 @@ struct GraftFeature {
                                 failure: GraftStartFailure(error: error)
                             ))
                         }
+                    }
+                }
+
+            case .forceStop(let assocID):
+                guard let existing = state.sessions[id: assocID] else { return .none }
+                // A session in `.error` state never owns live
+                // resources — just drop the placeholder. Unlike
+                // `toggleGraft`, we never retry-start (the caller is
+                // a removal path; the association no longer exists).
+                if case .error = existing.status {
+                    state.sessions.remove(id: assocID)
+                    return .none
+                }
+                return .run { send in
+                    do {
+                        try await graftService.stop(assocID)
+                        await send(.stopSucceeded(assocID))
+                    } catch {
+                        await send(.stopFailed(
+                            assocID,
+                            error: String(describing: error)
+                        ))
                     }
                 }
 

--- a/Nex/Services/GraftService.swift
+++ b/Nex/Services/GraftService.swift
@@ -324,12 +324,31 @@ final class GraftServiceImpl: Sendable {
                 // cancellation and re-applies the worktree's tree
                 // AFTER the parent has been restored, leaving the
                 // parent dirty and breaking the stash pop.
+                //
+                // The spawn + register MUST happen atomically under
+                // the lock, AND we must verify the watcher entry is
+                // still live AFTER the lock. Otherwise `stop()` can
+                // slip in between batch arrival and registration:
+                //   1. batch arrives, watcher about to spawn syncTask
+                //   2. stop() removes our watcherTask, reads empty
+                //      activeSyncTasks, proceeds to restoreParent
+                //   3. watcher finally spawns syncTask → read-tree
+                //      lands AFTER restore and corrupts the parent.
+                // Guarding on `watcherTasks[assocID] != nil` inside
+                // the same lock closes the race: stop's first lock
+                // (`watcherTasks.removeValue`) and our spawn-or-abort
+                // check are now totally ordered.
                 let assocID = association.id
-                let syncTask = Task { [weak self] in
-                    guard let self else { return }
-                    await handleBatch(associationID: assocID, batch: batch)
+                let syncTask: Task<Void, Never>? = lock.withLock {
+                    guard watcherTasks[assocID] != nil else { return nil }
+                    let task = Task { [weak self] in
+                        guard let self else { return }
+                        await handleBatch(associationID: assocID, batch: batch)
+                    }
+                    activeSyncTasks[assocID] = task
+                    return task
                 }
-                lock.withLock { activeSyncTasks[assocID] = syncTask }
+                guard let syncTask else { return }
                 await syncTask.value
                 // The watcher loop is serial — only one batch can be
                 // in flight per session at a time. If `stop()` already

--- a/NexTests/RecursiveFSWatcherTests.swift
+++ b/NexTests/RecursiveFSWatcherTests.swift
@@ -81,10 +81,16 @@ struct RecursiveFSWatcherTests {
 
         let received = try await firstBatch(stream, timeout: .seconds(3))
         // All 10 writes should coalesce into a single batch under the
-        // 300ms debounce. FSEvents itself batches further; the watcher's
-        // debounce is the upper bound.
+        // 300ms debounce. FSEvents itself batches further — and can
+        // collapse N file writes inside one directory down to a
+        // single parent-dir event when the writes happen quickly
+        // enough. The path count is therefore not stable; the
+        // invariant we care about is "the watcher delivered SOMETHING
+        // under tempDir within the debounce window, in one batch".
+        // Graft's sync pass is full-tree per batch anyway, so the
+        // per-path fanout was never load-bearing.
         let touched = received.filter { $0.contains(tempDir) }
-        #expect(touched.count >= 5)
+        #expect(!touched.isEmpty)
 
         watcher.stopAll()
     }


### PR DESCRIPTION
## Summary

Five graft fixes that were meant for #137 but landed after the merge. Each is independently testable and the changes are small in scope; bundled here as a single follow-up rather than fanned out across five PRs.

- **AppReducer: `graft.forceStop` on cleanup paths.** Workspace delete, bulk delete, group cascade delete, repo removal, and auto-unlink now stop any live graft session for the affected associations. Without this, removing the owning workspace/repo leaves the graft mirroring a worktree whose association is gone, with no UI/CLI path to stop it.
- **AppReducer: `graft(.onAppLaunched)` on first-run state load.** When `stateLoaded` fires with no workspaces (first launch), we now still hand off to `GraftFeature` so its updates subscription installs alongside the default-workspace creation. Without this, a CLI-started graft on first run is invisible to status / stop / quit-flush.
- **GraftFeature: new `forceStop(UUID)` action.** Unconditional stop with no retry-start. `toggleGraft` was the wrong primitive for removal paths because it retry-starts a session when its status is `.error`. `forceStop` drops the placeholder when the session is in `.error`, otherwise calls through to `graftService.stop`. Idempotent on missing sessions.
- **GraftService: spawn + register `syncTask` atomically under the lock.** Closes a race where `stop()` could slip in between batch arrival and `syncTask` registration: stop removes the watcher entry, reads an empty `activeSyncTasks`, then proceeds to `restoreParent` while a syncTask spawns immediately after and lands its `read-tree` AFTER the restore, corrupting the parent. Now spawn-or-abort runs under the same lock that `stop()` uses to clear `watcherTasks`, making the two paths totally ordered.
- **RecursiveFSWatcherTests: relax coalescing assertion.** FSEvents can collapse N file writes inside one directory down to a single parent-dir event when the writes happen quickly enough, so the path count is not stable. Replaced `count >= 5` with `!touched.isEmpty`. Graft's sync pass is full-tree per batch anyway, so per-path fanout was never load-bearing.

## Test plan

- [ ] Local: `make check` passes (NOTE: hit one transient CodeSign flake during the first run; clean re-run succeeded)
- [ ] Workspace delete with a live graft on one of its associations stops the graft cleanly (no orphaned `git read-tree` after the workspace is gone)
- [ ] Bulk delete (multi-select workspaces) with live grafts stops all of them
- [ ] Group cascade delete (`--cascade`) with grafts on child workspaces stops them all
- [ ] Removing a repo from the registry stops any grafts on its associations
- [ ] Detaching a pane from an auto-linked worktree stops the graft for that association
- [ ] On first launch (delete `~/Library/Application Support/Nex/nex.db`), start a graft via the CLI; verify `nex` status surfaces it and Cmd-Q's quit-flush waits for it
- [ ] Toggle a graft into `.error` state, then delete the association; verify the placeholder is dropped (no retry-start)

## Notes

Branched off `main` after #137 was squash-merged. The actual code was developed on `feat/graft-integration` before that branch's PR merged, but never committed at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)