### PR TITLE
Web pane: in-app browser with agent-driven console + element capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ DerivedData/
 *.xcworkspace/xcuserdata/
 *.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
 xcuserdata/
+# xcodegen regenerates schemes from project.yml
+*.xcodeproj/xcshareddata/
 
 # macOS
 .DS_Store

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		5109ADD55C00BC02B15EDE81 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3879BA745F8737CA5872F80D /* DatabaseService.swift */; };
 		52D4477AF5CCF1724D609119 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = EFC4D8E9A152683486EC7F29 /* Sparkle */; };
 		539AACF3A856FD51EC92A6F1 /* WebPaneBatchMarkerScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579D8D40F1D9930845C3B0C9 /* WebPaneBatchMarkerScript.swift */; };
+		53AD8B876DA9611918F5F585 /* WebPaneURLNormalisationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06845D1AC00D409504EDAB61 /* WebPaneURLNormalisationTests.swift */; };
 		550563B9BEDE841D3B7CE6B8 /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221A3B0170CFD708F3B03A84 /* Repo.swift */; };
 		5883FFD10BE73F44EA8F4A5C /* PaneSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE917FD003D3FFD196DBF77 /* PaneSearchOverlay.swift */; };
 		58B6A951A34B2ED1516194C4 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08D39F8F87D7505CD32D25D /* WebKit.framework */; };
@@ -181,6 +182,7 @@
 		005B56542A2F5FD5D3BC588C /* PaneGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneGridView.swift; sourceTree = "<group>"; };
 		0153509BA13BB205C40DE2D5 /* GitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitService.swift; sourceTree = "<group>"; };
 		018EF0FBACD529C982B7811D /* SurfaceContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceContainerView.swift; sourceTree = "<group>"; };
+		06845D1AC00D409504EDAB61 /* WebPaneURLNormalisationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneURLNormalisationTests.swift; sourceTree = "<group>"; };
 		0689D085597FF9C7F4D87401 /* RepoPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoPickerView.swift; sourceTree = "<group>"; };
 		09102B6ADEAB463454E7F15E /* StatusBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarController.swift; sourceTree = "<group>"; };
 		0C975C89EC3EAA135F52A7AD /* WorkspaceDropTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDropTarget.swift; sourceTree = "<group>"; };
@@ -452,6 +454,7 @@
 				ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */,
 				AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */,
 				1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */,
+				06845D1AC00D409504EDAB61 /* WebPaneURLNormalisationTests.swift */,
 				94D09D767C96B3F96E4DF7C5 /* WindowSpacesBindingTests.swift */,
 				28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */,
 				E01C66D4D59D04F6372D8AD7 /* WorkspaceDropTargetTests.swift */,
@@ -851,6 +854,7 @@
 				EAF43DC55C5612F3AE83BF02 /* SettingsFeatureTests.swift in Sources */,
 				2B4533964D77117EE6D98690 /* SocketParsingTests.swift in Sources */,
 				EF4258CFC52EB748609C7F18 /* SurfaceViewKeyboardTests.swift in Sources */,
+				53AD8B876DA9611918F5F585 /* WebPaneURLNormalisationTests.swift in Sources */,
 				DDD05A3B3A535DEA66485A47 /* WindowSpacesBindingTests.swift in Sources */,
 				5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */,
 				F01CDB667AE2A0CF2A825AD3 /* WorkspaceDropTargetTests.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		4A2AC027454C7CBDF4B312C9 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F71D541343DA67CDCADA821 /* CoreText.framework */; };
 		4AF9CB9A4E7CE871FBE1A6F2 /* WorkspaceColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4B95F852C737F18989F8FA /* WorkspaceColor.swift */; };
 		4D7F4ECDA338E826904B584E /* PaneLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11F5427AE75515696FB8295 /* PaneLayoutTests.swift */; };
+		503C106566E08F34EDBC80D0 /* Favourites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EECDF8241787F53AC4EA24 /* Favourites.swift */; };
 		5109ADD55C00BC02B15EDE81 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3879BA745F8737CA5872F80D /* DatabaseService.swift */; };
 		52D4477AF5CCF1724D609119 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = EFC4D8E9A152683486EC7F29 /* Sparkle */; };
 		539AACF3A856FD51EC92A6F1 /* WebPaneBatchMarkerScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579D8D40F1D9930845C3B0C9 /* WebPaneBatchMarkerScript.swift */; };
@@ -229,6 +230,7 @@
 		4DA17E3004A004E6B4DDDBF6 /* PersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceTests.swift; sourceTree = "<group>"; };
 		4F0D3AB3067CDBF5A490F532 /* NewWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceSheet.swift; sourceTree = "<group>"; };
 		523DE37561222E411737C3F8 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		54EECDF8241787F53AC4EA24 /* Favourites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Favourites.swift; sourceTree = "<group>"; };
 		579D8D40F1D9930845C3B0C9 /* WebPaneBatchMarkerScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneBatchMarkerScript.swift; sourceTree = "<group>"; };
 		57C59BDCBA03302FC7FDE16B /* WorkspaceInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceInspectorView.swift; sourceTree = "<group>"; };
 		5AC82B39AC5EEEC6A787B4D4 /* FocusNotifyingTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusNotifyingTextView.swift; sourceTree = "<group>"; };
@@ -595,6 +597,7 @@
 		8C7E8AA61857407F1760CCCF /* WebPane */ = {
 			isa = PBXGroup;
 			children = (
+				54EECDF8241787F53AC4EA24 /* Favourites.swift */,
 				BF16F0C4A6A8BF8151651F53 /* InspectPayloadSanitiser.swift */,
 				1D792DEC74448D403CE1A96D /* RingBuffer.swift */,
 				998480F19F798025639D20A7 /* WebBatchInspectPanel.swift */,
@@ -875,6 +878,7 @@
 				77FB1142F26F5C33539E3F23 /* DiffHTMLRenderer.swift in Sources */,
 				7B54AB73465C0926D5259580 /* DiffPaneView.swift in Sources */,
 				A3B349AFCABD43FDC2F97A2A /* EditorService.swift in Sources */,
+				503C106566E08F34EDBC80D0 /* Favourites.swift in Sources */,
 				9D8356F03AF69469528218D5 /* FocusNotifyingTextView.swift in Sources */,
 				2BD04AF1F25BBC3516E5F706 /* GhosttyApp.swift in Sources */,
 				ECA2C078504EB9BF0E04B343 /* GhosttyConfig.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2B4533964D77117EE6D98690 /* SocketParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */; };
 		2BD04AF1F25BBC3516E5F706 /* GhosttyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000C46C62FB60503295A92E8 /* GhosttyApp.swift */; };
 		2D8754E0B3E9AD185D7EB6B0 /* ConfigParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4114D723403D4FF8F4AC1B /* ConfigParser.swift */; };
+		2F440D3EB93B6C127A1FF003 /* WebPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A97924791DAA26F0E4B0BA /* WebPaneView.swift */; };
 		3B60C0FC48A2AAF6282CAB40 /* WorkspaceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F9C43CA9B19E7281082913 /* WorkspaceListView.swift */; };
 		3C74513CA9D5FD60E672B477 /* CommandPaletteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1870562A61E6F66FFE03A8BA /* CommandPaletteItem.swift */; };
 		3DF88C2A2966C7B0209E22FE /* RepoPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0689D085597FF9C7F4D87401 /* RepoPickerView.swift */; };
@@ -55,6 +56,7 @@
 		5CFC8C5F96B371044A5ABE91 /* QuitConfirmationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD202733564AC92AEC00A0C /* QuitConfirmationTests.swift */; };
 		62564D224FD57BC3C02100EA /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191E820170ADF2ADB58B8079 /* GitServiceTests.swift */; };
 		62BC1CC522515C8E6A99F508 /* GitHeadWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 281BB8BFA202B0E43FC1E2AE /* GitHeadWatcher.swift */; };
+		630837DB73DACFE99190C60D /* WebPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B04ED477C0C51A44953A8C /* WebPaneState.swift */; };
 		64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A24C1FEC6EA31096603326 /* SurfaceManager.swift */; };
 		692A08796F7DF555CFAF0653 /* MarkdownFindScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4FA41668CB28EB0FFA7911 /* MarkdownFindScript.swift */; };
 		696312BB96D35569F48B7CAE /* MarkdownFrontMatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43F769C33118440222BF5FA /* MarkdownFrontMatter.swift */; };
@@ -90,6 +92,9 @@
 		A1937931A23F2D0EB8472737 /* ConfigParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309F641591BB580429299666 /* ConfigParserTests.swift */; };
 		A33EF4059D3F3479ED5C9EE2 /* WorkspaceGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2687F4D886D153C83D8A60 /* WorkspaceGroup.swift */; };
 		A3B349AFCABD43FDC2F97A2A /* EditorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CED7EFE254E4491327CAE0 /* EditorService.swift */; };
+		A60D7684F5DA8DD340A04A01 /* WebPaneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC5A9C48821CE81CCB7FFB5 /* WebPaneCoordinator.swift */; };
+		A8626EC08DC12588F912E1EF /* WebPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A94E80914F7411EED712E5 /* WebPaneStore.swift */; };
+		A895048D11AFDC1FDA5DF846 /* WebPaneChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DFA60F59651234F0F59BE9 /* WebPaneChrome.swift */; };
 		A8F1A82072120476BAEC2D52 /* UserDefaultsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C693AF419763177AE1CEA0F /* UserDefaultsClient.swift */; };
 		AC234A5AAADE90A7EC7BB5F8 /* MarkdownHTMLRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E7D450881FC7318F58CB78F /* MarkdownHTMLRenderer.swift */; };
 		AF0F22742F34298F1E06A238 /* WorkspaceGroupSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F7D5571F89D43BC6C76928 /* WorkspaceGroupSocketTests.swift */; };
@@ -200,6 +205,7 @@
 		36F691F3442E4E1BBC495C78 /* GraftFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraftFeatureTests.swift; sourceTree = "<group>"; };
 		3714AA1F15C85762BF36B1FE /* NexApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NexApp.swift; sourceTree = "<group>"; };
 		377C07C6C4B00D0699682EA3 /* PaneType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneType.swift; sourceTree = "<group>"; };
+		37B04ED477C0C51A44953A8C /* WebPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneState.swift; sourceTree = "<group>"; };
 		37DDBBE36E6F9BC00B9EB07E /* MarkdownFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFindController.swift; sourceTree = "<group>"; };
 		3879BA745F8737CA5872F80D /* DatabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseService.swift; sourceTree = "<group>"; };
 		396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffHTMLRendererTests.swift; sourceTree = "<group>"; };
@@ -209,6 +215,7 @@
 		42A24C1FEC6EA31096603326 /* SurfaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceManager.swift; sourceTree = "<group>"; };
 		439174A029FAFE2C252A1B8B /* KeybindingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingsSettingsView.swift; sourceTree = "<group>"; };
 		452A1B196F8438AD7A7DAC0A /* PaneSendKeyReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSendKeyReplyTests.swift; sourceTree = "<group>"; };
+		45DFA60F59651234F0F59BE9 /* WebPaneChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneChrome.swift; sourceTree = "<group>"; };
 		4CCB57D9C4E2AC2014127FC8 /* MarkdownCheckboxRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCheckboxRenderingTests.swift; sourceTree = "<group>"; };
 		4DA17E3004A004E6B4DDDBF6 /* PersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceTests.swift; sourceTree = "<group>"; };
 		4F0D3AB3067CDBF5A490F532 /* NewWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceSheet.swift; sourceTree = "<group>"; };
@@ -247,7 +254,9 @@
 		94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceView.swift; sourceTree = "<group>"; };
 		94D09D767C96B3F96E4DF7C5 /* WindowSpacesBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowSpacesBindingTests.swift; sourceTree = "<group>"; };
 		96AD7A8D7E6592B90FBB7D24 /* GhosttyConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfig.swift; sourceTree = "<group>"; };
+		98A97924791DAA26F0E4B0BA /* WebPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneView.swift; sourceTree = "<group>"; };
 		9D96CD47FF756C95404DF4F6 /* Pane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pane.swift; sourceTree = "<group>"; };
+		A0A94E80914F7411EED712E5 /* WebPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneStore.swift; sourceTree = "<group>"; };
 		A11F5427AE75515696FB8295 /* PaneLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutTests.swift; sourceTree = "<group>"; };
 		A2554566AF4F790EB30637E3 /* AgentLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleTests.swift; sourceTree = "<group>"; };
 		A47FF7FB9A9C29221EAD089E /* GhosttyConfigClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigClient.swift; sourceTree = "<group>"; };
@@ -302,6 +311,7 @@
 		F90FF9C2E7F0BC50E51C47DE /* RepoRegistryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoRegistryView.swift; sourceTree = "<group>"; };
 		F9DA0C4B28F4E3DAF4CF1EB0 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneListTests.swift; sourceTree = "<group>"; };
+		FDC5A9C48821CE81CCB7FFB5 /* WebPaneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneCoordinator.swift; sourceTree = "<group>"; };
 		FF88062F290789D98B545AC6 /* WorkspaceGroupCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupCRUDTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -506,6 +516,7 @@
 				0E3C930E9EEBE1D0094A6538 /* ScratchpadPane */,
 				3C80F4E7F9BFB46382583CF8 /* Settings */,
 				C07DAE9A20D318288C360D1B /* StatusBar */,
+				8C7E8AA61857407F1760CCCF /* WebPane */,
 				7D8D8A8C5E2891A6686932C2 /* Workspace */,
 			);
 			path = Features;
@@ -561,6 +572,18 @@
 				1CB2BCC7EBF45A4E50F314F2 /* DiffPaneView.swift */,
 			);
 			path = DiffPane;
+			sourceTree = "<group>";
+		};
+		8C7E8AA61857407F1760CCCF /* WebPane */ = {
+			isa = PBXGroup;
+			children = (
+				45DFA60F59651234F0F59BE9 /* WebPaneChrome.swift */,
+				FDC5A9C48821CE81CCB7FFB5 /* WebPaneCoordinator.swift */,
+				37B04ED477C0C51A44953A8C /* WebPaneState.swift */,
+				A0A94E80914F7411EED712E5 /* WebPaneStore.swift */,
+				98A97924791DAA26F0E4B0BA /* WebPaneView.swift */,
+			);
+			path = WebPane;
 			sourceTree = "<group>";
 		};
 		9405054AFE00CF7F6065B578 /* Graft */ = {
@@ -890,6 +913,11 @@
 				B8DCB316773E208FABEDA9D7 /* UpdaterService.swift in Sources */,
 				A8F1A82072120476BAEC2D52 /* UserDefaultsClient.swift in Sources */,
 				B167B81282ADF716B21B1679 /* VibrancyView.swift in Sources */,
+				A895048D11AFDC1FDA5DF846 /* WebPaneChrome.swift in Sources */,
+				A60D7684F5DA8DD340A04A01 /* WebPaneCoordinator.swift in Sources */,
+				630837DB73DACFE99190C60D /* WebPaneState.swift in Sources */,
+				A8626EC08DC12588F912E1EF /* WebPaneStore.swift in Sources */,
+				2F440D3EB93B6C127A1FF003 /* WebPaneView.swift in Sources */,
 				EDF35E86B633BB1E8C3DE844 /* WindowSpacesBinding.swift in Sources */,
 				4AF9CB9A4E7CE871FBE1A6F2 /* WorkspaceColor.swift in Sources */,
 				B4846A1AC5C67E51AFA9C846 /* WorkspaceDropTarget.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0D7D8E5C230B6C98E7693D66 /* PaneListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */; };
 		0EAFF0FDB683293F95D8AB47 /* RenameWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */; };
 		0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B822ABF12B071E574E089BB4 /* GroupIconTests.swift */; };
+		131F8A6071A7ADF25504AD4E /* InspectPayloadSanitiser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF16F0C4A6A8BF8151651F53 /* InspectPayloadSanitiser.swift */; };
 		1397C2AF47888F6A056F5970 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D5AF8FEB520FE55ADB0C59 /* AppDelegate.swift */; };
 		13CFD579791838D9D23C9613 /* WorkspaceLabelViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684EF74D8EC3F295B22944AB /* WorkspaceLabelViews.swift */; };
 		149E80DD671127055EF67F7F /* DiffHTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */; };
@@ -30,8 +31,10 @@
 		27D6386295651D4FE9A3DF6B /* Pane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D96CD47FF756C95404DF4F6 /* Pane.swift */; };
 		291A22061671351813971551 /* MarkdownEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED3289901F70616FC36F80B /* MarkdownEditorView.swift */; };
 		29C636F17D2FEF2D5E0BE55D /* SettingsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8322D3C28268495A01EA0597 /* SettingsFeature.swift */; };
+		2B0CCA8BFF359E4AF96AB5AA /* WebPaneConsoleScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = D919B65B3E950098BF3405EA /* WebPaneConsoleScript.swift */; };
 		2B4533964D77117EE6D98690 /* SocketParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */; };
 		2BD04AF1F25BBC3516E5F706 /* GhosttyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000C46C62FB60503295A92E8 /* GhosttyApp.swift */; };
+		2CD77355541CE17C3427C610 /* InspectPayloadSanitiserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D0AA21761E50EFDA70A0E9 /* InspectPayloadSanitiserTests.swift */; };
 		2D8754E0B3E9AD185D7EB6B0 /* ConfigParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4114D723403D4FF8F4AC1B /* ConfigParser.swift */; };
 		2F440D3EB93B6C127A1FF003 /* WebPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A97924791DAA26F0E4B0BA /* WebPaneView.swift */; };
 		3B60C0FC48A2AAF6282CAB40 /* WorkspaceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F9C43CA9B19E7281082913 /* WorkspaceListView.swift */; };
@@ -47,11 +50,13 @@
 		4D7F4ECDA338E826904B584E /* PaneLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11F5427AE75515696FB8295 /* PaneLayoutTests.swift */; };
 		5109ADD55C00BC02B15EDE81 /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3879BA745F8737CA5872F80D /* DatabaseService.swift */; };
 		52D4477AF5CCF1724D609119 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = EFC4D8E9A152683486EC7F29 /* Sparkle */; };
+		539AACF3A856FD51EC92A6F1 /* WebPaneBatchMarkerScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579D8D40F1D9930845C3B0C9 /* WebPaneBatchMarkerScript.swift */; };
 		550563B9BEDE841D3B7CE6B8 /* Repo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221A3B0170CFD708F3B03A84 /* Repo.swift */; };
 		5883FFD10BE73F44EA8F4A5C /* PaneSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE917FD003D3FFD196DBF77 /* PaneSearchOverlay.swift */; };
 		58B6A951A34B2ED1516194C4 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E08D39F8F87D7505CD32D25D /* WebKit.framework */; };
 		58D251ED7E3B564C9BA3AD91 /* NexGhosttyDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935FE280F97CB5A1DBD31113 /* NexGhosttyDefaults.swift */; };
 		59239C7AD0D26E390C647C46 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 98CF017F4F26916F63300A33 /* Yams */; };
+		5A9607BD6AD03E15B0124B88 /* RingBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D792DEC74448D403CE1A96D /* RingBuffer.swift */; };
 		5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */; };
 		5CFC8C5F96B371044A5ABE91 /* QuitConfirmationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD202733564AC92AEC00A0C /* QuitConfirmationTests.swift */; };
 		62564D224FD57BC3C02100EA /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191E820170ADF2ADB58B8079 /* GitServiceTests.swift */; };
@@ -79,6 +84,7 @@
 		80FD60045BEE77671F7A4269 /* GraftFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F691F3442E4E1BBC495C78 /* GraftFeatureTests.swift */; };
 		811C87C669F7A920EE05E8DA /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 3A812A87D56E4976C8BF532E /* GRDB */; };
 		8132EF9FB6ACF51F7AEB57CE /* NexCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA20CEA0FEF28F3972BCE7D /* NexCommands.swift */; };
+		838F2F85AED6591FE3D2C9C9 /* WebBatchInspectPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998480F19F798025639D20A7 /* WebBatchInspectPanel.swift */; };
 		840B487024194CA181EE42F8 /* AgentLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2554566AF4F790EB30637E3 /* AgentLifecycleTests.swift */; };
 		8BACC3111C7193B1AC30B40B /* PaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D306AA2907696B7A28F9DA /* PaneLayout.swift */; };
 		8E99D6024CA5451216D39602 /* PaneHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB94DA665D3B322A44251454 /* PaneHeaderView.swift */; };
@@ -97,6 +103,7 @@
 		A895048D11AFDC1FDA5DF846 /* WebPaneChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DFA60F59651234F0F59BE9 /* WebPaneChrome.swift */; };
 		A8F1A82072120476BAEC2D52 /* UserDefaultsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C693AF419763177AE1CEA0F /* UserDefaultsClient.swift */; };
 		AC234A5AAADE90A7EC7BB5F8 /* MarkdownHTMLRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E7D450881FC7318F58CB78F /* MarkdownHTMLRenderer.swift */; };
+		AD62C235AF0D846B08655B16 /* RingBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0625B2E7935BDDF63DC5D19 /* RingBufferTests.swift */; };
 		AF0F22742F34298F1E06A238 /* WorkspaceGroupSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F7D5571F89D43BC6C76928 /* WorkspaceGroupSocketTests.swift */; };
 		B167B81282ADF716B21B1679 /* VibrancyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D6AE6635332105A3C18A03 /* VibrancyView.swift */; };
 		B221D950378165611A0DF932 /* ClipboardImageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC371B0DE7B02828E9EDFE8E /* ClipboardImageHelper.swift */; };
@@ -113,6 +120,7 @@
 		BF19A66EC95FA4FB46CA400D /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F228193206574DB257C8B3FB /* AppKit.framework */; };
 		C052FE23BF089795BB04E10E /* RenamePaneSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191592BF0EBCEC22DF9F5745 /* RenamePaneSheet.swift */; };
 		C0DDF7284D01523225E5EEE7 /* GhosttyConfigClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47FF7FB9A9C29221EAD089E /* GhosttyConfigClient.swift */; };
+		C1FC2BD79FF0D9DC86910028 /* WebPaneInspectorScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BAD220346CCE551765FCD9 /* WebPaneInspectorScript.swift */; };
 		C276E6F9F7B46ED43FF491D5 /* NexApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3714AA1F15C85762BF36B1FE /* NexApp.swift */; };
 		CCBCDD690DA8A082B0C3D1EF /* StatusBarPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110D5179A9834B4AB19B705B /* StatusBarPopoverView.swift */; };
 		D0B97CB294CE96D259C08960 /* GraftCLIReplyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD93535314E9897122ED638 /* GraftCLIReplyTests.swift */; };
@@ -187,6 +195,7 @@
 		1BA6AA9E98405375983902BD /* WorkspaceFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFeature.swift; sourceTree = "<group>"; };
 		1C625959E287CE9896D5BA4D /* RepoRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoRegistryTests.swift; sourceTree = "<group>"; };
 		1CB2BCC7EBF45A4E50F314F2 /* DiffPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneView.swift; sourceTree = "<group>"; };
+		1D792DEC74448D403CE1A96D /* RingBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBuffer.swift; sourceTree = "<group>"; };
 		1E7D450881FC7318F58CB78F /* MarkdownHTMLRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownHTMLRenderer.swift; sourceTree = "<group>"; };
 		1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		1F71D541343DA67CDCADA821 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
@@ -220,6 +229,7 @@
 		4DA17E3004A004E6B4DDDBF6 /* PersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceTests.swift; sourceTree = "<group>"; };
 		4F0D3AB3067CDBF5A490F532 /* NewWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceSheet.swift; sourceTree = "<group>"; };
 		523DE37561222E411737C3F8 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		579D8D40F1D9930845C3B0C9 /* WebPaneBatchMarkerScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneBatchMarkerScript.swift; sourceTree = "<group>"; };
 		57C59BDCBA03302FC7FDE16B /* WorkspaceInspectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceInspectorView.swift; sourceTree = "<group>"; };
 		5AC82B39AC5EEEC6A787B4D4 /* FocusNotifyingTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusNotifyingTextView.swift; sourceTree = "<group>"; };
 		5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingTests.swift; sourceTree = "<group>"; };
@@ -253,8 +263,10 @@
 		93D45D65A66C475B0CEEC53C /* KeybindingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingService.swift; sourceTree = "<group>"; };
 		94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceView.swift; sourceTree = "<group>"; };
 		94D09D767C96B3F96E4DF7C5 /* WindowSpacesBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowSpacesBindingTests.swift; sourceTree = "<group>"; };
+		95D0AA21761E50EFDA70A0E9 /* InspectPayloadSanitiserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectPayloadSanitiserTests.swift; sourceTree = "<group>"; };
 		96AD7A8D7E6592B90FBB7D24 /* GhosttyConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfig.swift; sourceTree = "<group>"; };
 		98A97924791DAA26F0E4B0BA /* WebPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneView.swift; sourceTree = "<group>"; };
+		998480F19F798025639D20A7 /* WebBatchInspectPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebBatchInspectPanel.swift; sourceTree = "<group>"; };
 		9D96CD47FF756C95404DF4F6 /* Pane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pane.swift; sourceTree = "<group>"; };
 		A0A94E80914F7411EED712E5 /* WebPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneStore.swift; sourceTree = "<group>"; };
 		A11F5427AE75515696FB8295 /* PaneLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutTests.swift; sourceTree = "<group>"; };
@@ -265,12 +277,14 @@
 		ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeatureTests.swift; sourceTree = "<group>"; };
 		B02A888F436610636F5A4D55 /* MarkdownPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPaneView.swift; sourceTree = "<group>"; };
 		B0F76E0BE2C08C77C58B1278 /* SidebarID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarID.swift; sourceTree = "<group>"; };
+		B2BAD220346CCE551765FCD9 /* WebPaneInspectorScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneInspectorScript.swift; sourceTree = "<group>"; };
 		B504C980131A9A777767EEB1 /* QuitGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitGate.swift; sourceTree = "<group>"; };
 		B6CC74E2D5AA179FFCE3B825 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B822ABF12B071E574E089BB4 /* GroupIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupIconTests.swift; sourceTree = "<group>"; };
 		BB94DA665D3B322A44251454 /* PaneHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneHeaderView.swift; sourceTree = "<group>"; };
 		BEA20CEA0FEF28F3972BCE7D /* NexCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NexCommands.swift; sourceTree = "<group>"; };
 		BECB2222837AC350E94222BB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		BF16F0C4A6A8BF8151651F53 /* InspectPayloadSanitiser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectPayloadSanitiser.swift; sourceTree = "<group>"; };
 		C4D5453E5B7EB4E8E7F11453 /* PaneSendReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSendReplyTests.swift; sourceTree = "<group>"; };
 		C58BE92A0878D9CCC786A657 /* WorkspaceRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRowView.swift; sourceTree = "<group>"; };
 		C711FF0D53387D16F50C5EA6 /* UpdaterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterService.swift; sourceTree = "<group>"; };
@@ -284,6 +298,7 @@
 		D6B83DC43AEA38B4929307FA /* AppReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReducerTests.swift; sourceTree = "<group>"; };
 		D70E36C00A55A87562F4AC1D /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
 		D7D46DA7C3A37F67FBBBEAC7 /* AppActivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivation.swift; sourceTree = "<group>"; };
+		D919B65B3E950098BF3405EA /* WebPaneConsoleScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneConsoleScript.swift; sourceTree = "<group>"; };
 		D9335AE3C92A37DD50A5715A /* AppReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReducer.swift; sourceTree = "<group>"; };
 		D9EC869803E36C99B3653FF5 /* CLIInstallService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIInstallService.swift; sourceTree = "<group>"; };
 		DAE917FD003D3FFD196DBF77 /* PaneSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSearchOverlay.swift; sourceTree = "<group>"; };
@@ -292,6 +307,7 @@
 		DDD03468B083223FF50F68E0 /* GhosttySurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurface.swift; sourceTree = "<group>"; };
 		DE56BB11F5C7C34821411297 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E01C66D4D59D04F6372D8AD7 /* WorkspaceDropTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDropTargetTests.swift; sourceTree = "<group>"; };
+		E0625B2E7935BDDF63DC5D19 /* RingBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBufferTests.swift; sourceTree = "<group>"; };
 		E08D39F8F87D7505CD32D25D /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		E5859C5B2E1850D1262AFE4B /* Nex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nex.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5A4C5D8F4C099C65A7EA890 /* ScratchpadEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadEditorView.swift; sourceTree = "<group>"; };
@@ -413,6 +429,7 @@
 				876AB562CDB247E67A7485CA /* GraftServiceTests.swift */,
 				B822ABF12B071E574E089BB4 /* GroupIconTests.swift */,
 				EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */,
+				95D0AA21761E50EFDA70A0E9 /* InspectPayloadSanitiserTests.swift */,
 				5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */,
 				4CCB57D9C4E2AC2014127FC8 /* MarkdownCheckboxRenderingTests.swift */,
 				200EB2588E40ABB7C51E24E6 /* MarkdownHTMLRendererTests.swift */,
@@ -427,6 +444,7 @@
 				6CD202733564AC92AEC00A0C /* QuitConfirmationTests.swift */,
 				EBD3F55DB0088089F62AFBFA /* RecursiveFSWatcherTests.swift */,
 				1C625959E287CE9896D5BA4D /* RepoRegistryTests.swift */,
+				E0625B2E7935BDDF63DC5D19 /* RingBufferTests.swift */,
 				ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */,
 				AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */,
 				1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */,
@@ -577,8 +595,14 @@
 		8C7E8AA61857407F1760CCCF /* WebPane */ = {
 			isa = PBXGroup;
 			children = (
+				BF16F0C4A6A8BF8151651F53 /* InspectPayloadSanitiser.swift */,
+				1D792DEC74448D403CE1A96D /* RingBuffer.swift */,
+				998480F19F798025639D20A7 /* WebBatchInspectPanel.swift */,
+				579D8D40F1D9930845C3B0C9 /* WebPaneBatchMarkerScript.swift */,
 				45DFA60F59651234F0F59BE9 /* WebPaneChrome.swift */,
+				D919B65B3E950098BF3405EA /* WebPaneConsoleScript.swift */,
 				FDC5A9C48821CE81CCB7FFB5 /* WebPaneCoordinator.swift */,
+				B2BAD220346CCE551765FCD9 /* WebPaneInspectorScript.swift */,
 				37B04ED477C0C51A44953A8C /* WebPaneState.swift */,
 				A0A94E80914F7411EED712E5 /* WebPaneStore.swift */,
 				98A97924791DAA26F0E4B0BA /* WebPaneView.swift */,
@@ -802,6 +826,7 @@
 				F9F8ADDD652AD7CEFC6BCD89 /* GraftServiceTests.swift in Sources */,
 				0EC37EE951CB883BC4DD5E9E /* GroupIconTests.swift in Sources */,
 				EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */,
+				2CD77355541CE17C3427C610 /* InspectPayloadSanitiserTests.swift in Sources */,
 				B701F36FA68D43170D591F40 /* KeyBindingTests.swift in Sources */,
 				0D23E37D86270E1BAADFF549 /* MarkdownCheckboxRenderingTests.swift in Sources */,
 				EA22F9720B68648A78D237E3 /* MarkdownHTMLRendererTests.swift in Sources */,
@@ -816,6 +841,7 @@
 				5CFC8C5F96B371044A5ABE91 /* QuitConfirmationTests.swift in Sources */,
 				B7D2BF4B62D8D6DB71C707B5 /* RecursiveFSWatcherTests.swift in Sources */,
 				B5B3A5F0C2FA6509D37FA74A /* RepoRegistryTests.swift in Sources */,
+				AD62C235AF0D846B08655B16 /* RingBufferTests.swift in Sources */,
 				EAF43DC55C5612F3AE83BF02 /* SettingsFeatureTests.swift in Sources */,
 				2B4533964D77117EE6D98690 /* SocketParsingTests.swift in Sources */,
 				EF4258CFC52EB748609C7F18 /* SurfaceViewKeyboardTests.swift in Sources */,
@@ -865,6 +891,7 @@
 				B2498EB9F42EA84196516DAE /* GroupHeaderRow.swift in Sources */,
 				E02D1D3DE36CC8F66B5072AB /* GroupIcon.swift in Sources */,
 				089AA30B37857F3539BF81C3 /* HelpView.swift in Sources */,
+				131F8A6071A7ADF25504AD4E /* InspectPayloadSanitiser.swift in Sources */,
 				F1139F84E35AF1181F136C9D /* KeyBinding.swift in Sources */,
 				E0ABD2D68012C6BF24A92E7D /* KeybindingService.swift in Sources */,
 				6CF210BA0C7BFE62B90844F7 /* KeybindingsSettingsView.swift in Sources */,
@@ -899,6 +926,7 @@
 				3DF88C2A2966C7B0209E22FE /* RepoPickerView.swift in Sources */,
 				40D01E98BD9BE2397CFC1080 /* RepoRegistryView.swift in Sources */,
 				ED79F70009D8C2A4A1A742F8 /* ResizeDimensionsOverlay.swift in Sources */,
+				5A9607BD6AD03E15B0124B88 /* RingBuffer.swift in Sources */,
 				FB45777E3BD181F04B322F93 /* ScratchpadEditorView.swift in Sources */,
 				29C636F17D2FEF2D5E0BE55D /* SettingsFeature.swift in Sources */,
 				E31F1B84CF270603EF2B93E0 /* SettingsView.swift in Sources */,
@@ -913,8 +941,12 @@
 				B8DCB316773E208FABEDA9D7 /* UpdaterService.swift in Sources */,
 				A8F1A82072120476BAEC2D52 /* UserDefaultsClient.swift in Sources */,
 				B167B81282ADF716B21B1679 /* VibrancyView.swift in Sources */,
+				838F2F85AED6591FE3D2C9C9 /* WebBatchInspectPanel.swift in Sources */,
+				539AACF3A856FD51EC92A6F1 /* WebPaneBatchMarkerScript.swift in Sources */,
 				A895048D11AFDC1FDA5DF846 /* WebPaneChrome.swift in Sources */,
+				2B0CCA8BFF359E4AF96AB5AA /* WebPaneConsoleScript.swift in Sources */,
 				A60D7684F5DA8DD340A04A01 /* WebPaneCoordinator.swift in Sources */,
+				C1FC2BD79FF0D9DC86910028 /* WebPaneInspectorScript.swift in Sources */,
 				630837DB73DACFE99190C60D /* WebPaneState.swift in Sources */,
 				A8626EC08DC12588F912E1EF /* WebPaneStore.swift in Sources */,
 				2F440D3EB93B6C127A1FF003 /* WebPaneView.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		B652FDDE5CE91C5CA1DAC8E2 /* DatabaseMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21064C4AB47888B6A02CCD73 /* DatabaseMigrationTests.swift */; };
 		B701F36FA68D43170D591F40 /* KeyBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */; };
 		B7D2BF4B62D8D6DB71C707B5 /* RecursiveFSWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD3F55DB0088089F62AFBFA /* RecursiveFSWatcherTests.swift */; };
+		B8B5B666D5CC24071420A966 /* StoragePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45141531B99E3E1B79620ECA /* StoragePanel.swift */; };
 		B8DCB316773E208FABEDA9D7 /* UpdaterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C711FF0D53387D16F50C5EA6 /* UpdaterService.swift */; };
 		BF19A66EC95FA4FB46CA400D /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F228193206574DB257C8B3FB /* AppKit.framework */; };
 		C052FE23BF089795BB04E10E /* RenamePaneSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191592BF0EBCEC22DF9F5745 /* RenamePaneSheet.swift */; };
@@ -224,6 +225,7 @@
 		3DD93535314E9897122ED638 /* GraftCLIReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraftCLIReplyTests.swift; sourceTree = "<group>"; };
 		42A24C1FEC6EA31096603326 /* SurfaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceManager.swift; sourceTree = "<group>"; };
 		439174A029FAFE2C252A1B8B /* KeybindingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingsSettingsView.swift; sourceTree = "<group>"; };
+		45141531B99E3E1B79620ECA /* StoragePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePanel.swift; sourceTree = "<group>"; };
 		452A1B196F8438AD7A7DAC0A /* PaneSendKeyReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSendKeyReplyTests.swift; sourceTree = "<group>"; };
 		45DFA60F59651234F0F59BE9 /* WebPaneChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneChrome.swift; sourceTree = "<group>"; };
 		4CCB57D9C4E2AC2014127FC8 /* MarkdownCheckboxRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCheckboxRenderingTests.swift; sourceTree = "<group>"; };
@@ -600,6 +602,7 @@
 				54EECDF8241787F53AC4EA24 /* Favourites.swift */,
 				BF16F0C4A6A8BF8151651F53 /* InspectPayloadSanitiser.swift */,
 				1D792DEC74448D403CE1A96D /* RingBuffer.swift */,
+				45141531B99E3E1B79620ECA /* StoragePanel.swift */,
 				998480F19F798025639D20A7 /* WebBatchInspectPanel.swift */,
 				579D8D40F1D9930845C3B0C9 /* WebPaneBatchMarkerScript.swift */,
 				45DFA60F59651234F0F59BE9 /* WebPaneChrome.swift */,
@@ -939,6 +942,7 @@
 				77CF808E3AF2C06BD12D11C0 /* SplitDividerView.swift in Sources */,
 				066D1D15DCA5E39EC770E77C /* StatusBarController.swift in Sources */,
 				CCBCDD690DA8A082B0C3D1EF /* StatusBarPopoverView.swift in Sources */,
+				B8B5B666D5CC24071420A966 /* StoragePanel.swift in Sources */,
 				8F5D3C9118D51569A13CB473 /* SurfaceContainerView.swift in Sources */,
 				64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */,
 				75BECE7D63EF981C344D4902 /* SurfaceView.swift in Sources */,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ComposableArchitecture
 import Foundation
+import WebKit
 
 @Reducer
 struct AppReducer {
@@ -472,6 +473,13 @@ struct AppReducer {
         /// disarm and clear batch state.
         case webBatchInspectSend(paneID: UUID, sendTo: UUID?)
         case webBatchInspectCancel(paneID: UUID)
+        /// Set the per-pane private flag. `enabled: nil` flips the
+        /// current value (UI toggle); a concrete value matches the CLI
+        /// `nex web private on|off` path. The reducer destroys the
+        /// pane's coordinator so the next SwiftUI pass rebuilds tabs
+        /// against the new data store. Live JS state is lost; the
+        /// chrome warns the user before sending this.
+        case webPaneSetPrivate(paneID: UUID, enabled: Bool?)
         /// Focus a batch item from either side of the list↔page sync.
         /// `origin == .panel` came from a panel-row tap → highlight
         /// the badge on the page. `origin == .page` came from a
@@ -1477,6 +1485,7 @@ struct AppReducer {
         state: State,
         paneID _: UUID?,
         url: String,
+        isPrivate: Bool,
         reply: SocketServer.ReplyHandle?
     ) -> Effect<Action> {
         guard let activeID = state.activeWorkspaceID else {
@@ -1492,6 +1501,7 @@ struct AppReducer {
             "pane_id": newPaneID.uuidString,
             "tab_id": newTabID.uuidString,
             "url": normalized,
+            "private": isPrivate,
             "workspace_id": activeID.uuidString
         ])
         reply?.close()
@@ -1502,7 +1512,7 @@ struct AppReducer {
                 tabID: newTabID,
                 url: url,
                 reusePaneID: nil,
-                isPrivate: false
+                isPrivate: isPrivate
             )
         )))
     }
@@ -1643,10 +1653,11 @@ struct AppReducer {
         let tabID = tab.id
         let tabURL = tab.url
         let tabTitle = tab.title
+        let isPrivate = resolved.webState.isPrivate
 
         return .run { _ in
             let snapshot: (url: String, title: String) = await MainActor.run {
-                store.coordinator(for: resolvedPaneID).currentURLAndTitle(tabID: tabID)
+                store.coordinator(for: resolvedPaneID, isPrivate: isPrivate).currentURLAndTitle(tabID: tabID)
                     ?? (tabURL, tabTitle)
             }
             var payload: [String: Any] = [
@@ -1661,11 +1672,11 @@ struct AppReducer {
             case .meta:
                 break
             case .text:
-                let text = await store.coordinator(for: resolvedPaneID).captureText(tabID: tabID)
+                let text = await store.coordinator(for: resolvedPaneID, isPrivate: isPrivate).captureText(tabID: tabID)
                 payload["text"] = text
                 payload["byte_count"] = text.utf8.count
             case .screenshot:
-                let pngData = await store.coordinator(for: resolvedPaneID).captureScreenshot(tabID: tabID)
+                let pngData = await store.coordinator(for: resolvedPaneID, isPrivate: isPrivate).captureScreenshot(tabID: tabID)
                 if let pngData {
                     let inlineThreshold = 1_000_000 // 1 MB
                     if pngData.count <= inlineThreshold {
@@ -2024,13 +2035,14 @@ struct AppReducer {
         let workspaceID = resolved.workspace.id
         let store = webPaneStore
         let tabID = tab.id
+        let isPrivate = resolved.webState.isPrivate
 
         return .run { send in
             // Arm the in-page picker on the main actor and read back
             // the nonce. Hop to MainActor.run synchronously so we
             // can return the nonce before the reply lands.
             let nonce: String? = await MainActor.run {
-                store.coordinator(for: resolvedPaneID).armInspector(tabID: tabID)
+                store.coordinator(for: resolvedPaneID, isPrivate: isPrivate).armInspector(tabID: tabID)
             }
             guard let nonce else {
                 reply?.error("failed to arm inspector for active tab")
@@ -2107,6 +2119,201 @@ struct AppReducer {
             return .merge(effects)
         }
         return .none
+    }
+
+    // MARK: - Web pane storage / cookies handlers (Phase 5)
+
+    func handleWebPrivate(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        enabled: Bool,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        let already = resolved.webState.isPrivate == enabled
+        reply?.sendAndClose([
+            "ok": true,
+            "pane_id": resolved.paneID.uuidString,
+            "workspace_id": resolved.workspace.id.uuidString,
+            "private": enabled,
+            "changed": !already
+        ])
+        if already { return .none }
+        return .send(.webPaneSetPrivate(paneID: resolved.paneID, enabled: enabled))
+    }
+
+    func handleWebCookiesList(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        let store = webPaneStore
+        let resolvedPaneID = resolved.paneID
+        let workspaceID = resolved.workspace.id
+        let isPrivate = resolved.webState.isPrivate
+        return .run { _ in
+            let cookies: [HTTPCookie] = await withCheckedContinuation { continuation in
+                Task { @MainActor in
+                    guard let coord = store.coordinatorIfExists(for: resolvedPaneID) else {
+                        continuation.resume(returning: [])
+                        return
+                    }
+                    coord.dataStore.httpCookieStore.getAllCookies { result in
+                        continuation.resume(returning: result)
+                    }
+                }
+            }
+            let payload: [String: Any] = [
+                "ok": true,
+                "pane_id": resolvedPaneID.uuidString,
+                "workspace_id": workspaceID.uuidString,
+                "private": isPrivate,
+                "cookies": cookies.map(Self.cookieJSON)
+            ]
+            reply?.sendAndClose(payload)
+        }
+    }
+
+    func handleWebCookiesClear(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        domain: String?,
+        all: Bool,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        if all, domain != nil {
+            reply?.error("--all and --domain are mutually exclusive")
+            return .none
+        }
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        let store = webPaneStore
+        let resolvedPaneID = resolved.paneID
+        let workspaceID = resolved.workspace.id
+        return .run { _ in
+            let removed: Int = await withCheckedContinuation { continuation in
+                Task { @MainActor in
+                    guard let coord = store.coordinatorIfExists(for: resolvedPaneID) else {
+                        continuation.resume(returning: 0)
+                        return
+                    }
+                    let dataStore = coord.dataStore
+                    if all {
+                        let types = WKWebsiteDataStore.allWebsiteDataTypes()
+                        dataStore.removeData(ofTypes: types, modifiedSince: .distantPast) {
+                            // Count is unknown for the omnibus
+                            // removeData path; report -1 so callers
+                            // can distinguish from "0 cookies matched".
+                            continuation.resume(returning: -1)
+                        }
+                        return
+                    }
+                    let needle = domain.map(HTTPCookie.canonicalDomain)
+                    dataStore.httpCookieStore.deleteAll(
+                        matching: { cookie in
+                            guard let needle else { return true }
+                            return HTTPCookie.canonicalDomain(cookie.domain) == needle
+                        },
+                        completion: { count in continuation.resume(returning: count) }
+                    )
+                }
+            }
+            var payload: [String: Any] = [
+                "ok": true,
+                "pane_id": resolvedPaneID.uuidString,
+                "workspace_id": workspaceID.uuidString
+            ]
+            if all {
+                payload["cleared_site_data"] = true
+            } else {
+                payload["deleted"] = removed
+                if let domain {
+                    payload["domain"] = domain
+                }
+            }
+            reply?.sendAndClose(payload)
+        }
+    }
+
+    func handleWebCookiesDelete(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        name: String,
+        domain: String?,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        let store = webPaneStore
+        let resolvedPaneID = resolved.paneID
+        let workspaceID = resolved.workspace.id
+        return .run { _ in
+            let removed: Int = await withCheckedContinuation { continuation in
+                Task { @MainActor in
+                    guard let coord = store.coordinatorIfExists(for: resolvedPaneID) else {
+                        continuation.resume(returning: 0)
+                        return
+                    }
+                    let needle = domain.map(HTTPCookie.canonicalDomain)
+                    coord.dataStore.httpCookieStore.deleteAll(
+                        matching: { cookie in
+                            guard cookie.name == name else { return false }
+                            guard let needle else { return true }
+                            return HTTPCookie.canonicalDomain(cookie.domain) == needle
+                        },
+                        completion: { count in continuation.resume(returning: count) }
+                    )
+                }
+            }
+            var payload: [String: Any] = [
+                "ok": true,
+                "pane_id": resolvedPaneID.uuidString,
+                "workspace_id": workspaceID.uuidString,
+                "deleted": removed,
+                "name": name
+            ]
+            if let domain {
+                payload["domain"] = domain
+            }
+            reply?.sendAndClose(payload)
+        }
+    }
+
+    private static func cookieJSON(_ cookie: HTTPCookie) -> [String: Any] {
+        var dict: [String: Any] = [
+            "name": cookie.name,
+            "value": cookie.value,
+            "domain": cookie.domain,
+            "path": cookie.path,
+            "is_secure": cookie.isSecure,
+            "is_http_only": cookie.isHTTPOnly
+        ]
+        if let expires = cookie.expiresDate {
+            dict["expires"] = expires.timeIntervalSince1970
+        }
+        if cookie.isSessionOnly {
+            dict["session_only"] = true
+        }
+        return dict
     }
 
     /// Returns the last `n` lines of `text`, joined by `\n`. Preserves
@@ -3550,10 +3757,12 @@ struct AppReducer {
 
             case .webBatchInspectStart(let paneID):
                 guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
-                guard let tab = workspace.webPanes[paneID]?.activeTab else { return .none }
+                guard let webState = workspace.webPanes[paneID],
+                      let tab = webState.activeTab else { return .none }
                 let store = webPaneStore
                 let workspaceID = workspace.id
                 let tabID = tab.id
+                let isPrivate = webState.isPrivate
                 return .merge(
                     .send(.workspaces(.element(
                         id: workspaceID,
@@ -3562,7 +3771,7 @@ struct AppReducer {
                     .send(.syncBatchMarkers(paneID: paneID)),
                     .run { send in
                         let nonce: String? = await MainActor.run {
-                            store.coordinator(for: paneID).armInspector(tabID: tabID, sticky: true)
+                            store.coordinator(for: paneID, isPrivate: isPrivate).armInspector(tabID: tabID, sticky: true)
                         }
                         guard let nonce else { return }
                         await send(.workspaces(.element(
@@ -3611,10 +3820,12 @@ struct AppReducer {
 
             case .webBatchInspectShow(let paneID):
                 guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
-                guard let tab = workspace.webPanes[paneID]?.activeTab else { return .none }
+                guard let webState = workspace.webPanes[paneID],
+                      let tab = webState.activeTab else { return .none }
                 let store = webPaneStore
                 let workspaceID = workspace.id
                 let tabID = tab.id
+                let isPrivate = webState.isPrivate
                 return .merge(
                     .send(.workspaces(.element(
                         id: workspaceID,
@@ -3623,7 +3834,7 @@ struct AppReducer {
                     .send(.syncBatchMarkers(paneID: paneID)),
                     .run { send in
                         let nonce: String? = await MainActor.run {
-                            store.coordinator(for: paneID).armInspector(tabID: tabID, sticky: true)
+                            store.coordinator(for: paneID, isPrivate: isPrivate).armInspector(tabID: tabID, sticky: true)
                         }
                         guard let nonce else { return }
                         await send(.workspaces(.element(
@@ -3632,6 +3843,30 @@ struct AppReducer {
                                 paneID: paneID, sendTo: nil, nonce: nonce
                             )
                         )))
+                    }
+                )
+
+            case .webPaneSetPrivate(let paneID, let enabledOpt):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                let current = workspace.webPanes[paneID]?.isPrivate ?? false
+                let enabled = enabledOpt ?? !current
+                guard current != enabled else { return .none }
+                let store = webPaneStore
+                let workspaceID = workspace.id
+                return .merge(
+                    .send(.workspaces(.element(
+                        id: workspaceID,
+                        action: .webPaneSetIsPrivate(paneID: paneID, enabled: enabled)
+                    ))),
+                    // Destroy the coordinator so the host's next pass
+                    // builds a fresh one against the new data store.
+                    // The host's mismatch check would catch this too,
+                    // but doing it here keeps the teardown ordered
+                    // with the state flip.
+                    .run { _ in
+                        await MainActor.run {
+                            store.destroyCoordinator(paneID: paneID)
+                        }
                     }
                 )
 
@@ -4319,8 +4554,14 @@ struct AppReducer {
                 case .graftStatus:
                     return handleGraftStatus(state: state, reply: reply)
 
-                case .webOpen(let paneID, let url):
-                    return handleWebOpen(state: state, paneID: paneID, url: url, reply: reply)
+                case .webOpen(let paneID, let url, let isPrivate):
+                    return handleWebOpen(
+                        state: state,
+                        paneID: paneID,
+                        url: url,
+                        isPrivate: isPrivate,
+                        reply: reply
+                    )
 
                 case .webURL(let paneID, let target, let workspaceFilter):
                     return handleWebURL(
@@ -4442,6 +4683,47 @@ struct AppReducer {
                         target: target,
                         workspaceFilter: workspaceFilter,
                         clear: clear,
+                        reply: reply
+                    )
+
+                case .webPrivate(let paneID, let target, let workspaceFilter, let enabled):
+                    return handleWebPrivate(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        enabled: enabled,
+                        reply: reply
+                    )
+
+                case .webCookiesList(let paneID, let target, let workspaceFilter):
+                    return handleWebCookiesList(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        reply: reply
+                    )
+
+                case .webCookiesClear(let paneID, let target, let workspaceFilter, let domain, let all):
+                    return handleWebCookiesClear(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        domain: domain,
+                        all: all,
+                        reply: reply
+                    )
+
+                case .webCookiesDelete(let paneID, let target, let workspaceFilter, let name, let domain):
+                    return handleWebCookiesDelete(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        name: name,
+                        domain: domain,
                         reply: reply
                     )
                 }

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -451,24 +451,26 @@ struct AppReducer {
         /// Enter) after the delivered paste. Cleared after every
         /// delivery. Phase 3 ships paste-only by default.
         case setWebInspectArmedSubmit(paneID: UUID, submit: Bool)
-        /// UI-driven equivalent of `nex web inspect --send-to <pane>`.
-        /// Asks the coordinator to arm the picker on the named pane's
-        /// active tab and stash the destination so the next click's
-        /// payload is sanitised + pasted via `paneSendText`. `sendTo`
-        /// nil = just arm, drop the result into the inspect queue for
-        /// later draining by the CLI.
-        case webPaneArmInspectorViaUI(paneID: UUID, sendTo: UUID?)
-        /// Symmetric disarm for the UI flow.
-        case webPaneDisarmInspectorViaUI(paneID: UUID)
         /// Begin a batch-annotate session for `paneID`. Arms the
         /// picker in sticky mode so each click adds another item;
         /// the user finalises via `webBatchInspectSend` or aborts
-        /// via `webBatchInspectCancel`.
-        case webBatchInspectStart(paneID: UUID, sendTo: UUID?)
-        /// Format all collected items and paste them into the
-        /// destination pane (or queue locally when sendTo is nil),
-        /// then disarm the picker and clear batch state.
-        case webBatchInspectSend(paneID: UUID)
+        /// via `webBatchInspectCancel`. Destination is picked at
+        /// send time via the panel's footer dropdown.
+        case webBatchInspectStart(paneID: UUID)
+        /// Hide the batch panel without discarding items. Disarms
+        /// the page picker but leaves `batchInspect` in state so the
+        /// next scope-toggle re-opens with the same queue + markers.
+        case webBatchInspectHide(paneID: UUID)
+        /// Re-show a hidden batch panel. Re-arms the picker and
+        /// re-paints the on-page markers from the current items.
+        case webBatchInspectShow(paneID: UUID)
+        /// Toggle from the chrome scope button — routes to start /
+        /// hide / show based on current state.
+        case webBatchInspectToggle(paneID: UUID)
+        /// Format collected items and paste them into `sendTo` (or
+        /// queue locally for `nex web inspect-result` when nil), then
+        /// disarm and clear batch state.
+        case webBatchInspectSend(paneID: UUID, sendTo: UUID?)
         case webBatchInspectCancel(paneID: UUID)
         /// Focus a batch item from either side of the list↔page sync.
         /// `origin == .panel` came from a panel-row tap → highlight
@@ -2068,17 +2070,41 @@ struct AppReducer {
             state: state, paneID: paneID, target: target,
             workspaceFilter: workspaceFilter, reply: reply
         ) else { return .none }
+        // Drain *both* sources: the legacy single-shot queue
+        // (`inspectResultQueue`, written by `nex web inspect`
+        // without `--send-to`) and the batch panel items (the
+        // unified UI queue — items collected via the scope button
+        // that haven't been sent to a target yet). Items annotate
+        // with their per-batch comment before serialising.
+        var results: [InspectResult] = []
+        results.append(contentsOf: resolved.webState.inspectResultQueue)
+        if let batch = resolved.webState.batchInspect {
+            for item in batch.items {
+                var annotated = item.result
+                annotated.comment = item.comment
+                results.append(annotated)
+            }
+        }
         reply?.sendAndClose([
             "ok": true,
             "pane_id": resolved.paneID.uuidString,
             "workspace_id": resolved.workspace.id.uuidString,
-            "results": resolved.webState.inspectResultQueue.map(inspectResultJSON)
+            "results": results.map(inspectResultJSON)
         ])
         if clear {
-            return .send(.workspaces(.element(
-                id: resolved.workspace.id,
-                action: .webInspectResultClear(paneID: resolved.paneID)
-            )))
+            var effects: [Effect<Action>] = [
+                .send(.workspaces(.element(
+                    id: resolved.workspace.id,
+                    action: .webInspectResultClear(paneID: resolved.paneID)
+                )))
+            ]
+            // Only tear down the batch when one exists — `Cancel`
+            // disarms the page picker, and a single-shot inspect may
+            // be armed on this pane independently of any batch.
+            if resolved.webState.batchInspect != nil {
+                effects.append(.send(.webBatchInspectCancel(paneID: resolved.paneID)))
+            }
+            return .merge(effects)
         }
         return .none
     }
@@ -3085,11 +3111,12 @@ struct AppReducer {
                     scheduleAutoUnlink(workspaceID: wsID, in: state)
                 )
 
-            case .workspaces(.element(id: let wsID, action: .closePane)):
+            case .workspaces(.element(id: let wsID, action: .closePane(let paneID))):
                 if let renamingPaneID = state.renamingPaneID,
                    !state.workspaces.contains(where: { $0.panes[id: renamingPaneID] != nil }) {
                     state.renamingPaneID = nil
                 }
+                state.webInspectArmedSubmit.removeValue(forKey: paneID)
                 return .merge(
                     .send(.persistState),
                     scheduleAutoUnlink(workspaceID: wsID, in: state)
@@ -3521,31 +3548,56 @@ struct AppReducer {
                 }
                 return .none
 
-            case .webPaneArmInspectorViaUI(let paneID, let sendTo):
+            case .webBatchInspectStart(let paneID):
                 guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
                 guard let tab = workspace.webPanes[paneID]?.activeTab else { return .none }
                 let store = webPaneStore
                 let workspaceID = workspace.id
                 let tabID = tab.id
-                return .run { send in
-                    let nonce: String? = await MainActor.run {
-                        store.coordinator(for: paneID).armInspector(tabID: tabID)
-                    }
-                    guard let nonce else { return }
-                    await send(.workspaces(.element(
+                return .merge(
+                    .send(.workspaces(.element(
                         id: workspaceID,
-                        action: .webInspectArmedFor(
-                            paneID: paneID, sendTo: sendTo, nonce: nonce
-                        )
-                    )))
+                        action: .webBatchInspectBegin(paneID: paneID)
+                    ))),
+                    .send(.syncBatchMarkers(paneID: paneID)),
+                    .run { send in
+                        let nonce: String? = await MainActor.run {
+                            store.coordinator(for: paneID).armInspector(tabID: tabID, sticky: true)
+                        }
+                        guard let nonce else { return }
+                        await send(.workspaces(.element(
+                            id: workspaceID,
+                            action: .webInspectArmedFor(
+                                paneID: paneID, sendTo: nil, nonce: nonce
+                            )
+                        )))
+                    }
+                )
+
+            case .webBatchInspectToggle(let paneID):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                let batch = workspace.webPanes[paneID]?.batchInspect
+                if batch == nil {
+                    return .send(.webBatchInspectStart(paneID: paneID))
+                } else if batch?.panelVisible == true {
+                    return .send(.webBatchInspectHide(paneID: paneID))
+                } else {
+                    return .send(.webBatchInspectShow(paneID: paneID))
                 }
 
-            case .webPaneDisarmInspectorViaUI(let paneID):
+            case .webBatchInspectHide(let paneID):
                 guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
                 let store = webPaneStore
                 let workspaceID = workspace.id
-                state.webInspectArmedSubmit.removeValue(forKey: paneID)
                 return .merge(
+                    .send(.workspaces(.element(
+                        id: workspaceID,
+                        action: .webBatchPanelVisible(paneID: paneID, visible: false)
+                    ))),
+                    // Disarm the page picker and clear the on-page
+                    // markers; the SwiftUI panel + items in state
+                    // remain so the next show restores everything.
+                    .send(.syncBatchMarkers(paneID: paneID)),
                     .send(.workspaces(.element(
                         id: workspaceID,
                         action: .webInspectDisarm(paneID: paneID)
@@ -3557,7 +3609,7 @@ struct AppReducer {
                     }
                 )
 
-            case .webBatchInspectStart(let paneID, let sendTo):
+            case .webBatchInspectShow(let paneID):
                 guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
                 guard let tab = workspace.webPanes[paneID]?.activeTab else { return .none }
                 let store = webPaneStore
@@ -3566,7 +3618,7 @@ struct AppReducer {
                 return .merge(
                     .send(.workspaces(.element(
                         id: workspaceID,
-                        action: .webBatchInspectBegin(paneID: paneID, sendTo: sendTo)
+                        action: .webBatchPanelVisible(paneID: paneID, visible: true)
                     ))),
                     .send(.syncBatchMarkers(paneID: paneID)),
                     .run { send in
@@ -3577,7 +3629,7 @@ struct AppReducer {
                         await send(.workspaces(.element(
                             id: workspaceID,
                             action: .webInspectArmedFor(
-                                paneID: paneID, sendTo: sendTo, nonce: nonce
+                                paneID: paneID, sendTo: nil, nonce: nonce
                             )
                         )))
                     }
@@ -3605,13 +3657,20 @@ struct AppReducer {
                     }
                 )
 
-            case .webBatchInspectSend(let paneID):
+            case .webBatchInspectSend(let paneID, let sendTo):
                 guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
                 guard let batch = workspace.webPanes[paneID]?.batchInspect else { return .none }
                 let store = webPaneStore
                 let workspaceID = workspace.id
                 let submit = state.webInspectArmedSubmit[paneID] ?? false
                 state.webInspectArmedSubmit.removeValue(forKey: paneID)
+                // Seed `lastBatchTarget` so the next batch on this
+                // pane defaults to the same destination. In-memory
+                // only — fresh launch always starts unselected.
+                if !batch.items.isEmpty {
+                    let memory: BatchTargetMemory = sendTo.map { .pane($0) } ?? .local
+                    state.workspaces[id: workspaceID]?.webPanes[paneID]?.lastBatchTarget = memory
+                }
 
                 var effects: [Effect<Action>] = [
                     .send(.workspaces(.element(
@@ -3633,7 +3692,7 @@ struct AppReducer {
                 if batch.items.isEmpty {
                     return .merge(effects)
                 }
-                if let sendTo = batch.sendTo {
+                if let sendTo {
                     let formatted = InspectPayloadSanitiser.formatBatchForPaste(batch.items)
                     effects.append(paneSendText(paneID: sendTo, text: formatted, bare: !submit))
                 } else {
@@ -3690,7 +3749,11 @@ struct AppReducer {
                 guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
                 let webState = workspace.webPanes[paneID]
                 let tabID = webState?.activeTab?.id
-                let items: [BatchMarkerInput] = (webState?.batchInspect?.items ?? [])
+                // Hidden panel = no on-page markers either. Items
+                // still live in state for when the user re-opens.
+                let panelVisible = webState?.batchInspect?.panelVisible ?? false
+                let items: [BatchMarkerInput] = panelVisible
+                    ? (webState?.batchInspect?.items ?? [])
                     .enumerated()
                     .map { idx, item in
                         BatchMarkerInput(
@@ -3700,6 +3763,7 @@ struct AppReducer {
                             comment: item.comment
                         )
                     }
+                    : []
                 let store = webPaneStore
                 return .run { _ in
                     await MainActor.run {
@@ -3751,8 +3815,11 @@ struct AppReducer {
                 // refresh the on-page numbered markers so the new
                 // pick gets a badge, then focus the new item so the
                 // page draws its ring and the panel auto-focuses the
-                // comment field.
-                if webState?.batchInspect != nil {
+                // comment field. A hidden batch (panelVisible == false)
+                // is paused — `nex web inspect --send-to` can arm a
+                // single-shot inspect on top, so route the result down
+                // the single-shot path instead of hijacking it.
+                if webState?.batchInspect?.panelVisible == true {
                     let item = BatchInspectItem(result: result)
                     return .merge(
                         .send(.workspaces(.element(

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -36,6 +36,12 @@ struct AppReducer {
         var globalHotkeyHideOnRepress: Bool = true
         var globalHotkeyRegistrationError: String?
 
+        /// Per-web-pane monotonic counter used as the URL bar focus
+        /// token. The priority key layer bumps this when ⌘L fires on
+        /// a focused web pane; `WebPaneView` picks up the change and
+        /// promotes its URL bar to first responder.
+        var webPaneURLFocusTokens: [UUID: UInt64] = [:]
+
         /// Collision between the current global hotkey and an in-app
         /// keybinding. Computed so it always reflects the latest state —
         /// `keybindings` and `globalHotkey` can land in state in either
@@ -159,6 +165,7 @@ struct AppReducer {
                     case .markdown: "doc.text"
                     case .scratchpad: "note.text"
                     case .diff: "plusminus"
+                    case .web: "globe"
                     }
                     items.append(CommandPaletteItem(
                         id: "pane:\(paneID)",
@@ -411,6 +418,10 @@ struct AppReducer {
         case openFile
         case openFileAtPath(String, fromPaneID: UUID?)
         case openDiffPath(repoPath: String, targetPath: String?, fromPaneID: UUID?)
+        /// Open a web pane in the active workspace.
+        case openWebPanePath(url: String, fromPaneID: UUID?)
+        /// Bump the URL bar focus token for a web pane (⌘L).
+        case webPaneFocusURLBar(paneID: UUID)
 
         // Inspector + Git Status
         case toggleInspector
@@ -478,6 +489,7 @@ struct AppReducer {
     @Dependency(\.ghosttyConfig) var ghosttyConfig
     @Dependency(\.globalHotkeyService) var globalHotkeyService
     @Dependency(\.graftService) var graftService
+    @Dependency(\.webPaneStore) var webPaneStore
     @Dependency(\.uuid) var uuid
     @Dependency(\.continuousClock) var clock
 
@@ -1355,6 +1367,246 @@ struct AppReducer {
         reply?.send(payload)
         reply?.close()
         return .none
+    }
+
+    // MARK: - Web pane handlers (Phase 1)
+
+    enum WebNavAction { case back, forward, reload, reloadHard }
+
+    /// Open a new `.web` pane in the active workspace. Mirrors the
+    /// shape of `handlePaneList` — single JSON reply, then close.
+    /// Allocates the new pane (and active-tab) UUIDs up front so the
+    /// reply payload can echo a concrete `pane_id` *before* the
+    /// workspace effect runs and the CLI can print/script against it.
+    func handleWebOpen(
+        state: State,
+        paneID _: UUID?,
+        url: String,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let activeID = state.activeWorkspaceID else {
+            reply?.send(["ok": false, "error": "no active workspace"])
+            reply?.close()
+            return .none
+        }
+        let normalized = WebPaneCoordinator.normalizeURLInput(url)
+        let newPaneID = uuid()
+        let newTabID = uuid()
+        reply?.send([
+            "ok": true,
+            "pane_id": newPaneID.uuidString,
+            "tab_id": newTabID.uuidString,
+            "url": normalized,
+            "workspace_id": activeID.uuidString
+        ])
+        reply?.close()
+        return .send(.workspaces(.element(
+            id: activeID,
+            action: .openWebPane(
+                paneID: newPaneID,
+                tabID: newTabID,
+                url: url,
+                reusePaneID: nil,
+                isPrivate: false
+            )
+        )))
+    }
+
+    /// Resolve a pane-target reference to a `.web` pane. Replies with
+    /// the structured error on a miss and returns nil so the caller
+    /// can short-circuit cleanly.
+    private func resolveWebPane(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        reply: SocketServer.ReplyHandle?
+    ) -> (paneID: UUID, workspace: WorkspaceFeature.State, webState: WebPaneState)? {
+        switch resolvePaneTarget(state: state, paneID: paneID, target: target, workspaceFilter: workspaceFilter) {
+        case .found(let resolvedID, let ws):
+            guard let pane = ws.panes[id: resolvedID] else {
+                reply?.send(["ok": false, "error": "pane not found: \(resolvedID.uuidString)"])
+                reply?.close()
+                return nil
+            }
+            guard pane.type == .web else {
+                reply?.send(["ok": false, "error": "pane is not a web pane (type: \(pane.type.rawValue))"])
+                reply?.close()
+                return nil
+            }
+            guard let webState = ws.webPanes[resolvedID] else {
+                reply?.send(["ok": false, "error": "web pane state missing for \(resolvedID.uuidString)"])
+                reply?.close()
+                return nil
+            }
+            return (resolvedID, ws, webState)
+        case .error(let message):
+            reply?.send(["ok": false, "error": message])
+            reply?.close()
+            return nil
+        }
+    }
+
+    func handleWebURL(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+
+        // Destructure into Sendable locals — Swift 6 strict
+        // concurrency rejects capturing the resolved tuple
+        // (which carries WorkspaceFeature.State) in a @Sendable
+        // closure.
+        let store = webPaneStore
+        let resolvedPaneID = resolved.paneID
+        let workspaceID = resolved.workspace.id
+        let tabID = resolved.webState.activeTab?.id
+        let fallbackURL = resolved.webState.activeTab?.url ?? ""
+        let fallbackTitle = resolved.webState.activeTab?.title ?? ""
+
+        return .run { _ in
+            let snapshot: (url: String, title: String)? = await MainActor.run {
+                guard let tabID else { return nil }
+                return store.coordinatorIfExists(for: resolvedPaneID)?
+                    .currentURLAndTitle(tabID: tabID)
+            }
+            let url = snapshot?.url.isEmpty == false ? snapshot!.url : fallbackURL
+            let title = snapshot?.title.isEmpty == false ? snapshot!.title : fallbackTitle
+            reply?.send([
+                "ok": true,
+                "pane_id": resolvedPaneID.uuidString,
+                "workspace_id": workspaceID.uuidString,
+                "url": url,
+                "title": title
+            ])
+            reply?.close()
+        }
+    }
+
+    func handleWebNav(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        action: WebNavAction,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+
+        reply?.send([
+            "ok": true,
+            "pane_id": resolved.paneID.uuidString,
+            "workspace_id": resolved.workspace.id.uuidString
+        ])
+        reply?.close()
+
+        let wsID = resolved.workspace.id
+        let paneID = resolved.paneID
+        switch action {
+        case .back:
+            return .send(.workspaces(.element(id: wsID, action: .webPaneBack(paneID: paneID))))
+        case .forward:
+            return .send(.workspaces(.element(id: wsID, action: .webPaneForward(paneID: paneID))))
+        case .reload:
+            return .send(.workspaces(.element(id: wsID, action: .webPaneReload(paneID: paneID, hard: false))))
+        case .reloadHard:
+            return .send(.workspaces(.element(id: wsID, action: .webPaneReload(paneID: paneID, hard: true))))
+        }
+    }
+
+    func handleWebCapture(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        mode: String,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        guard let tab = resolved.webState.activeTab else {
+            reply?.send(["ok": false, "error": "web pane has no active tab"])
+            reply?.close()
+            return .none
+        }
+
+        guard let captureMode = WebCaptureMode(rawValue: mode) else {
+            reply?.send(["ok": false, "error": "unknown capture mode '\(mode)' (allowed: meta, text, screenshot)"])
+            reply?.close()
+            return .none
+        }
+
+        // Destructure into Sendable locals for the .run closure
+        // (Swift 6 strict concurrency disallows capturing the
+        // resolved tuple, which carries WorkspaceFeature.State).
+        let store = webPaneStore
+        let resolvedPaneID = resolved.paneID
+        let workspaceID = resolved.workspace.id
+        let tabID = tab.id
+        let tabURL = tab.url
+        let tabTitle = tab.title
+
+        return .run { _ in
+            let snapshot: (url: String, title: String) = await MainActor.run {
+                store.coordinator(for: resolvedPaneID).currentURLAndTitle(tabID: tabID)
+                    ?? (tabURL, tabTitle)
+            }
+            var payload: [String: Any] = [
+                "ok": true,
+                "pane_id": resolvedPaneID.uuidString,
+                "workspace_id": workspaceID.uuidString,
+                "url": snapshot.url,
+                "title": snapshot.title,
+                "mode": captureMode.rawValue
+            ]
+            switch captureMode {
+            case .meta:
+                break
+            case .text:
+                let text = await store.coordinator(for: resolvedPaneID).captureText(tabID: tabID)
+                payload["text"] = text
+                payload["byte_count"] = text.utf8.count
+            case .screenshot:
+                let pngData = await store.coordinator(for: resolvedPaneID).captureScreenshot(tabID: tabID)
+                if let pngData {
+                    let inlineThreshold = 1_000_000 // 1 MB
+                    if pngData.count <= inlineThreshold {
+                        payload["png_base64"] = pngData.base64EncodedString()
+                        payload["byte_count"] = pngData.count
+                    } else {
+                        // Per-app temporary directory — OS prunes it
+                        // automatically (vs. `/tmp` where files lingered
+                        // until reboot).
+                        let ts = Int(Date().timeIntervalSince1970)
+                        let url = FileManager.default.temporaryDirectory
+                            .appendingPathComponent("nex-web-capture-\(resolvedPaneID.uuidString)-\(ts).png")
+                        if (try? pngData.write(to: url)) != nil {
+                            payload["path"] = url.path
+                            payload["byte_count"] = pngData.count
+                        } else {
+                            payload["ok"] = false
+                            payload["error"] = "failed to write screenshot to \(url.path)"
+                        }
+                    }
+                } else {
+                    payload["ok"] = false
+                    payload["error"] = "screenshot capture failed"
+                }
+            }
+            reply?.send(payload)
+            reply?.close()
+        }
     }
 
     /// Returns the last `n` lines of `text`, joined by `\n`. Preserves
@@ -2696,6 +2948,23 @@ struct AppReducer {
                     action: .openMarkdownFile(filePath: resolvedPath)
                 )))
 
+            case .openWebPanePath(let url, _):
+                guard let activeID = state.activeWorkspaceID else { return .none }
+                return .send(.workspaces(.element(
+                    id: activeID,
+                    action: .openWebPane(
+                        paneID: uuid(),
+                        tabID: uuid(),
+                        url: url,
+                        reusePaneID: nil,
+                        isPrivate: false
+                    )
+                )))
+
+            case .webPaneFocusURLBar(let paneID):
+                state.webPaneURLFocusTokens[paneID, default: 0] &+= 1
+                return .none
+
             case .openDiffPath(let repoPath, let targetPath, let fromPaneID):
                 guard let activeID = state.activeWorkspaceID else { return .none }
                 let workspace = state.workspaces[id: activeID]
@@ -2939,8 +3208,23 @@ struct AppReducer {
 
                     let sourceWSID = sourceWS.id
 
+                    // Capture web sidecar before removal so it can
+                    // ride along to the target workspace below. The
+                    // Pane struct doesn't carry tab/URL state for
+                    // `.web` panes — it lives in `webPanes[paneID]`
+                    // on the workspace, and the move must transfer
+                    // it explicitly or the target ends up with a
+                    // blank pane and `nex web url` fails with
+                    // "web pane state missing".
+                    let webStateToTransfer: WebPaneState? = pane.type == .web
+                        ? sourceWS.webPanes[paneID]
+                        : nil
+
                     // Remove from source
                     state.workspaces[id: sourceWSID]?.panes.remove(id: paneID)
+                    if webStateToTransfer != nil {
+                        state.workspaces[id: sourceWSID]?.webPanes.removeValue(forKey: paneID)
+                    }
                     let newSourceLayout = state.workspaces[id: sourceWSID]!.layout.removing(paneID: paneID)
                     state.workspaces[id: sourceWSID]?.layout = newSourceLayout
                     state.workspaces[id: sourceWSID]?.currentLayoutIndex = nil
@@ -2977,6 +3261,9 @@ struct AppReducer {
 
                     // Add to target
                     state.workspaces[id: targetWSID]?.panes.append(pane)
+                    if let webStateToTransfer {
+                        state.workspaces[id: targetWSID]?.webPanes[paneID] = webStateToTransfer
+                    }
 
                     let targetLayout = state.workspaces[id: targetWSID]?.layout ?? .empty
                     if targetLayout.isEmpty {
@@ -3134,6 +3421,58 @@ struct AppReducer {
 
                 case .graftStatus:
                     return handleGraftStatus(state: state, reply: reply)
+
+                case .webOpen(let paneID, let url):
+                    return handleWebOpen(state: state, paneID: paneID, url: url, reply: reply)
+
+                case .webURL(let paneID, let target, let workspaceFilter):
+                    return handleWebURL(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        reply: reply
+                    )
+
+                case .webBack(let paneID, let target, let workspaceFilter):
+                    return handleWebNav(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        action: .back,
+                        reply: reply
+                    )
+
+                case .webForward(let paneID, let target, let workspaceFilter):
+                    return handleWebNav(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        action: .forward,
+                        reply: reply
+                    )
+
+                case .webReload(let paneID, let target, let workspaceFilter, let hard):
+                    return handleWebNav(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        action: hard ? .reloadHard : .reload,
+                        reply: reply
+                    )
+
+                case .webCapture(let paneID, let target, let workspaceFilter, let mode):
+                    return handleWebCapture(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        mode: mode,
+                        reply: reply
+                    )
                 }
 
             // MARK: - Cross-Workspace Surface Notifications

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -41,6 +41,12 @@ struct AppReducer {
         /// a focused web pane; `WebPaneView` picks up the change and
         /// promotes its URL bar to first responder.
         var webPaneURLFocusTokens: [UUID: UInt64] = [:]
+        /// Phase 3: per-pane "submit after paste" flag set at arm
+        /// time by `nex web inspect --submit`. Kept on AppReducer
+        /// (rather than WebPaneState) because it's purely a hint to
+        /// the in-flight `paneSendText` call after the next click —
+        /// not state worth surfacing to the view layer or persisting.
+        var webInspectArmedSubmit: [UUID: Bool] = [:]
 
         /// Collision between the current global hotkey and an in-app
         /// keybinding. Computed so it always reflects the latest state —
@@ -432,6 +438,54 @@ struct AppReducer {
         /// through to the workspace's closePane when only one tab
         /// remains.
         case webPaneTabCloseActiveFocused
+        /// Sanitised inspect payload from the picker. Dispatched by
+        /// `ContentView` (after running the raw dictionary through
+        /// `InspectPayloadSanitiser.decode`). The reducer queues the
+        /// result on the pane and, if a pending `--send-to` is set,
+        /// pastes the formatted text into the destination pane via
+        /// `paneSendText`.
+        case webInspectPayloadReceived(paneID: UUID, result: InspectResult)
+        /// Stash whether the current inspect arm should submit (press
+        /// Enter) after the delivered paste. Cleared after every
+        /// delivery. Phase 3 ships paste-only by default.
+        case setWebInspectArmedSubmit(paneID: UUID, submit: Bool)
+        /// UI-driven equivalent of `nex web inspect --send-to <pane>`.
+        /// Asks the coordinator to arm the picker on the named pane's
+        /// active tab and stash the destination so the next click's
+        /// payload is sanitised + pasted via `paneSendText`. `sendTo`
+        /// nil = just arm, drop the result into the inspect queue for
+        /// later draining by the CLI.
+        case webPaneArmInspectorViaUI(paneID: UUID, sendTo: UUID?)
+        /// Symmetric disarm for the UI flow.
+        case webPaneDisarmInspectorViaUI(paneID: UUID)
+        /// Begin a batch-annotate session for `paneID`. Arms the
+        /// picker in sticky mode so each click adds another item;
+        /// the user finalises via `webBatchInspectSend` or aborts
+        /// via `webBatchInspectCancel`.
+        case webBatchInspectStart(paneID: UUID, sendTo: UUID?)
+        /// Format all collected items and paste them into the
+        /// destination pane (or queue locally when sendTo is nil),
+        /// then disarm the picker and clear batch state.
+        case webBatchInspectSend(paneID: UUID)
+        case webBatchInspectCancel(paneID: UUID)
+        /// Focus a batch item from either side of the list↔page sync.
+        /// `origin == .panel` came from a panel-row tap → highlight
+        /// the badge on the page. `origin == .page` came from a
+        /// page-marker click → highlight the row in the panel only
+        /// (no need to scroll the page again).
+        case webBatchFocusItem(paneID: UUID, itemID: UUID, origin: BatchFocusOrigin)
+        /// Push the current batch's marker list to the page after a
+        /// state change. Internal — fired from reducers that mutate
+        /// the items / batch state.
+        case syncBatchMarkers(paneID: UUID)
+        /// Push a single comment edit from the panel side into the
+        /// page popover. The JS skips the update if its textarea is
+        /// currently focused so the user's caret stays put.
+        case pushBatchCommentToPage(paneID: UUID, itemID: UUID, comment: String)
+        /// User clicked Done (or pressed Esc) in the page popover.
+        /// Clears the focused-item highlight (panel side) and hides
+        /// the popover + focus ring (page side).
+        case webBatchDismissPopover(paneID: UUID)
 
         // Inspector + Git Status
         case toggleInspector
@@ -1103,15 +1157,24 @@ struct AppReducer {
         reply?.send(payload)
         reply?.close()
 
+        return paneSendText(paneID: resolvedID, text: text, bare: bare)
+    }
+
+    /// Write `text` to a pane's PTY. `bare: true` writes the bytes
+    /// verbatim; `bare: false` follows up with an Enter keystroke so
+    /// the receiver runs it as a command. Factored out of
+    /// `handlePaneSend` so the Phase 3 element picker can reuse the
+    /// same PTY-write path without going through `sendCommand`
+    /// directly. The picker defaults to `bare: true` (paste-only,
+    /// the safe default) and only flips to `bare: false` when the
+    /// arming call passed `--submit`.
+    func paneSendText(paneID: UUID, text: String, bare: Bool) -> Effect<Action> {
         let mgr = surfaceManager
         return .run { _ in
             if bare {
-                // Compose-mode: write text only, no Enter. Caller is
-                // expected to follow up with `pane send-key` to drive
-                // the input (autocomplete, multi-key sequences, ...).
-                await mgr.sendText(to: resolvedID, text: text)
+                await mgr.sendText(to: paneID, text: text)
             } else {
-                await mgr.sendCommand(to: resolvedID, command: text)
+                await mgr.sendCommand(to: paneID, command: text)
             }
         }
     }
@@ -1435,24 +1498,20 @@ struct AppReducer {
         switch resolvePaneTarget(state: state, paneID: paneID, target: target, workspaceFilter: workspaceFilter) {
         case .found(let resolvedID, let ws):
             guard let pane = ws.panes[id: resolvedID] else {
-                reply?.send(["ok": false, "error": "pane not found: \(resolvedID.uuidString)"])
-                reply?.close()
+                reply?.error("pane not found: \(resolvedID.uuidString)")
                 return nil
             }
             guard pane.type == .web else {
-                reply?.send(["ok": false, "error": "pane is not a web pane (type: \(pane.type.rawValue))"])
-                reply?.close()
+                reply?.error("pane is not a web pane (type: \(pane.type.rawValue))")
                 return nil
             }
             guard let webState = ws.webPanes[resolvedID] else {
-                reply?.send(["ok": false, "error": "web pane state missing for \(resolvedID.uuidString)"])
-                reply?.close()
+                reply?.error("web pane state missing for \(resolvedID.uuidString)")
                 return nil
             }
             return (resolvedID, ws, webState)
         case .error(let message):
-            reply?.send(["ok": false, "error": message])
-            reply?.close()
+            reply?.error(message)
             return nil
         }
     }
@@ -1488,14 +1547,13 @@ struct AppReducer {
             }
             let url = snapshot?.url.isEmpty == false ? snapshot!.url : fallbackURL
             let title = snapshot?.title.isEmpty == false ? snapshot!.title : fallbackTitle
-            reply?.send([
+            reply?.sendAndClose([
                 "ok": true,
                 "pane_id": resolvedPaneID.uuidString,
                 "workspace_id": workspaceID.uuidString,
                 "url": url,
                 "title": title
             ])
-            reply?.close()
         }
     }
 
@@ -1512,12 +1570,11 @@ struct AppReducer {
             workspaceFilter: workspaceFilter, reply: reply
         ) else { return .none }
 
-        reply?.send([
+        reply?.sendAndClose([
             "ok": true,
             "pane_id": resolved.paneID.uuidString,
             "workspace_id": resolved.workspace.id.uuidString
         ])
-        reply?.close()
 
         let wsID = resolved.workspace.id
         let paneID = resolved.paneID
@@ -1546,14 +1603,12 @@ struct AppReducer {
             workspaceFilter: workspaceFilter, reply: reply
         ) else { return .none }
         guard let tab = resolved.webState.activeTab else {
-            reply?.send(["ok": false, "error": "web pane has no active tab"])
-            reply?.close()
+            reply?.error("web pane has no active tab")
             return .none
         }
 
         guard let captureMode = WebCaptureMode(rawValue: mode) else {
-            reply?.send(["ok": false, "error": "unknown capture mode '\(mode)' (allowed: meta, text, screenshot)"])
-            reply?.close()
+            reply?.error("unknown capture mode '\(mode)' (allowed: meta, text, screenshot)")
             return .none
         }
 
@@ -1614,8 +1669,7 @@ struct AppReducer {
                     payload["error"] = "screenshot capture failed"
                 }
             }
-            reply?.send(payload)
-            reply?.close()
+            reply?.sendAndClose(payload)
         }
     }
 
@@ -1777,6 +1831,236 @@ struct AppReducer {
                 action: .webPaneTabSelect(paneID: resolved.paneID, tabID: tabID)
             )))
         }
+    }
+
+    // MARK: - Web pane console + inspector handlers (Phase 3)
+
+    private func consoleLineJSON(_ entry: RingBuffer<ConsoleLine>.Entry) -> [String: Any] {
+        let line = entry.value
+        var dict: [String: Any] = [
+            "seq": entry.seq,
+            "tab_id": line.tabID.uuidString,
+            "level": line.level.rawValue,
+            "message": line.message,
+            "url": line.url,
+            "captured_at": InspectPayloadSanitiser.isoFormatter.string(from: line.capturedAt)
+        ]
+        if let n = line.lineNumber { dict["line"] = n }
+        if let n = line.columnNumber { dict["column"] = n }
+        return dict
+    }
+
+    private func inspectResultJSON(_ result: InspectResult) -> [String: Any] {
+        var dict: [String: Any] = [
+            "tab_id": result.tabID.uuidString,
+            "selector": result.selector,
+            "xpath": result.xpath,
+            "tag": result.tag,
+            "id": result.elementID,
+            "url": result.url,
+            "text": result.text,
+            "attributes": result.attributes,
+            "rect": [
+                "x": result.rect.origin.x,
+                "y": result.rect.origin.y,
+                "w": result.rect.size.width,
+                "h": result.rect.size.height
+            ],
+            "captured_at": InspectPayloadSanitiser.isoFormatter.string(from: result.capturedAt)
+        ]
+        if !result.outerHTML.isEmpty { dict["outer_html"] = result.outerHTML }
+        if !result.contextHTML.isEmpty { dict["context_html"] = result.contextHTML }
+        if !result.comment.isEmpty { dict["comment"] = result.comment }
+        return dict
+    }
+
+    func handleWebConsole(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        since: UInt64,
+        level: String?,
+        clear: Bool,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        let entries = resolved.webState.consoleBuffer.entries(since: since)
+        let filtered: [RingBuffer<ConsoleLine>.Entry] = if let level {
+            entries.filter { $0.value.level.rawValue == level }
+        } else {
+            entries
+        }
+        let nextSeq = resolved.webState.consoleBuffer.nextSeq
+        let dropped = resolved.webState.consoleBuffer.droppedSinceLastDrain
+        reply?.sendAndClose([
+            "ok": true,
+            "pane_id": resolved.paneID.uuidString,
+            "workspace_id": resolved.workspace.id.uuidString,
+            "lines": filtered.map(consoleLineJSON),
+            "next_since": nextSeq,
+            "dropped": dropped
+        ])
+        // Acknowledge the reported drops so the next call only
+        // surfaces drops that accumulated after this drain. Always
+        // dispatched, even when `dropped == 0`, so the reducer
+        // doesn't have to branch on it.
+        var effects: [Effect<Action>] = [
+            .send(.workspaces(.element(
+                id: resolved.workspace.id,
+                action: .webConsoleAcknowledgeDrops(paneID: resolved.paneID)
+            )))
+        ]
+        if clear {
+            effects.append(.send(.workspaces(.element(
+                id: resolved.workspace.id,
+                action: .webConsoleClear(paneID: resolved.paneID)
+            ))))
+        }
+        return .merge(effects)
+    }
+
+    func handleWebInspect(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        sendTo: String?,
+        submit: Bool,
+        disarm: Bool,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+
+        // Explicit disarm path: no arming, just clear server-side
+        // state and the in-page picker.
+        if disarm {
+            reply?.sendAndClose([
+                "ok": true,
+                "pane_id": resolved.paneID.uuidString,
+                "armed": false
+            ])
+            let resolvedPaneID = resolved.paneID
+            let store = webPaneStore
+            return .merge(
+                .send(.workspaces(.element(
+                    id: resolved.workspace.id,
+                    action: .webInspectDisarm(paneID: resolvedPaneID)
+                ))),
+                .run { _ in
+                    await MainActor.run {
+                        store.coordinatorIfExists(for: resolvedPaneID)?.disarmInspector()
+                    }
+                }
+            )
+        }
+
+        guard let tab = resolved.webState.activeTab else {
+            reply?.error("web pane has no active tab")
+            return .none
+        }
+
+        // Resolve `--send-to` to a concrete pane UUID up front so we
+        // can report a clear error before arming. Only `.shell` panes
+        // have a terminal surface that `paneSendText` can write to —
+        // markdown / scratchpad / diff / web destinations would
+        // silently no-op inside `SurfaceManager.sendText`, so reject
+        // them here with a typed error instead.
+        let sendToPaneID: UUID?
+        if let sendTo {
+            switch resolvePaneTarget(
+                state: state, paneID: paneID, target: sendTo,
+                workspaceFilter: workspaceFilter
+            ) {
+            case .found(let resolvedID, let workspace):
+                guard let destPane = workspace.panes[id: resolvedID] else {
+                    reply?.error("--send-to: pane not found: \(resolvedID.uuidString)")
+                    return .none
+                }
+                guard destPane.type == .shell else {
+                    reply?.error(
+                        "--send-to: destination must be a shell pane (got: \(destPane.type.rawValue))"
+                    )
+                    return .none
+                }
+                sendToPaneID = resolvedID
+            case .error(let message):
+                reply?.error("--send-to: \(message)")
+                return .none
+            }
+        } else {
+            sendToPaneID = nil
+        }
+
+        let resolvedPaneID = resolved.paneID
+        let workspaceID = resolved.workspace.id
+        let store = webPaneStore
+        let tabID = tab.id
+
+        return .run { send in
+            // Arm the in-page picker on the main actor and read back
+            // the nonce. Hop to MainActor.run synchronously so we
+            // can return the nonce before the reply lands.
+            let nonce: String? = await MainActor.run {
+                store.coordinator(for: resolvedPaneID).armInspector(tabID: tabID)
+            }
+            guard let nonce else {
+                reply?.error("failed to arm inspector for active tab")
+                return
+            }
+            await send(.workspaces(.element(
+                id: workspaceID,
+                action: .webInspectArmedFor(
+                    paneID: resolvedPaneID,
+                    sendTo: sendToPaneID,
+                    nonce: nonce
+                )
+            )))
+            if submit {
+                await send(.setWebInspectArmedSubmit(paneID: resolvedPaneID, submit: true))
+            }
+            reply?.sendAndClose([
+                "ok": true,
+                "pane_id": resolvedPaneID.uuidString,
+                "tab_id": tabID.uuidString,
+                "armed": true,
+                "send_to": sendToPaneID?.uuidString ?? "",
+                "submit": submit
+            ])
+        }
+    }
+
+    func handleWebInspectResult(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        clear: Bool,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        reply?.sendAndClose([
+            "ok": true,
+            "pane_id": resolved.paneID.uuidString,
+            "workspace_id": resolved.workspace.id.uuidString,
+            "results": resolved.webState.inspectResultQueue.map(inspectResultJSON)
+        ])
+        if clear {
+            return .send(.workspaces(.element(
+                id: resolved.workspace.id,
+                action: .webInspectResultClear(paneID: resolved.paneID)
+            )))
+        }
+        return .none
     }
 
     /// Returns the last `n` lines of `text`, joined by `\n`. Preserves
@@ -3136,9 +3420,7 @@ struct AppReducer {
                 return .none
 
             case .webPaneOpenNewTab(let paneID, let url):
-                guard let workspace = state.workspaces.first(where: { $0.webPanes[paneID] != nil }) else {
-                    return .none
-                }
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
                 let newTabID = uuid()
                 return .send(.workspaces(.element(
                     id: workspace.id,
@@ -3171,6 +3453,288 @@ struct AppReducer {
                     id: activeID,
                     action: .webPaneTabClose(paneID: focusedID, tabID: activeTabID)
                 )))
+
+            case .setWebInspectArmedSubmit(let paneID, let submit):
+                if submit {
+                    state.webInspectArmedSubmit[paneID] = true
+                } else {
+                    state.webInspectArmedSubmit.removeValue(forKey: paneID)
+                }
+                return .none
+
+            case .webPaneArmInspectorViaUI(let paneID, let sendTo):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                guard let tab = workspace.webPanes[paneID]?.activeTab else { return .none }
+                let store = webPaneStore
+                let workspaceID = workspace.id
+                let tabID = tab.id
+                return .run { send in
+                    let nonce: String? = await MainActor.run {
+                        store.coordinator(for: paneID).armInspector(tabID: tabID)
+                    }
+                    guard let nonce else { return }
+                    await send(.workspaces(.element(
+                        id: workspaceID,
+                        action: .webInspectArmedFor(
+                            paneID: paneID, sendTo: sendTo, nonce: nonce
+                        )
+                    )))
+                }
+
+            case .webPaneDisarmInspectorViaUI(let paneID):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                let store = webPaneStore
+                let workspaceID = workspace.id
+                state.webInspectArmedSubmit.removeValue(forKey: paneID)
+                return .merge(
+                    .send(.workspaces(.element(
+                        id: workspaceID,
+                        action: .webInspectDisarm(paneID: paneID)
+                    ))),
+                    .run { _ in
+                        await MainActor.run {
+                            store.coordinatorIfExists(for: paneID)?.disarmInspector()
+                        }
+                    }
+                )
+
+            case .webBatchInspectStart(let paneID, let sendTo):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                guard let tab = workspace.webPanes[paneID]?.activeTab else { return .none }
+                let store = webPaneStore
+                let workspaceID = workspace.id
+                let tabID = tab.id
+                return .merge(
+                    .send(.workspaces(.element(
+                        id: workspaceID,
+                        action: .webBatchInspectBegin(paneID: paneID, sendTo: sendTo)
+                    ))),
+                    .send(.syncBatchMarkers(paneID: paneID)),
+                    .run { send in
+                        let nonce: String? = await MainActor.run {
+                            store.coordinator(for: paneID).armInspector(tabID: tabID, sticky: true)
+                        }
+                        guard let nonce else { return }
+                        await send(.workspaces(.element(
+                            id: workspaceID,
+                            action: .webInspectArmedFor(
+                                paneID: paneID, sendTo: sendTo, nonce: nonce
+                            )
+                        )))
+                    }
+                )
+
+            case .webBatchInspectCancel(let paneID):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                let store = webPaneStore
+                let workspaceID = workspace.id
+                state.webInspectArmedSubmit.removeValue(forKey: paneID)
+                return .merge(
+                    .send(.workspaces(.element(
+                        id: workspaceID,
+                        action: .webBatchInspectCleared(paneID: paneID)
+                    ))),
+                    .send(.syncBatchMarkers(paneID: paneID)),
+                    .send(.workspaces(.element(
+                        id: workspaceID,
+                        action: .webInspectDisarm(paneID: paneID)
+                    ))),
+                    .run { _ in
+                        await MainActor.run {
+                            store.coordinatorIfExists(for: paneID)?.disarmInspector()
+                        }
+                    }
+                )
+
+            case .webBatchInspectSend(let paneID):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                guard let batch = workspace.webPanes[paneID]?.batchInspect else { return .none }
+                let store = webPaneStore
+                let workspaceID = workspace.id
+                let submit = state.webInspectArmedSubmit[paneID] ?? false
+                state.webInspectArmedSubmit.removeValue(forKey: paneID)
+
+                var effects: [Effect<Action>] = [
+                    .send(.workspaces(.element(
+                        id: workspaceID,
+                        action: .webBatchInspectCleared(paneID: paneID)
+                    ))),
+                    .send(.syncBatchMarkers(paneID: paneID)),
+                    .send(.workspaces(.element(
+                        id: workspaceID,
+                        action: .webInspectDisarm(paneID: paneID)
+                    ))),
+                    .run { _ in
+                        await MainActor.run {
+                            store.coordinatorIfExists(for: paneID)?.disarmInspector()
+                        }
+                    }
+                ]
+                // Empty batch — nothing to send, just tear down.
+                if batch.items.isEmpty {
+                    return .merge(effects)
+                }
+                if let sendTo = batch.sendTo {
+                    let formatted = InspectPayloadSanitiser.formatBatchForPaste(batch.items)
+                    effects.append(paneSendText(paneID: sendTo, text: formatted, bare: !submit))
+                } else {
+                    // No destination — queue each item locally for
+                    // `nex web inspect-result` to drain. Stamp the
+                    // per-item comment onto the result before
+                    // enqueueing so `inspectResultJSON` surfaces it
+                    // (the single-shot picker path always leaves
+                    // `comment` empty).
+                    for item in batch.items {
+                        var annotated = item.result
+                        annotated.comment = item.comment
+                        effects.append(.send(.workspaces(.element(
+                            id: workspaceID,
+                            action: .webInspectResultReceived(
+                                paneID: paneID, result: annotated
+                            )
+                        ))))
+                    }
+                }
+                return .merge(effects)
+
+            case .webBatchFocusItem(let paneID, let itemID, let origin):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                guard let webState = workspace.webPanes[paneID],
+                      let tab = webState.activeTab else { return .none }
+                let store = webPaneStore
+                let tabID = tab.id
+                // Push the focus ring + badge pulse onto the page
+                // regardless of origin — the persistent ring is the
+                // primary visual feedback, and re-pulsing the badge
+                // is cheap. `.panel` also scrolls the page; `.page`
+                // skips the scroll since the element is already under
+                // the cursor.
+                let scrollIntoView = origin == .panel
+                return .merge(
+                    .send(.workspaces(.element(
+                        id: workspace.id,
+                        action: .webBatchItemFocused(paneID: paneID, itemID: itemID)
+                    ))),
+                    .run { _ in
+                        await MainActor.run {
+                            store.coordinatorIfExists(for: paneID)?
+                                .highlightBatchMarker(
+                                    tabID: tabID,
+                                    itemID: itemID,
+                                    scrollIntoView: scrollIntoView
+                                )
+                        }
+                    }
+                )
+
+            case .syncBatchMarkers(let paneID):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                let webState = workspace.webPanes[paneID]
+                let tabID = webState?.activeTab?.id
+                let items: [BatchMarkerInput] = (webState?.batchInspect?.items ?? [])
+                    .enumerated()
+                    .map { idx, item in
+                        BatchMarkerInput(
+                            id: item.id,
+                            selector: item.result.selector,
+                            label: String(idx + 1),
+                            comment: item.comment
+                        )
+                    }
+                let store = webPaneStore
+                return .run { _ in
+                    await MainActor.run {
+                        guard let coordinator = store.coordinatorIfExists(for: paneID),
+                              let tabID else { return }
+                        if items.isEmpty {
+                            coordinator.clearBatchMarkers(tabID: tabID)
+                        } else {
+                            coordinator.syncBatchMarkers(tabID: tabID, items: items)
+                        }
+                    }
+                }
+
+            case .pushBatchCommentToPage(let paneID, let itemID, let comment):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                guard let tabID = workspace.webPanes[paneID]?.activeTab?.id else { return .none }
+                let store = webPaneStore
+                return .run { _ in
+                    await MainActor.run {
+                        store.coordinatorIfExists(for: paneID)?
+                            .pushBatchComment(tabID: tabID, itemID: itemID, comment: comment)
+                    }
+                }
+
+            case .webBatchDismissPopover(let paneID):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                let tabID = workspace.webPanes[paneID]?.activeTab?.id
+                let store = webPaneStore
+                return .merge(
+                    .send(.workspaces(.element(
+                        id: workspace.id,
+                        action: .webBatchItemFocused(paneID: paneID, itemID: nil)
+                    ))),
+                    .run { _ in
+                        await MainActor.run {
+                            guard let tabID else { return }
+                            store.coordinatorIfExists(for: paneID)?.unfocusBatch(tabID: tabID)
+                        }
+                    }
+                )
+
+            case .webInspectPayloadReceived(let paneID, let result):
+                guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
+                let webState = workspace.webPanes[paneID]
+
+                // Batch mode: append to the in-progress batch and
+                // leave the picker armed (sticky) for the next pick.
+                // No paste happens until the user hits Send. Also
+                // refresh the on-page numbered markers so the new
+                // pick gets a badge, then focus the new item so the
+                // page draws its ring and the panel auto-focuses the
+                // comment field.
+                if webState?.batchInspect != nil {
+                    let item = BatchInspectItem(result: result)
+                    return .merge(
+                        .send(.workspaces(.element(
+                            id: workspace.id,
+                            action: .webBatchItemAdded(paneID: paneID, item: item)
+                        ))),
+                        .send(.syncBatchMarkers(paneID: paneID)),
+                        // Origin .page — the click was on the page,
+                        // so we don't re-scroll the element into view
+                        // (it's already where the user clicked).
+                        .send(.webBatchFocusItem(
+                            paneID: paneID, itemID: item.id, origin: .page
+                        ))
+                    )
+                }
+
+                // Single-shot mode: queue on source pane (so
+                // `nex web inspect-result` can drain it later), and
+                // if this arm was set up with `--send-to`, paste the
+                // formatted block into the destination via the
+                // factored paneSendText helper. Submit-after-paste
+                // is recorded out-of-band in `webInspectArmedSubmit`
+                // (Phase 3 ships paste-only as the safe default).
+                let sendTo = webState?.pendingInspectSendTo
+                let submit = state.webInspectArmedSubmit[paneID] ?? false
+                var effects: [Effect<Action>] = [
+                    .send(.workspaces(.element(
+                        id: workspace.id,
+                        action: .webInspectResultReceived(paneID: paneID, result: result)
+                    ))),
+                    .send(.workspaces(.element(
+                        id: workspace.id,
+                        action: .webInspectDisarm(paneID: paneID)
+                    )))
+                ]
+                state.webInspectArmedSubmit.removeValue(forKey: paneID)
+                if let sendTo {
+                    let formatted = InspectPayloadSanitiser.formatForPaste(result)
+                    effects.append(paneSendText(paneID: sendTo, text: formatted, bare: !submit))
+                }
+                return .merge(effects)
 
             case .openDiffPath(let repoPath, let targetPath, let fromPaneID):
                 guard let activeID = state.activeWorkspaceID else { return .none }
@@ -3718,6 +4282,40 @@ struct AppReducer {
                         target: target,
                         workspaceFilter: workspaceFilter,
                         tabRef: tabRef,
+                        reply: reply
+                    )
+
+                case .webConsole(let paneID, let target, let workspaceFilter, let since, let level, let clear):
+                    return handleWebConsole(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        since: since,
+                        level: level,
+                        clear: clear,
+                        reply: reply
+                    )
+
+                case .webInspect(let paneID, let target, let workspaceFilter, let sendTo, let submit, let disarm):
+                    return handleWebInspect(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        sendTo: sendTo,
+                        submit: submit,
+                        disarm: disarm,
+                        reply: reply
+                    )
+
+                case .webInspectResult(let paneID, let target, let workspaceFilter, let clear):
+                    return handleWebInspectResult(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        clear: clear,
                         reply: reply
                     )
                 }

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -422,6 +422,16 @@ struct AppReducer {
         case openWebPanePath(url: String, fromPaneID: UUID?)
         /// Bump the URL bar focus token for a web pane (⌘L).
         case webPaneFocusURLBar(paneID: UUID)
+        /// Open a new tab in an existing web pane. `url == nil` →
+        /// blank tab. Allocates the tab id here so the priority key
+        /// path (⌘T) and CLI (`nex web tab-new`) share one entry point.
+        case webPaneOpenNewTab(paneID: UUID, url: String?)
+        /// Cycle tabs in the focused web pane. `+1` = next, `-1` = prev.
+        case webPaneTabCycleFocused(offset: Int)
+        /// Close the active tab in the focused web pane. Falls
+        /// through to the workspace's closePane when only one tab
+        /// remains.
+        case webPaneTabCloseActiveFocused
 
         // Inspector + Git Status
         case toggleInspector
@@ -1606,6 +1616,166 @@ struct AppReducer {
             }
             reply?.send(payload)
             reply?.close()
+        }
+    }
+
+    // MARK: - Web pane tab handlers
+
+    enum TabRefResolution {
+        case found(UUID)
+        case error(String)
+    }
+
+    /// Resolve a `tab` ref (UUID string or numeric index) against a
+    /// web pane's tab list. Returns the concrete tab UUID or an
+    /// error message safe to surface in a reply.
+    private func resolveTabRef(
+        _ ref: String,
+        in webState: WebPaneState
+    ) -> TabRefResolution {
+        if let uuid = UUID(uuidString: ref) {
+            guard webState.contains(tabID: uuid) else {
+                return .error("no tab with UUID '\(ref)' in this web pane")
+            }
+            return .found(uuid)
+        }
+        if let idx = Int(ref) {
+            guard webState.tabs.indices.contains(idx) else {
+                return .error("tab index \(idx) out of range (0..<\(webState.tabs.count))")
+            }
+            return .found(webState.tabs[idx].id)
+        }
+        return .error("tab ref must be a UUID or numeric index, got '\(ref)'")
+    }
+
+    private func tabJSON(_ tab: WebTab, isActive: Bool, index: Int) -> [String: Any] {
+        [
+            "id": tab.id.uuidString,
+            "url": tab.url,
+            "title": tab.title,
+            "index": index,
+            "active": isActive
+        ]
+    }
+
+    func handleWebTabs(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        let activeID = resolved.webState.activeTab?.id
+        let entries = resolved.webState.tabs.enumerated().map { idx, tab in
+            tabJSON(tab, isActive: tab.id == activeID, index: idx)
+        }
+        reply?.sendAndClose([
+            "ok": true,
+            "pane_id": resolved.paneID.uuidString,
+            "workspace_id": resolved.workspace.id.uuidString,
+            "tabs": entries
+        ])
+        return .none
+    }
+
+    func handleWebTabNew(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        url: String,
+        makeActive: Bool,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        let newTabID = uuid()
+        reply?.sendAndClose([
+            "ok": true,
+            "pane_id": resolved.paneID.uuidString,
+            "tab_id": newTabID.uuidString,
+            "workspace_id": resolved.workspace.id.uuidString,
+            "url": WebPaneCoordinator.normalizeURLInput(url),
+            "active": makeActive
+        ])
+        return .send(.workspaces(.element(
+            id: resolved.workspace.id,
+            action: .webPaneTabOpen(
+                paneID: resolved.paneID,
+                tabID: newTabID,
+                url: url,
+                makeActive: makeActive
+            )
+        )))
+    }
+
+    func handleWebTabClose(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        tabRef: String,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        switch resolveTabRef(tabRef, in: resolved.webState) {
+        case .error(let message):
+            reply?.error(message)
+            return .none
+        case .found(let tabID):
+            if resolved.webState.tabs.count == 1 {
+                reply?.error("cannot close the only tab in a web pane, use `nex pane close` to close the pane itself")
+                return .none
+            }
+            reply?.sendAndClose([
+                "ok": true,
+                "pane_id": resolved.paneID.uuidString,
+                "workspace_id": resolved.workspace.id.uuidString,
+                "tab_id": tabID.uuidString
+            ])
+            return .send(.workspaces(.element(
+                id: resolved.workspace.id,
+                action: .webPaneTabClose(paneID: resolved.paneID, tabID: tabID)
+            )))
+        }
+    }
+
+    func handleWebTabSelect(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        tabRef: String,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        switch resolveTabRef(tabRef, in: resolved.webState) {
+        case .error(let message):
+            reply?.error(message)
+            return .none
+        case .found(let tabID):
+            reply?.sendAndClose([
+                "ok": true,
+                "pane_id": resolved.paneID.uuidString,
+                "workspace_id": resolved.workspace.id.uuidString,
+                "tab_id": tabID.uuidString
+            ])
+            return .send(.workspaces(.element(
+                id: resolved.workspace.id,
+                action: .webPaneTabSelect(paneID: resolved.paneID, tabID: tabID)
+            )))
         }
     }
 
@@ -2965,6 +3135,43 @@ struct AppReducer {
                 state.webPaneURLFocusTokens[paneID, default: 0] &+= 1
                 return .none
 
+            case .webPaneOpenNewTab(let paneID, let url):
+                guard let workspace = state.workspaces.first(where: { $0.webPanes[paneID] != nil }) else {
+                    return .none
+                }
+                let newTabID = uuid()
+                return .send(.workspaces(.element(
+                    id: workspace.id,
+                    action: .webPaneTabOpen(
+                        paneID: paneID,
+                        tabID: newTabID,
+                        url: url ?? "",
+                        makeActive: true
+                    )
+                )))
+
+            case .webPaneTabCycleFocused(let offset):
+                guard let activeID = state.activeWorkspaceID,
+                      let workspace = state.workspaces[id: activeID],
+                      let focusedID = workspace.focusedPaneID,
+                      workspace.panes[id: focusedID]?.type == .web else { return .none }
+                return .send(.workspaces(.element(
+                    id: activeID,
+                    action: .webPaneTabCycle(paneID: focusedID, offset: offset)
+                )))
+
+            case .webPaneTabCloseActiveFocused:
+                guard let activeID = state.activeWorkspaceID,
+                      let workspace = state.workspaces[id: activeID],
+                      let focusedID = workspace.focusedPaneID,
+                      workspace.panes[id: focusedID]?.type == .web,
+                      let webState = workspace.webPanes[focusedID],
+                      let activeTabID = webState.activeTab?.id else { return .none }
+                return .send(.workspaces(.element(
+                    id: activeID,
+                    action: .webPaneTabClose(paneID: focusedID, tabID: activeTabID)
+                )))
+
             case .openDiffPath(let repoPath, let targetPath, let fromPaneID):
                 guard let activeID = state.activeWorkspaceID else { return .none }
                 let workspace = state.workspaces[id: activeID]
@@ -3471,6 +3678,46 @@ struct AppReducer {
                         target: target,
                         workspaceFilter: workspaceFilter,
                         mode: mode,
+                        reply: reply
+                    )
+
+                case .webTabs(let paneID, let target, let workspaceFilter):
+                    return handleWebTabs(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        reply: reply
+                    )
+
+                case .webTabNew(let paneID, let target, let workspaceFilter, let url, let makeActive):
+                    return handleWebTabNew(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        url: url,
+                        makeActive: makeActive,
+                        reply: reply
+                    )
+
+                case .webTabClose(let paneID, let target, let workspaceFilter, let tabRef):
+                    return handleWebTabClose(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        tabRef: tabRef,
+                        reply: reply
+                    )
+
+                case .webTabSelect(let paneID, let target, let workspaceFilter, let tabRef):
+                    return handleWebTabSelect(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        tabRef: tabRef,
                         reply: reply
                     )
                 }

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -48,6 +48,8 @@ struct AppReducer {
         /// not state worth surfacing to the view layer or persisting.
         var webInspectArmedSubmit: [UUID: Bool] = [:]
 
+        var favourites: [Favourite] = []
+
         /// Collision between the current global hotkey and an in-app
         /// keybinding. Computed so it always reflects the latest state —
         /// `keybindings` and `globalHotkey` can land in state in either
@@ -487,6 +489,16 @@ struct AppReducer {
         /// the popover + focus ring (page side).
         case webBatchDismissPopover(paneID: UUID)
 
+        // MARK: - Web favourites
+
+        case favouritesLoaded([Favourite])
+        case removeFavourite(id: UUID)
+        case renameFavourite(id: UUID, title: String)
+        case moveFavourite(fromIndex: Int, toIndex: Int)
+        /// Star toggle: add when missing, remove when present.
+        /// URL match is case-insensitive with trailing-slash stripped.
+        case toggleFavourite(url: String, title: String)
+
         // Inspector + Git Status
         case toggleInspector
         case refreshGitStatus
@@ -556,6 +568,7 @@ struct AppReducer {
     @Dependency(\.webPaneStore) var webPaneStore
     @Dependency(\.uuid) var uuid
     @Dependency(\.continuousClock) var clock
+    @Dependency(\.userDefaults) var userDefaults
 
     private enum GitStatusTimerID: Hashable { case timer }
     private enum AutoLinkResolveID: Hashable { case pane(UUID) }
@@ -592,6 +605,13 @@ struct AppReducer {
             await surfaceManager.focus(paneID: paneID)
         }
         .cancellable(id: PaletteFocusID.pending, cancelInFlight: true)
+    }
+
+    private func persistFavourites(_ favourites: [Favourite]) -> Effect<Action> {
+        let json = FavouritesStorage.encode(favourites)
+        return .run { [userDefaults] _ in
+            userDefaults.setString(json, FavouritesStorage.defaultsKey)
+        }
     }
 
     /// Coalesce rapid `cd`s before scanning the directory for a repo root.
@@ -2108,6 +2128,10 @@ struct AppReducer {
                             globalHotkey: config.globalHotkey,
                             globalHotkeyHideOnRepress: config.globalHotkeyHideOnRepress
                         ))
+                    },
+                    .run { [userDefaults] send in
+                        let json = userDefaults.stringForKey(FavouritesStorage.defaultsKey)
+                        await send(.favouritesLoaded(FavouritesStorage.decode(json)))
                     }
                 )
 
@@ -3186,6 +3210,41 @@ struct AppReducer {
                     ?? state.workspaces[id: item.workspaceID]?.focusedPaneID
                 effects.append(scheduleFocusAfterPaletteClose(paneID: targetPaneID))
                 return .merge(effects)
+
+            // MARK: - Web favourites
+
+            case .favouritesLoaded(let list):
+                state.favourites = list
+                return .none
+
+            case .removeFavourite(let id):
+                guard let idx = state.favourites.firstIndex(where: { $0.id == id })
+                else { return .none }
+                state.favourites.remove(at: idx)
+                return persistFavourites(state.favourites)
+
+            case .renameFavourite(let id, let title):
+                guard let idx = state.favourites.firstIndex(where: { $0.id == id })
+                else { return .none }
+                state.favourites[idx].title = title
+                return persistFavourites(state.favourites)
+
+            case .moveFavourite(let from, let to):
+                guard from >= 0, from < state.favourites.count,
+                      to >= 0, to <= state.favourites.count, from != to
+                else { return .none }
+                state.favourites.move(fromOffsets: IndexSet(integer: from), toOffset: to)
+                return persistFavourites(state.favourites)
+
+            case .toggleFavourite(let url, let title):
+                let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return .none }
+                if let existing = state.favourites.firstMatching(url: trimmed) {
+                    state.favourites.removeAll { $0.id == existing.id }
+                } else {
+                    state.favourites.append(Favourite(id: uuid(), url: trimmed, title: title))
+                }
+                return persistFavourites(state.favourites)
 
             // MARK: - Keybindings
 

--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -184,12 +184,81 @@ final class PaneShortcutMonitor {
         // the dispatcher order ever changes.
         if store.globalHotkey == trigger { return false }
 
+        // Web pane priority layer: when the focused pane is a `.web`
+        // pane, consult a hard-coded ⌘L / ⌘R / ⌘[ / ⌘] map *before*
+        // falling through to the normal keybinding lookup. This way
+        // the global defaults (close pane / focus prev / focus next /
+        // markdown font) keep working for every other pane type while
+        // web panes get browser-style shortcuts.
+        if let consumed = handleWebPanePriorityShortcut(
+            event: event,
+            trigger: trigger,
+            activeWorkspaceID: activeID
+        ) {
+            return consumed
+        }
+
         guard let action = store.keybindings.action(for: trigger) else { return false }
 
         // Menu bar actions are handled by SwiftUI Commands — don't consume here.
         if action.isMenuBarAction { return false }
 
         return dispatchAction(action, activeWorkspaceID: activeID)
+    }
+
+    /// Phase 1 web priority layer. Returns:
+    /// - `true`  — event consumed by a web action
+    /// - `false` — event consumed by an intentional fall-through
+    ///   (e.g. URL bar editing + ⌘[ shouldn't trip back)
+    /// - `nil`   — not applicable, the main layer should run
+    private func handleWebPanePriorityShortcut(
+        event _: NSEvent,
+        trigger: KeyTrigger,
+        activeWorkspaceID id: UUID
+    ) -> Bool? {
+        guard let workspace = store.workspaces[id: id],
+              let focusedID = workspace.focusedPaneID,
+              let pane = workspace.panes[id: focusedID],
+              pane.type == .web else { return nil }
+
+        // ⌘ alone, no shift / ctrl / option.
+        let isPlainCommand = trigger.modifiers == .command
+        // ⌘[ / ⌘] — only intercept when the URL bar isn't editing.
+        // The bar is an NSTextField, which becomes the window's
+        // firstResponder via its NSText editor when typing.
+        let urlBarIsEditing: Bool = {
+            guard let keyWindow = NSApp.keyWindow,
+                  let responder = keyWindow.firstResponder else { return false }
+            return responder is NSText
+        }()
+
+        switch (trigger.keyCode, isPlainCommand) {
+        case (37, true): // ⌘L
+            store.send(.webPaneFocusURLBar(paneID: focusedID))
+            return true
+        case (15, true): // ⌘R
+            store.send(.workspaces(.element(
+                id: id,
+                action: .webPaneReload(paneID: focusedID, hard: false)
+            )))
+            return true
+        case (33, true): // ⌘[
+            if urlBarIsEditing { return nil } // fall through to focusPreviousPane
+            store.send(.workspaces(.element(
+                id: id,
+                action: .webPaneBack(paneID: focusedID)
+            )))
+            return true
+        case (30, true): // ⌘]
+            if urlBarIsEditing { return nil }
+            store.send(.workspaces(.element(
+                id: id,
+                action: .webPaneForward(paneID: focusedID)
+            )))
+            return true
+        default:
+            return nil
+        }
     }
 
     // MARK: - Action Dispatch
@@ -287,9 +356,52 @@ final class PaneShortcutMonitor {
         case .openDiff:
             return handleOpenDiff(activeWorkspaceID: id)
 
+        case .openWebPane:
+            // Open a fresh web pane on a blank URL — user can type
+            // one in the URL bar. Matches what ⌘L does for a brand-new
+            // pane. No `--here` semantics here; that's reserved for
+            // the explicit CLI flow.
+            store.send(.openWebPanePath(url: "", fromPaneID: nil))
+            return true
+
+        case .webFocusURLBar:
+            return handleWebAction(activeWorkspaceID: id) { paneID in
+                .webPaneFocusURLBar(paneID: paneID)
+            }
+
+        case .webBack:
+            return handleWebAction(activeWorkspaceID: id) { paneID in
+                .workspaces(.element(id: id, action: .webPaneBack(paneID: paneID)))
+            }
+
+        case .webForward:
+            return handleWebAction(activeWorkspaceID: id) { paneID in
+                .workspaces(.element(id: id, action: .webPaneForward(paneID: paneID)))
+            }
+
+        case .webReload:
+            return handleWebAction(activeWorkspaceID: id) { paneID in
+                .workspaces(.element(id: id, action: .webPaneReload(paneID: paneID, hard: false)))
+            }
+
         default:
             return false
         }
+    }
+
+    /// Run a web-pane action only when the focused pane is `.web`,
+    /// returning false (so the keybinding can fall through to a
+    /// non-web default) otherwise. Mirrors `handleMarkdownFontSize`.
+    private func handleWebAction(
+        activeWorkspaceID id: UUID,
+        _ build: (UUID) -> AppReducer.Action
+    ) -> Bool {
+        guard let workspace = store.workspaces[id: id],
+              let focusedID = workspace.focusedPaneID,
+              workspace.panes[id: focusedID]?.type == .web
+        else { return false }
+        store.send(build(focusedID))
+        return true
     }
 
     // MARK: - Conditional Handlers

--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -206,11 +206,11 @@ final class PaneShortcutMonitor {
         return dispatchAction(action, activeWorkspaceID: activeID)
     }
 
-    /// Phase 1 web priority layer. Returns:
-    /// - `true`  — event consumed by a web action
-    /// - `false` — event consumed by an intentional fall-through
+    /// Web pane priority layer. Returns:
+    /// - `true`  - event consumed by a web action
+    /// - `false` - event consumed by an intentional fall-through
     ///   (e.g. URL bar editing + ⌘[ shouldn't trip back)
-    /// - `nil`   — not applicable, the main layer should run
+    /// - `nil`   - not applicable, the main layer should run
     private func handleWebPanePriorityShortcut(
         event _: NSEvent,
         trigger: KeyTrigger,
@@ -223,6 +223,7 @@ final class PaneShortcutMonitor {
 
         // ⌘ alone, no shift / ctrl / option.
         let isPlainCommand = trigger.modifiers == .command
+        let isCmdShift = trigger.modifiers == [.command, .shift]
         // ⌘[ / ⌘] — only intercept when the URL bar isn't editing.
         // The bar is an NSTextField, which becomes the window's
         // firstResponder via its NSText editor when typing.
@@ -232,29 +233,49 @@ final class PaneShortcutMonitor {
             return responder is NSText
         }()
 
-        switch (trigger.keyCode, isPlainCommand) {
-        case (37, true): // ⌘L
+        switch (trigger.keyCode, isPlainCommand, isCmdShift) {
+        case (37, true, _): // ⌘L
             store.send(.webPaneFocusURLBar(paneID: focusedID))
             return true
-        case (15, true): // ⌘R
+        case (15, true, _): // ⌘R
             store.send(.workspaces(.element(
                 id: id,
                 action: .webPaneReload(paneID: focusedID, hard: false)
             )))
             return true
-        case (33, true): // ⌘[
+        case (33, true, _): // ⌘[
             if urlBarIsEditing { return nil } // fall through to focusPreviousPane
             store.send(.workspaces(.element(
                 id: id,
                 action: .webPaneBack(paneID: focusedID)
             )))
             return true
-        case (30, true): // ⌘]
+        case (30, true, _): // ⌘]
             if urlBarIsEditing { return nil }
             store.send(.workspaces(.element(
                 id: id,
                 action: .webPaneForward(paneID: focusedID)
             )))
+            return true
+        case (17, true, _): // ⌘T → new tab
+            store.send(.webPaneOpenNewTab(paneID: focusedID, url: nil))
+            return true
+        case (13, true, _): // ⌘W → close tab (falls through to closePane on the last tab)
+            guard let webState = workspace.webPanes[focusedID],
+                  webState.tabs.count > 1,
+                  let activeTabID = webState.activeTab?.id else { return nil }
+            store.send(.workspaces(.element(
+                id: id,
+                action: .webPaneTabClose(paneID: focusedID, tabID: activeTabID)
+            )))
+            return true
+        case (33, false, true): // ⌘⇧[ → previous tab
+            if urlBarIsEditing { return nil }
+            store.send(.webPaneTabCycleFocused(offset: -1))
+            return true
+        case (30, false, true): // ⌘⇧] → next tab
+            if urlBarIsEditing { return nil }
+            store.send(.webPaneTabCycleFocused(offset: 1))
             return true
         default:
             return nil
@@ -382,6 +403,37 @@ final class PaneShortcutMonitor {
         case .webReload:
             return handleWebAction(activeWorkspaceID: id) { paneID in
                 .workspaces(.element(id: id, action: .webPaneReload(paneID: paneID, hard: false)))
+            }
+
+        case .webTabNew:
+            return handleWebAction(activeWorkspaceID: id) { paneID in
+                .webPaneOpenNewTab(paneID: paneID, url: nil)
+            }
+
+        case .webTabClose:
+            // Single-tab panes fall through (returns false) so the
+            // binding doesn't no-op — the user's keymap can route ⌘W
+            // to the workspace-level close-pane action instead.
+            guard let workspace = store.workspaces[id: id],
+                  let focusedID = workspace.focusedPaneID,
+                  workspace.panes[id: focusedID]?.type == .web,
+                  let webState = workspace.webPanes[focusedID],
+                  webState.tabs.count > 1,
+                  let activeTabID = webState.activeTab?.id else { return false }
+            store.send(.workspaces(.element(
+                id: id,
+                action: .webPaneTabClose(paneID: focusedID, tabID: activeTabID)
+            )))
+            return true
+
+        case .webTabPrev:
+            return handleWebAction(activeWorkspaceID: id) { _ in
+                .webPaneTabCycleFocused(offset: -1)
+            }
+
+        case .webTabNext:
+            return handleWebAction(activeWorkspaceID: id) { _ in
+                .webPaneTabCycleFocused(offset: 1)
             }
 
         default:

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -115,6 +115,32 @@ struct ContentView: View {
                                 ),
                                 reply: nil
                             ))
+                        },
+                        webPanes: workspace.webPanes,
+                        webPaneURLFocusToken: store.webPaneURLFocusTokens,
+                        onWebNavigate: { paneID, url in
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .webPaneNavigate(paneID: paneID, url: url)
+                            )))
+                        },
+                        onWebBack: { paneID in
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .webPaneBack(paneID: paneID)
+                            )))
+                        },
+                        onWebForward: { paneID in
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .webPaneForward(paneID: paneID)
+                            )))
+                        },
+                        onWebReload: { paneID in
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .webPaneReload(paneID: paneID, hard: false)
+                            )))
                         }
                     )
                 } else {
@@ -238,6 +264,28 @@ struct ContentView: View {
                       let paneID = surfaceManager.paneID(for: surface) else { return }
                 // Route through AppReducer for cross-workspace support
                 store.send(.surfaceTitleChanged(paneID: paneID, title: title))
+            }
+            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.stateDidChangeNotification)) { notification in
+                // WKWebView KVO fired for url/title — push the new
+                // values into the workspace reducer so persistence,
+                // close/reopen snapshots, pane titles, and the CLI
+                // `nex web url` reply stay in sync with what the
+                // user actually has on screen (link clicks, back/
+                // forward, redirects, etc.).
+                guard let info = notification.userInfo,
+                      let paneID = info["paneID"] as? UUID,
+                      let tabID = info["tabID"] as? UUID else { return }
+                let url = (info["url"] as? String) ?? ""
+                let title = (info["title"] as? String) ?? ""
+                guard let workspace = store.workspaces.first(where: {
+                    $0.webPanes[paneID] != nil
+                }) else { return }
+                store.send(.workspaces(.element(
+                    id: workspace.id,
+                    action: .webPaneStateChanged(
+                        paneID: paneID, tabID: tabID, url: url, title: title
+                    )
+                )))
             }
             .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.surfacePwdNotification)) { notification in
                 guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -200,6 +200,16 @@ struct ContentView: View {
                         },
                         onWebBatchCancel: { paneID in
                             store.send(.webBatchInspectCancel(paneID: paneID))
+                        },
+                        favourites: store.favourites,
+                        onToggleFavourite: { url, title in
+                            store.send(.toggleFavourite(url: url, title: title))
+                        },
+                        onOpenFavourite: { paneID, url in
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .webPaneNavigate(paneID: paneID, url: url)
+                            )))
                         }
                     )
                 } else {

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -193,6 +193,9 @@ struct ContentView: View {
                         onWebBatchCancel: { paneID in
                             store.send(.webBatchInspectCancel(paneID: paneID))
                         },
+                        onWebTogglePrivate: { paneID in
+                            store.send(.webPaneSetPrivate(paneID: paneID, enabled: nil))
+                        },
                         favourites: store.favourites,
                         onToggleFavourite: { url, title in
                             store.send(.toggleFavourite(url: url, title: title))

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -141,6 +141,21 @@ struct ContentView: View {
                                 id: activeID,
                                 action: .webPaneReload(paneID: paneID, hard: false)
                             )))
+                        },
+                        onWebTabSelect: { paneID, tabID in
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .webPaneTabSelect(paneID: paneID, tabID: tabID)
+                            )))
+                        },
+                        onWebTabClose: { paneID, tabID in
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .webPaneTabClose(paneID: paneID, tabID: tabID)
+                            )))
+                        },
+                        onWebTabNew: { paneID in
+                            store.send(.webPaneOpenNewTab(paneID: paneID, url: nil))
                         }
                     )
                 } else {

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -157,16 +157,8 @@ struct ContentView: View {
                         onWebTabNew: { paneID in
                             store.send(.webPaneOpenNewTab(paneID: paneID, url: nil))
                         },
-                        onWebArmInspectorPickup: { paneID, sendTo in
-                            store.send(.webPaneArmInspectorViaUI(
-                                paneID: paneID, sendTo: sendTo
-                            ))
-                        },
-                        onWebDisarmInspectorPickup: { paneID in
-                            store.send(.webPaneDisarmInspectorViaUI(paneID: paneID))
-                        },
-                        onWebStartBatchInspect: { paneID, sendTo in
-                            store.send(.webBatchInspectStart(paneID: paneID, sendTo: sendTo))
+                        onWebTogglePickup: { paneID in
+                            store.send(.webBatchInspectToggle(paneID: paneID))
                         },
                         onWebBatchItemCommentChanged: { paneID, itemID, comment in
                             store.send(.workspaces(.element(
@@ -195,8 +187,8 @@ struct ContentView: View {
                                 paneID: paneID, itemID: itemID, origin: .panel
                             ))
                         },
-                        onWebBatchSend: { paneID in
-                            store.send(.webBatchInspectSend(paneID: paneID))
+                        onWebBatchSend: { paneID, sendTo in
+                            store.send(.webBatchInspectSend(paneID: paneID, sendTo: sendTo))
                         },
                         onWebBatchCancel: { paneID in
                             store.send(.webBatchInspectCancel(paneID: paneID))

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -156,6 +156,50 @@ struct ContentView: View {
                         },
                         onWebTabNew: { paneID in
                             store.send(.webPaneOpenNewTab(paneID: paneID, url: nil))
+                        },
+                        onWebArmInspectorPickup: { paneID, sendTo in
+                            store.send(.webPaneArmInspectorViaUI(
+                                paneID: paneID, sendTo: sendTo
+                            ))
+                        },
+                        onWebDisarmInspectorPickup: { paneID in
+                            store.send(.webPaneDisarmInspectorViaUI(paneID: paneID))
+                        },
+                        onWebStartBatchInspect: { paneID, sendTo in
+                            store.send(.webBatchInspectStart(paneID: paneID, sendTo: sendTo))
+                        },
+                        onWebBatchItemCommentChanged: { paneID, itemID, comment in
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .webBatchItemCommentChanged(
+                                    paneID: paneID, itemID: itemID, comment: comment
+                                )
+                            )))
+                            // Push to the page popover too so it
+                            // mirrors the panel edit when shown for
+                            // the same item (no-op if its textarea
+                            // currently holds keyboard focus).
+                            store.send(.pushBatchCommentToPage(
+                                paneID: paneID, itemID: itemID, comment: comment
+                            ))
+                        },
+                        onWebBatchItemRemoved: { paneID, itemID in
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .webBatchItemRemoved(paneID: paneID, itemID: itemID)
+                            )))
+                            store.send(.syncBatchMarkers(paneID: paneID))
+                        },
+                        onWebBatchRowTapped: { paneID, itemID in
+                            store.send(.webBatchFocusItem(
+                                paneID: paneID, itemID: itemID, origin: .panel
+                            ))
+                        },
+                        onWebBatchSend: { paneID in
+                            store.send(.webBatchInspectSend(paneID: paneID))
+                        },
+                        onWebBatchCancel: { paneID in
+                            store.send(.webBatchInspectCancel(paneID: paneID))
                         }
                     )
                 } else {
@@ -301,6 +345,106 @@ struct ContentView: View {
                         paneID: paneID, tabID: tabID, url: url, title: title
                     )
                 )))
+            }
+            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.consoleLineNotification)) { notification in
+                // Console capture: every wrapped console.* call and
+                // every window error fires here. Push into the pane's
+                // ring buffer so `nex web console` can drain it.
+                guard let info = notification.userInfo,
+                      let paneID = info["paneID"] as? UUID,
+                      let tabID = info["tabID"] as? UUID,
+                      let levelRaw = info["level"] as? String,
+                      let level = ConsoleLine.Level(rawValue: levelRaw) else { return }
+                let message = (info["message"] as? String) ?? ""
+                let url = (info["url"] as? String) ?? ""
+                let lineNumber = info["lineNumber"] as? Int
+                let columnNumber = info["columnNumber"] as? Int
+                guard let workspace = store.workspaces.first(where: {
+                    $0.webPanes[paneID] != nil
+                }) else { return }
+                let line = ConsoleLine(
+                    tabID: tabID,
+                    level: level,
+                    message: message,
+                    url: url,
+                    lineNumber: lineNumber,
+                    columnNumber: columnNumber,
+                    capturedAt: Date()
+                )
+                store.send(.workspaces(.element(
+                    id: workspace.id,
+                    action: .webConsoleLineReceived(paneID: paneID, line: line)
+                )))
+            }
+            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchMarkerClickedNotification)) { notification in
+                // User clicked a numbered badge on the page — focus
+                // the matching row in the side panel. Skip the
+                // page-side highlight (the badge was just under their
+                // cursor; re-pulsing it would be redundant).
+                guard let info = notification.userInfo,
+                      let paneID = info["paneID"] as? UUID,
+                      let itemID = info["itemID"] as? UUID else { return }
+                store.send(.webBatchFocusItem(
+                    paneID: paneID, itemID: itemID, origin: .page
+                ))
+            }
+            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchCommentEditedNotification)) { notification in
+                // User edited the comment in the page popover.
+                // Push it into state via the usual workspace action,
+                // skipping the panel→page sync (origin == .page) so
+                // we don't bounce the value back into JS and clobber
+                // the textarea cursor.
+                guard let info = notification.userInfo,
+                      let paneID = info["paneID"] as? UUID,
+                      let itemID = info["itemID"] as? UUID,
+                      let comment = info["comment"] as? String,
+                      let workspace = store.workspaces.first(where: {
+                          $0.webPanes[paneID] != nil
+                      }) else { return }
+                store.send(.workspaces(.element(
+                    id: workspace.id,
+                    action: .webBatchItemCommentChanged(
+                        paneID: paneID, itemID: itemID, comment: comment
+                    )
+                )))
+            }
+            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchPopoverDismissedNotification)) { notification in
+                // Done / Esc in the page popover. Clear focus so
+                // the popover and focus ring hide; user can pick
+                // the next element.
+                guard let info = notification.userInfo,
+                      let paneID = info["paneID"] as? UUID else { return }
+                store.send(.webBatchDismissPopover(paneID: paneID))
+            }
+            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchItemRemovedFromPopoverNotification)) { notification in
+                // Remove button in the page popover — same effect as
+                // the panel's ❌, plus a marker re-sync so the badge
+                // disappears.
+                guard let info = notification.userInfo,
+                      let paneID = info["paneID"] as? UUID,
+                      let itemID = info["itemID"] as? UUID,
+                      let workspace = store.workspaces.first(where: {
+                          $0.webPanes[paneID] != nil
+                      }) else { return }
+                store.send(.workspaces(.element(
+                    id: workspace.id,
+                    action: .webBatchItemRemoved(paneID: paneID, itemID: itemID)
+                )))
+                store.send(.syncBatchMarkers(paneID: paneID))
+            }
+            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.inspectResultNotification)) { notification in
+                // Picker delivered a click — sanitise the raw dict
+                // here so it crosses into the reducer as a typed,
+                // Equatable struct (Action enums must be Equatable).
+                guard let info = notification.userInfo,
+                      let paneID = info["paneID"] as? UUID,
+                      let tabID = info["tabID"] as? UUID,
+                      let payload = info["payload"] as? [String: Any],
+                      let result = InspectPayloadSanitiser.decode(payload, tabID: tabID)
+                else { return }
+                store.send(.webInspectPayloadReceived(
+                    paneID: paneID, result: result
+                ))
             }
             .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.surfacePwdNotification)) { notification in
                 guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -55,6 +55,10 @@ struct PaneGridView: View {
     var onWebBatchRowTapped: ((UUID, UUID) -> Void)?
     var onWebBatchSend: ((UUID) -> Void)?
     var onWebBatchCancel: ((UUID) -> Void)?
+    /// Global web favourites — surfaced in every web pane's chrome.
+    var favourites: [Favourite] = []
+    var onToggleFavourite: ((String, String) -> Void)?
+    var onOpenFavourite: ((UUID, String) -> Void)?
 
     @Environment(\.ghosttyConfig) private var ghosttyConfig
     @Environment(\.surfaceManager) private var surfaceManager
@@ -268,7 +272,14 @@ struct PaneGridView: View {
                         onWebBatchRowTapped?(pane.id, itemID)
                     },
                     onBatchSend: { onWebBatchSend?(pane.id) },
-                    onBatchCancel: { onWebBatchCancel?(pane.id) }
+                    onBatchCancel: { onWebBatchCancel?(pane.id) },
+                    favourites: favourites,
+                    onToggleFavourite: { url, title in
+                        onToggleFavourite?(url, title)
+                    },
+                    onOpenFavourite: { url in
+                        onOpenFavourite?(pane.id, url)
+                    }
                 )
             }
         }

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -44,6 +44,17 @@ struct PaneGridView: View {
     var onWebTabSelect: ((UUID, UUID) -> Void)?
     var onWebTabClose: ((UUID, UUID) -> Void)?
     var onWebTabNew: ((UUID) -> Void)?
+    /// UI element-pickup arm. `paneID` is the source web pane;
+    /// `sendTo` is the destination pane (nil = queue locally).
+    var onWebArmInspectorPickup: ((UUID, UUID?) -> Void)?
+    var onWebDisarmInspectorPickup: ((UUID) -> Void)?
+    /// Begin a batch-annotate session on the source web pane.
+    var onWebStartBatchInspect: ((UUID, UUID?) -> Void)?
+    var onWebBatchItemCommentChanged: ((UUID, UUID, String) -> Void)?
+    var onWebBatchItemRemoved: ((UUID, UUID) -> Void)?
+    var onWebBatchRowTapped: ((UUID, UUID) -> Void)?
+    var onWebBatchSend: ((UUID) -> Void)?
+    var onWebBatchCancel: ((UUID) -> Void)?
 
     @Environment(\.ghosttyConfig) private var ghosttyConfig
     @Environment(\.surfaceManager) private var surfaceManager
@@ -236,7 +247,28 @@ struct PaneGridView: View {
                     onReload: { onWebReload?(pane.id) },
                     onTabSelect: { tabID in onWebTabSelect?(pane.id, tabID) },
                     onTabClose: { tabID in onWebTabClose?(pane.id, tabID) },
-                    onTabNew: { onWebTabNew?(pane.id) }
+                    onTabNew: { onWebTabNew?(pane.id) },
+                    availableInspectTargets: inspectTargets(excluding: pane.id),
+                    inspectorArmed: webPanes[pane.id]?.inspectorArmed ?? false,
+                    onArmInspectorPickup: { sendTo in
+                        onWebArmInspectorPickup?(pane.id, sendTo)
+                    },
+                    onDisarmInspectorPickup: { onWebDisarmInspectorPickup?(pane.id) },
+                    batchInspect: webPanes[pane.id]?.batchInspect,
+                    onStartBatchInspect: { sendTo in
+                        onWebStartBatchInspect?(pane.id, sendTo)
+                    },
+                    onBatchItemCommentChanged: { itemID, comment in
+                        onWebBatchItemCommentChanged?(pane.id, itemID, comment)
+                    },
+                    onBatchItemRemoved: { itemID in
+                        onWebBatchItemRemoved?(pane.id, itemID)
+                    },
+                    onBatchRowTapped: { itemID in
+                        onWebBatchRowTapped?(pane.id, itemID)
+                    },
+                    onBatchSend: { onWebBatchSend?(pane.id) },
+                    onBatchCancel: { onWebBatchCancel?(pane.id) }
                 )
             }
         }
@@ -336,6 +368,32 @@ struct PaneGridView: View {
             .frame(width: overlayRect.width, height: overlayRect.height)
             .offset(x: overlayRect.origin.x, y: overlayRect.origin.y)
             .allowsHitTesting(false)
+    }
+
+    /// Build the dropdown entries for the web pane's inspect-pickup
+    /// button: every other shell pane in the same workspace,
+    /// labelled by its tag (or working-directory tail when no tag is
+    /// set). The source web pane is excluded so users don't
+    /// accidentally pipe the payload back into the page they're
+    /// inspecting, and non-shell panes (markdown / scratchpad / diff
+    /// / web) are filtered out because they have no terminal surface
+    /// for `paneSendText` to write to.
+    private func inspectTargets(excluding sourcePaneID: UUID) -> [InspectTargetOption] {
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? ""
+        return panes.compactMap { pane -> InspectTargetOption? in
+            guard pane.id != sourcePaneID else { return nil }
+            guard pane.type == .shell else { return nil }
+            let label: String = {
+                if let tag = pane.label, !tag.isEmpty { return tag }
+                var cwd = pane.workingDirectory
+                if !home.isEmpty, cwd.hasPrefix(home) {
+                    cwd = "~" + cwd.dropFirst(home.count)
+                }
+                let lastComponent = (cwd as NSString).lastPathComponent
+                return "shell: \(lastComponent)"
+            }()
+            return InspectTargetOption(id: pane.id, label: label)
+        }
     }
 
     private func postMarkdownCopy(_ paneID: UUID, kind: MarkdownCopyKind) {

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -55,6 +55,10 @@ struct PaneGridView: View {
     /// nil = drop into the local inspect-result queue.
     var onWebBatchSend: ((UUID, UUID?) -> Void)?
     var onWebBatchCancel: ((UUID) -> Void)?
+    /// Flip the per-pane private mode flag. Reducer destroys the
+    /// coordinator, the host then rebuilds against the new store on
+    /// the next SwiftUI pass.
+    var onWebTogglePrivate: ((UUID) -> Void)?
     /// Global web favourites — surfaced in every web pane's chrome.
     var favourites: [Favourite] = []
     var onToggleFavourite: ((String, String) -> Void)?
@@ -243,6 +247,7 @@ struct PaneGridView: View {
                     paneID: pane.id,
                     tabs: webPanes[pane.id]?.tabs ?? [],
                     activeTabID: webPanes[pane.id]?.activeTabID,
+                    isPrivate: webPanes[pane.id]?.isPrivate ?? false,
                     isFocused: pane.id == focusedPaneID,
                     focusURLBarToken: webPaneURLFocusToken[pane.id] ?? 0,
                     onNavigate: { url in onWebNavigate?(pane.id, url) },
@@ -252,6 +257,7 @@ struct PaneGridView: View {
                     onTabSelect: { tabID in onWebTabSelect?(pane.id, tabID) },
                     onTabClose: { tabID in onWebTabClose?(pane.id, tabID) },
                     onTabNew: { onWebTabNew?(pane.id) },
+                    onTogglePrivate: { onWebTogglePrivate?(pane.id) },
                     availableInspectTargets: inspectTargets(excluding: pane.id),
                     inspectorArmed: (webPanes[pane.id]?.batchInspect?.panelVisible) ?? false,
                     batchInspect: webPanes[pane.id]?.batchInspect,

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -44,16 +44,16 @@ struct PaneGridView: View {
     var onWebTabSelect: ((UUID, UUID) -> Void)?
     var onWebTabClose: ((UUID, UUID) -> Void)?
     var onWebTabNew: ((UUID) -> Void)?
-    /// UI element-pickup arm. `paneID` is the source web pane;
-    /// `sendTo` is the destination pane (nil = queue locally).
-    var onWebArmInspectorPickup: ((UUID, UUID?) -> Void)?
-    var onWebDisarmInspectorPickup: ((UUID) -> Void)?
-    /// Begin a batch-annotate session on the source web pane.
-    var onWebStartBatchInspect: ((UUID, UUID?) -> Void)?
+    /// Toggle the element-pickup panel on a web pane. Reducer-side
+    /// logic decides between start / hide / show based on the
+    /// current state of `batchInspect` and `panelVisible`.
+    var onWebTogglePickup: ((UUID) -> Void)?
     var onWebBatchItemCommentChanged: ((UUID, UUID, String) -> Void)?
     var onWebBatchItemRemoved: ((UUID, UUID) -> Void)?
     var onWebBatchRowTapped: ((UUID, UUID) -> Void)?
-    var onWebBatchSend: ((UUID) -> Void)?
+    /// Send the batch. Second arg is the destination pane id —
+    /// nil = drop into the local inspect-result queue.
+    var onWebBatchSend: ((UUID, UUID?) -> Void)?
     var onWebBatchCancel: ((UUID) -> Void)?
     /// Global web favourites — surfaced in every web pane's chrome.
     var favourites: [Favourite] = []
@@ -253,15 +253,10 @@ struct PaneGridView: View {
                     onTabClose: { tabID in onWebTabClose?(pane.id, tabID) },
                     onTabNew: { onWebTabNew?(pane.id) },
                     availableInspectTargets: inspectTargets(excluding: pane.id),
-                    inspectorArmed: webPanes[pane.id]?.inspectorArmed ?? false,
-                    onArmInspectorPickup: { sendTo in
-                        onWebArmInspectorPickup?(pane.id, sendTo)
-                    },
-                    onDisarmInspectorPickup: { onWebDisarmInspectorPickup?(pane.id) },
+                    inspectorArmed: (webPanes[pane.id]?.batchInspect?.panelVisible) ?? false,
                     batchInspect: webPanes[pane.id]?.batchInspect,
-                    onStartBatchInspect: { sendTo in
-                        onWebStartBatchInspect?(pane.id, sendTo)
-                    },
+                    lastBatchTarget: webPanes[pane.id]?.lastBatchTarget,
+                    onTogglePickup: { onWebTogglePickup?(pane.id) },
                     onBatchItemCommentChanged: { itemID, comment in
                         onWebBatchItemCommentChanged?(pane.id, itemID, comment)
                     },
@@ -271,7 +266,7 @@ struct PaneGridView: View {
                     onBatchRowTapped: { itemID in
                         onWebBatchRowTapped?(pane.id, itemID)
                     },
-                    onBatchSend: { onWebBatchSend?(pane.id) },
+                    onBatchSend: { sendTo in onWebBatchSend?(pane.id, sendTo) },
                     onBatchCancel: { onWebBatchCancel?(pane.id) },
                     favourites: favourites,
                     onToggleFavourite: { url, title in

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -32,6 +32,15 @@ struct PaneGridView: View {
     var otherWorkspaces: [(id: UUID, name: String)] = []
     var onRenamePane: ((UUID) -> Void)?
     var onMovePaneToWorkspace: ((UUID, UUID) -> Void)?
+    /// Sidecar state for `.web` panes in this workspace. Keyed by pane id.
+    var webPanes: [UUID: WebPaneState] = [:]
+    /// URL bar focus token bumped by ⌘L. Used by `WebPaneView` to
+    /// promote the URL bar to first responder for the matching pane.
+    var webPaneURLFocusToken: [UUID: UInt64] = [:]
+    var onWebNavigate: ((UUID, String) -> Void)?
+    var onWebBack: ((UUID) -> Void)?
+    var onWebForward: ((UUID) -> Void)?
+    var onWebReload: ((UUID) -> Void)?
 
     @Environment(\.ghosttyConfig) private var ghosttyConfig
     @Environment(\.surfaceManager) private var surfaceManager
@@ -211,6 +220,17 @@ struct PaneGridView: View {
                     backgroundOpacity: ghosttyConfig.backgroundOpacity,
                     fontSize: pane.markdownFontSize
                 )
+            case .web:
+                WebPaneView(
+                    paneID: pane.id,
+                    tab: webPanes[pane.id]?.activeTab,
+                    isFocused: pane.id == focusedPaneID,
+                    focusURLBarToken: webPaneURLFocusToken[pane.id] ?? 0,
+                    onNavigate: { url in onWebNavigate?(pane.id, url) },
+                    onBack: { onWebBack?(pane.id) },
+                    onForward: { onWebForward?(pane.id) },
+                    onReload: { onWebReload?(pane.id) }
+                )
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -229,7 +249,7 @@ struct PaneGridView: View {
             }
         }
         .background {
-            if pane.type == .markdown || pane.type == .scratchpad || pane.type == .diff {
+            if pane.type == .markdown || pane.type == .scratchpad || pane.type == .diff || pane.type == .web {
                 Color(nsColor: ghosttyConfig.backgroundColor)
                     .opacity(ghosttyConfig.backgroundOpacity)
             }

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -41,6 +41,9 @@ struct PaneGridView: View {
     var onWebBack: ((UUID) -> Void)?
     var onWebForward: ((UUID) -> Void)?
     var onWebReload: ((UUID) -> Void)?
+    var onWebTabSelect: ((UUID, UUID) -> Void)?
+    var onWebTabClose: ((UUID, UUID) -> Void)?
+    var onWebTabNew: ((UUID) -> Void)?
 
     @Environment(\.ghosttyConfig) private var ghosttyConfig
     @Environment(\.surfaceManager) private var surfaceManager
@@ -223,13 +226,17 @@ struct PaneGridView: View {
             case .web:
                 WebPaneView(
                     paneID: pane.id,
-                    tab: webPanes[pane.id]?.activeTab,
+                    tabs: webPanes[pane.id]?.tabs ?? [],
+                    activeTabID: webPanes[pane.id]?.activeTabID,
                     isFocused: pane.id == focusedPaneID,
                     focusURLBarToken: webPaneURLFocusToken[pane.id] ?? 0,
                     onNavigate: { url in onWebNavigate?(pane.id, url) },
                     onBack: { onWebBack?(pane.id) },
                     onForward: { onWebForward?(pane.id) },
-                    onReload: { onWebReload?(pane.id) }
+                    onReload: { onWebReload?(pane.id) },
+                    onTabSelect: { tabID in onWebTabSelect?(pane.id, tabID) },
+                    onTabClose: { tabID in onWebTabClose?(pane.id, tabID) },
+                    onTabNew: { onWebTabNew?(pane.id) }
                 )
             }
         }

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -43,6 +43,11 @@ struct PaneHeaderView: View {
                     .font(.system(size: 10))
                     .foregroundStyle(.secondary)
                     .frame(width: 10, height: 10)
+            } else if pane.type == .web {
+                Image(systemName: "globe")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 10, height: 10)
             } else {
                 Circle()
                     .fill(statusDotColor)

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -2,31 +2,47 @@ import AppKit
 import ComposableArchitecture
 import SwiftUI
 
+/// Identifier for the Settings TabView's tabs, used for deep-linking
+/// from the web pane's "Manage favourites…" menu.
+enum SettingsTab: Hashable { case general, appearance, repos, keybindings, web }
+
 struct SettingsView: View {
     let store: StoreOf<AppReducer>
 
+    @State private var selectedTab: SettingsTab = .general
+
     var body: some View {
         WithPerceptionTracking {
-            TabView {
+            TabView(selection: $selectedTab) {
                 GeneralSettingsView(appStore: store)
                     .tabItem {
                         Label("General", systemImage: "gear")
                     }
+                    .tag(SettingsTab.general)
 
                 AppearanceSettingsView(store: store.scope(state: \.settings, action: \.settings))
                     .tabItem {
                         Label("Appearance", systemImage: "paintbrush")
                     }
+                    .tag(SettingsTab.appearance)
 
                 RepoRegistryView(store: store)
                     .tabItem {
                         Label("Repositories", systemImage: "externaldrive")
                     }
+                    .tag(SettingsTab.repos)
 
                 KeybindingsSettingsView(store: store)
                     .tabItem {
                         Label("Keybindings", systemImage: "command")
                     }
+                    .tag(SettingsTab.keybindings)
+
+                WebFavouritesSettingsView(store: store)
+                    .tabItem {
+                        Label("Web", systemImage: "globe")
+                    }
+                    .tag(SettingsTab.web)
             }
             .frame(
                 minWidth: 500, idealWidth: 600, maxWidth: .infinity,
@@ -39,6 +55,22 @@ struct SettingsView: View {
             // would leave the toggle stale until next launch (issue #129).
             .onReceive(NotificationCenter.default.publisher(for: QuitGate.confirmQuitChangedNotification)) { _ in
                 store.send(.settings(.refreshConfirmQuitWhenActive))
+            }
+            // Deep-link from a web pane's "Manage favourites…" menu.
+            // `pendingSettingsTab` covers cold-open (notification has
+            // no listener yet); `.onReceive` covers re-opens of an
+            // already-mounted Settings scene.
+            .onAppear {
+                if let pending = WebPaneChrome.pendingSettingsTab {
+                    selectedTab = pending
+                    WebPaneChrome.pendingSettingsTab = nil
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: WebPaneChrome.openSettingsTabNotification)) { note in
+                if let tab = note.object as? SettingsTab {
+                    selectedTab = tab
+                }
+                WebPaneChrome.pendingSettingsTab = nil
             }
         }
     }
@@ -282,5 +314,107 @@ private struct AppearanceSettingsView: View {
                 }
             }
         )
+    }
+}
+
+private struct WebFavouritesSettingsView: View {
+    let store: StoreOf<AppReducer>
+    @State private var selection: Favourite.ID?
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                if store.favourites.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "star")
+                            .font(.system(size: 28))
+                            .foregroundStyle(.tertiary)
+                        Text("No favourites yet")
+                            .foregroundStyle(.secondary)
+                        Text("Click the star button in a web pane's URL bar to save one.")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List(selection: $selection) {
+                        ForEach(store.favourites) { fav in
+                            FavouriteRow(
+                                favourite: fav,
+                                onRename: { newTitle in
+                                    store.send(.renameFavourite(id: fav.id, title: newTitle))
+                                },
+                                onRemove: {
+                                    store.send(.removeFavourite(id: fav.id))
+                                }
+                            )
+                            .tag(fav.id)
+                        }
+                        .onMove { source, destination in
+                            guard let from = source.first else { return }
+                            store.send(.moveFavourite(fromIndex: from, toIndex: destination))
+                        }
+                    }
+                    .listStyle(.inset)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+private struct FavouriteRow: View {
+    let favourite: Favourite
+    let onRename: (String) -> Void
+    let onRemove: () -> Void
+
+    @State private var editingTitle: String
+    @FocusState private var isFocused: Bool
+
+    init(favourite: Favourite, onRename: @escaping (String) -> Void, onRemove: @escaping () -> Void) {
+        self.favourite = favourite
+        self.onRename = onRename
+        self.onRemove = onRemove
+        _editingTitle = State(initialValue: favourite.title)
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "star.fill")
+                .foregroundStyle(Color.yellow)
+                .font(.system(size: 11))
+            VStack(alignment: .leading, spacing: 2) {
+                TextField("Title", text: $editingTitle)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, weight: .medium))
+                    .focused($isFocused)
+                    .onSubmit(commitRename)
+                    .onChange(of: isFocused) { _, focused in
+                        if !focused { commitRename() }
+                    }
+                Text(favourite.url)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Button(action: onRemove) {
+                Image(systemName: "trash")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Remove favourite")
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func commitRename() {
+        let trimmed = editingTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed != favourite.title {
+            onRename(trimmed)
+        }
     }
 }

--- a/Nex/Features/WebPane/Favourites.swift
+++ b/Nex/Features/WebPane/Favourites.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+struct Favourite: Equatable, Identifiable, Codable {
+    let id: UUID
+    var url: String
+    var title: String
+    let createdAt: Date
+
+    init(id: UUID = UUID(), url: String, title: String = "", createdAt: Date = Date()) {
+        self.id = id
+        self.url = url
+        self.title = title
+        self.createdAt = createdAt
+    }
+
+    /// Falls back through title -> host -> raw url so a favourite
+    /// captured before a page title arrives still shows something.
+    var displayLabel: String {
+        if !title.isEmpty { return title }
+        if let host = URL(string: url)?.host, !host.isEmpty { return host }
+        return url
+    }
+}
+
+enum FavouritesStorage {
+    static let defaultsKey = "web.favourites"
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    static func decode(_ json: String?) -> [Favourite] {
+        guard let json, !json.isEmpty,
+              let data = json.data(using: .utf8) else { return [] }
+        return (try? decoder.decode([Favourite].self, from: data)) ?? []
+    }
+
+    static func encode(_ favourites: [Favourite]) -> String {
+        guard let data = try? encoder.encode(favourites),
+              let json = String(data: data, encoding: .utf8) else { return "[]" }
+        return json
+    }
+}
+
+extension [Favourite] {
+    /// Match by URL, normalising only the parts that are
+    /// case-insensitive by spec (scheme + host) and stripping trailing
+    /// slashes. Paths and query strings stay case-sensitive — most
+    /// servers treat `/API` and `/api` as different resources.
+    func firstMatching(url: String) -> Favourite? {
+        let needle = Self.normalised(url)
+        return first { Self.normalised($0.url) == needle }
+    }
+
+    fileprivate static func normalised(_ url: String) -> String {
+        let trimmed = url.trimmingCharacters(in: .whitespaces)
+        var stripped: String
+        if var comps = URLComponents(string: trimmed) {
+            comps.scheme = comps.scheme?.lowercased()
+            comps.host = comps.host?.lowercased()
+            stripped = comps.string ?? trimmed
+        } else {
+            stripped = trimmed
+        }
+        while stripped.hasSuffix("/") {
+            stripped.removeLast()
+        }
+        return stripped
+    }
+}

--- a/Nex/Features/WebPane/InspectPayloadSanitiser.swift
+++ b/Nex/Features/WebPane/InspectPayloadSanitiser.swift
@@ -1,0 +1,247 @@
+import CoreGraphics
+import Foundation
+
+/// Strips dangerous control characters and clamps each field of an
+/// inspect payload to a sensible byte budget before it crosses the
+/// PTY boundary into an agent pane.
+///
+/// Web content can contain ANSI escape sequences (`ESC [ ... m`) or
+/// raw C0 bytes that a terminal will happily interpret — pasting an
+/// element's `outerHTML` should never accidentally reposition the
+/// cursor, switch palette mode, or fire OSC 52 clipboard writes on
+/// the receiver. Cap sizes match the plan (Phase 3 § sanitise):
+///   - outer_html   16 KB
+///   - context_html  4 KB
+///   - attributes per-value 1 KB
+///   - selector / xpath 1 KB
+///
+/// Truncated fields gain a `... [truncated]` marker so the agent
+/// knows the payload isn't complete.
+enum InspectPayloadSanitiser {
+    static let outerHTMLBudget = 16 * 1024
+    static let contextHTMLBudget = 4 * 1024
+    static let attributeValueBudget = 1024
+    static let selectorBudget = 1024
+
+    static let truncationMarker = "... [truncated]"
+
+    /// Shared ISO8601 formatter for inspect/console payload timestamps.
+    /// Why: `ISO8601DateFormatter()` is expensive to instantiate; this is
+    /// called per-inspect-payload, per-console-line, and on every batch
+    /// item, so the formatter is cached once and reused. `nonisolated(unsafe)`
+    /// because the formatter isn't `Sendable` but its `string(from:)` is
+    /// documented thread-safe.
+    nonisolated(unsafe) static let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    /// Decode the raw JSON dictionary the picker JS produced into a
+    /// fully sanitised `InspectResult`. Returns nil only when the
+    /// payload is so malformed there's nothing to surface (missing
+    /// tag / selector / url all empty).
+    static func decode(_ payload: [String: Any], tabID: UUID) -> InspectResult? {
+        let selector = clampField(payload["selector"] as? String ?? "", limit: selectorBudget)
+        let xpath = clampField(payload["xpath"] as? String ?? "", limit: selectorBudget)
+        let tag = clampField(payload["tag"] as? String ?? "", limit: 64)
+        let elementID = clampField(payload["element_id"] as? String ?? "", limit: 256)
+        let outerHTML = clampField(payload["outer_html"] as? String ?? "", limit: outerHTMLBudget)
+        let contextHTML = clampField(payload["context_html"] as? String ?? "", limit: contextHTMLBudget)
+        let text = clampField(payload["text"] as? String ?? "", limit: 1024)
+        let url = clampField(payload["url"] as? String ?? "", limit: 4096)
+
+        // Drop genuinely empty payloads (no tag, no selector, no URL —
+        // probably page JS spoofing despite the nonce check on the
+        // Swift side).
+        if selector.isEmpty, tag.isEmpty, url.isEmpty { return nil }
+
+        var attributes: [String: String] = [:]
+        if let raw = payload["attributes"] as? [String: Any] {
+            for (key, value) in raw {
+                let stringValue = (value as? String) ?? String(describing: value)
+                attributes[clampField(key, limit: 128)] =
+                    clampField(stringValue, limit: attributeValueBudget)
+            }
+        }
+
+        var rect = CGRect.zero
+        if let r = payload["rect"] as? [String: Any] {
+            let x = (r["x"] as? Double) ?? 0
+            let y = (r["y"] as? Double) ?? 0
+            let w = (r["w"] as? Double) ?? 0
+            let h = (r["h"] as? Double) ?? 0
+            rect = CGRect(x: x, y: y, width: w, height: h)
+        }
+
+        return InspectResult(
+            tabID: tabID,
+            selector: selector,
+            xpath: xpath,
+            tag: tag,
+            elementID: elementID,
+            outerHTML: outerHTML,
+            attributes: attributes,
+            rect: rect,
+            text: text,
+            contextHTML: contextHTML,
+            url: url,
+            capturedAt: Date()
+        )
+    }
+
+    /// Format a sanitised `InspectResult` for paste delivery into an
+    /// agent pane via `paneSendText`. Output is a one-line directive
+    /// followed by a fenced JSON block — easy for an LLM to detect
+    /// and parse but human-readable on a terminal.
+    static func formatForPaste(_ result: InspectResult) -> String {
+        let timestamp = isoFormatter.string(from: result.capturedAt)
+
+        // Build the JSON payload manually so the field order is
+        // stable + easy for an agent to scan.
+        var json: [String: Any] = [
+            "selector": result.selector,
+            "xpath": result.xpath,
+            "tag": result.tag,
+            "id": result.elementID,
+            "url": result.url,
+            "text": result.text,
+            "rect": [
+                "x": result.rect.origin.x,
+                "y": result.rect.origin.y,
+                "w": result.rect.size.width,
+                "h": result.rect.size.height
+            ],
+            "attributes": result.attributes,
+            "captured_at": timestamp
+        ]
+        if !result.outerHTML.isEmpty { json["outer_html"] = result.outerHTML }
+        if !result.contextHTML.isEmpty { json["context_html"] = result.contextHTML }
+
+        let body: String = {
+            guard let data = try? JSONSerialization.data(
+                withJSONObject: json,
+                options: [.prettyPrinted, .sortedKeys]
+            ),
+                let s = String(data: data, encoding: .utf8) else { return "{}" }
+            return s
+        }()
+
+        return """
+        # nex inspect \(timestamp)
+        ```json
+        \(body)
+        ```
+        """
+    }
+
+    /// Format a batch of annotated inspect results for paste delivery.
+    /// Emits a single fenced JSON array, with each entry carrying the
+    /// same sanitised fields as `formatForPaste` plus the user-supplied
+    /// `comment`. Header timestamp marks the moment the batch was sent.
+    static func formatBatchForPaste(_ items: [BatchInspectItem]) -> String {
+        let timestamp = isoFormatter.string(from: Date())
+
+        let array: [[String: Any]] = items.map { item in
+            let result = item.result
+            let captured = isoFormatter.string(from: result.capturedAt)
+            var entry: [String: Any] = [
+                "selector": result.selector,
+                "xpath": result.xpath,
+                "tag": result.tag,
+                "id": result.elementID,
+                "url": result.url,
+                "text": result.text,
+                "rect": [
+                    "x": result.rect.origin.x,
+                    "y": result.rect.origin.y,
+                    "w": result.rect.size.width,
+                    "h": result.rect.size.height
+                ],
+                "attributes": result.attributes,
+                "captured_at": captured,
+                "comment": clampField(item.comment, limit: 4 * 1024)
+            ]
+            if !result.outerHTML.isEmpty { entry["outer_html"] = result.outerHTML }
+            if !result.contextHTML.isEmpty { entry["context_html"] = result.contextHTML }
+            return entry
+        }
+
+        let body: String = {
+            guard let data = try? JSONSerialization.data(
+                withJSONObject: array,
+                options: [.prettyPrinted, .sortedKeys]
+            ),
+                let s = String(data: data, encoding: .utf8) else { return "[]" }
+            return s
+        }()
+
+        return """
+        # nex inspect batch \(timestamp) (\(items.count) item\(items.count == 1 ? "" : "s"))
+        ```json
+        \(body)
+        ```
+        """
+    }
+
+    // MARK: - Internals
+
+    /// Strip ANSI escape sequences and C0 control chars (except `\n`
+    /// and `\t`), then byte-clamp to `limit`, appending a truncation
+    /// marker when shorter than the input.
+    static func clampField(_ raw: String, limit: Int) -> String {
+        let stripped = stripUnsafeControlCharacters(raw)
+        if stripped.utf8.count <= limit { return stripped }
+        // Trim on a UTF-8 boundary, leave room for the marker.
+        let budget = max(limit - truncationMarker.utf8.count, 0)
+        var truncated = stripped
+        while truncated.utf8.count > budget {
+            truncated.removeLast()
+        }
+        return truncated + truncationMarker
+    }
+
+    /// Remove ANSI escape sequences (CSI / OSC etc.) and C0 control
+    /// chars except newline + tab. Keeps the output paste-safe on a
+    /// terminal without mangling whitespace inside an HTML snippet.
+    static func stripUnsafeControlCharacters(_ input: String) -> String {
+        guard !input.isEmpty else { return input }
+        var output = String()
+        output.reserveCapacity(input.utf8.count)
+
+        var iterator = input.unicodeScalars.makeIterator()
+        while let scalar = iterator.next() {
+            // ESC at U+001B starts an ANSI sequence. Drop ESC and
+            // skip the rest of the sequence per the rough ANSI
+            // grammar: CSI (`ESC [`) / OSC (`ESC ]`) / two-char
+            // (`ESC <byte>`).
+            if scalar.value == 0x1B {
+                if let next = iterator.next() {
+                    if next.value == 0x5B { // ESC [ → CSI: skip until final byte 0x40–0x7E
+                        while let csiByte = iterator.next() {
+                            if csiByte.value >= 0x40, csiByte.value <= 0x7E { break }
+                        }
+                    } else if next.value == 0x5D { // ESC ] → OSC: skip until BEL or ESC \
+                        while let oscByte = iterator.next() {
+                            if oscByte.value == 0x07 { break } // BEL terminator
+                            if oscByte.value == 0x1B { // ESC \ terminator (ST)
+                                _ = iterator.next()
+                                break
+                            }
+                        }
+                    }
+                    // Two-char sequence (ESC c, ESC =, etc.) — drop both.
+                }
+                continue
+            }
+            // Allow \n (0x0A), \t (0x09); strip every other C0.
+            if scalar.value < 0x20, scalar.value != 0x0A, scalar.value != 0x09 {
+                continue
+            }
+            // Strip DEL (0x7F).
+            if scalar.value == 0x7F { continue }
+            output.unicodeScalars.append(scalar)
+        }
+        return output
+    }
+}

--- a/Nex/Features/WebPane/RingBuffer.swift
+++ b/Nex/Features/WebPane/RingBuffer.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Fixed-capacity ring buffer that pairs each appended value with a
+/// monotonically increasing `seq`. `seq` keeps counting up even after
+/// entries fall off the head, so callers can ask "give me everything
+/// since seq N" without worrying about wraparound or reindexing.
+///
+/// Used by the web pane's console capture (Phase 3): the page can
+/// produce console output faster than any CLI poll, so the buffer
+/// drops oldest silently and the next streamed batch carries a
+/// `dropped: <count>` line so agents know they lost something.
+struct RingBuffer<Element: Equatable>: Equatable {
+    /// One entry in the buffer. `seq` is unique per buffer and never
+    /// recycled — even after the underlying slot is overwritten.
+    struct Entry: Equatable {
+        let seq: UInt64
+        let value: Element
+    }
+
+    let capacity: Int
+    private(set) var entries: [Entry] = []
+    /// Next `seq` to assign. Always strictly greater than every seq
+    /// already in `entries`.
+    private(set) var nextSeq: UInt64 = 0
+    /// How many entries were dropped because the buffer was full.
+    /// Reset by `acknowledgeDrops`.
+    private(set) var droppedSinceLastDrain: Int = 0
+
+    init(capacity: Int) {
+        precondition(capacity > 0, "RingBuffer capacity must be positive")
+        self.capacity = capacity
+        entries.reserveCapacity(capacity)
+    }
+
+    var count: Int { entries.count }
+    var isEmpty: Bool { entries.isEmpty }
+
+    /// Append `value`, evicting the oldest entry when full.
+    /// Increments `droppedSinceLastDrain` on eviction.
+    mutating func append(_ value: Element) {
+        if entries.count >= capacity {
+            entries.removeFirst()
+            droppedSinceLastDrain += 1
+        }
+        entries.append(Entry(seq: nextSeq, value: value))
+        nextSeq &+= 1
+    }
+
+    /// Return every entry whose `seq >= since`. `since == 0` yields
+    /// the whole live buffer. Result is in insertion order.
+    func entries(since: UInt64) -> [Entry] {
+        guard since > 0 else { return entries }
+        // entries[] is monotonically increasing in seq → binary search.
+        var lo = 0
+        var hi = entries.count
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if entries[mid].seq < since {
+                lo = mid + 1
+            } else {
+                hi = mid
+            }
+        }
+        return Array(entries[lo...])
+    }
+
+    /// Caller has consumed a batch; reset the dropped counter so the
+    /// next batch only reports drops since the last drain.
+    mutating func acknowledgeDrops() -> Int {
+        let n = droppedSinceLastDrain
+        droppedSinceLastDrain = 0
+        return n
+    }
+
+    /// Wipe everything. `seq` keeps counting — clearing doesn't reset
+    /// the namespace, so callers polling with `since` see the gap.
+    mutating func clear() {
+        entries.removeAll(keepingCapacity: true)
+    }
+}

--- a/Nex/Features/WebPane/StoragePanel.swift
+++ b/Nex/Features/WebPane/StoragePanel.swift
@@ -1,0 +1,690 @@
+import SwiftUI
+import WebKit
+
+/// Disclosure panel below the URL bar that exposes the per-pane
+/// storage controls: a private-mode toggle and a list of cookies for
+/// the active data store. Mirrors the visual treatment of the
+/// element-pickup panel — same border / background, same compact
+/// footer-row Send-style buttons.
+///
+/// Read/delete go through the pane's coordinator's
+/// `dataStore.httpCookieStore`. The toggle goes through `onTogglePrivate`
+/// up to the reducer, which warns the user before flipping the flag
+/// (toggling between persistent + nonPersistent stores forces a
+/// coordinator rebuild and loses live JS state).
+struct StoragePanel: View {
+    let paneID: UUID
+    let isPrivate: Bool
+    let onTogglePrivate: () -> Void
+    let onClose: () -> Void
+
+    @Environment(\.webPaneStore) private var webPaneStore
+
+    @State private var cookies: [HTTPCookie] = []
+    /// Grouped + sorted view of `cookies`. Cached in @State so body
+    /// invalidations driven by unrelated edits (e.g. typing in an
+    /// inline edit form) don't redo the O(n log n) grouping.
+    @State private var groupedCookies: [CookieDomainGroup] = []
+    @State private var isLoading: Bool = false
+    @State private var showingToggleConfirm: Bool = false
+    @State private var showingClearAllConfirm: Bool = false
+    /// Domains whose accordion is open. Default closed — keeps the
+    /// panel compact when sites pile up.
+    @State private var expandedDomains: Set<String> = []
+    /// Canonical identity (`domain|path|name`) of the cookie whose
+    /// inline edit form is open. nil = no edit form.
+    @State private var editingKey: String?
+    /// Non-nil while an inline create form is open. The string is the
+    /// pre-filled domain (empty = the top-level "any domain" form).
+    @State private var addingDomain: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+
+            privateToggleRow
+
+            Divider().opacity(0.5)
+
+            cookiesSection
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(alignment: .bottom) { Divider() }
+        .onAppear(perform: refreshCookies)
+        .confirmationDialog(
+            isPrivate
+                ? "Disable private mode for this pane?"
+                : "Enable private mode for this pane?",
+            isPresented: $showingToggleConfirm,
+            titleVisibility: .visible
+        ) {
+            Button(isPrivate ? "Disable private mode" : "Enable private mode", role: .destructive) {
+                onTogglePrivate()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(toggleConfirmMessage)
+        }
+        .confirmationDialog(
+            "Clear all site data for this pane?",
+            isPresented: $showingClearAllConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Clear all site data", role: .destructive) {
+                clearAllSiteData()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Removes cookies, local storage, IndexedDB, and caches. Logged-in sessions on this data store will be signed out.")
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: isPrivate ? "lock.fill" : "lock")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(isPrivate ? Color.accentColor : Color.secondary)
+            Text("Storage")
+                .font(.system(size: 12, weight: .semibold))
+            Spacer()
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .frame(width: 16, height: 16)
+                    .contentShape(Rectangle())
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Close storage panel")
+        }
+    }
+
+    private var privateToggleRow: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Private mode")
+                    .font(.system(size: 11, weight: .medium))
+                Text(isPrivate
+                    ? "Cookies + caches discarded on quit; tabs blank on restart."
+                    : "Cookies + caches persist across restarts.")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Toggle("", isOn: Binding(
+                get: { isPrivate },
+                set: { _ in showingToggleConfirm = true }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+            .controlSize(.small)
+        }
+    }
+
+    private var cookiesSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text("Cookies")
+                    .font(.system(size: 11, weight: .medium))
+                Text(cookies.isEmpty ? "" : "(\(cookies.count))")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.6)
+                        .frame(width: 12, height: 12)
+                }
+                Spacer()
+                Button(action: { beginAdd(forDomain: "") }) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 9, weight: .semibold))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Add a cookie")
+
+                Button(action: refreshCookies) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 9, weight: .semibold))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Refresh cookie list")
+
+                Button(role: .destructive, action: { showingClearAllConfirm = true }) {
+                    Image(systemName: "trash")
+                        .font(.system(size: 9, weight: .semibold))
+                        .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.red.opacity(0.85))
+                .help("Clear all site data (cookies, caches, local storage)")
+            }
+
+            // Top-level create form for a brand new domain. Opens
+            // above the domain list so the user sees their input near
+            // the trigger.
+            if addingDomain == "" {
+                CookieEditForm(
+                    initial: .blank(),
+                    allowDomainEdit: true,
+                    onSave: { draft in
+                        save(draft: draft, replacing: nil)
+                    },
+                    onCancel: { addingDomain = nil }
+                )
+                .padding(.vertical, 4)
+            }
+
+            if cookies.isEmpty, addingDomain == nil {
+                Text(isPrivate
+                    ? "No cookies (private mode — fresh on every launch)."
+                    : "No cookies for this data store yet.")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .padding(.vertical, 2)
+            } else if !cookies.isEmpty {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(groupedCookies, id: \.domain) { group in
+                            cookieDomainGroup(group)
+                        }
+                    }
+                }
+                .frame(maxHeight: 220)
+            }
+        }
+    }
+
+    private func cookieDomainGroup(_ group: CookieDomainGroup) -> some View {
+        let isOpen = expandedDomains.contains(group.domain)
+        return VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Button(action: { toggleExpanded(group.domain) }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: isOpen ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 8, weight: .semibold))
+                            .frame(width: 10)
+                            .foregroundStyle(.secondary)
+                        Text(group.domain)
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            .lineLimit(1)
+                        Text("(\(group.cookies.count))")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+
+                Button(action: { beginAdd(forDomain: group.domain) }) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 8, weight: .semibold))
+                        .frame(width: 16, height: 16)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Add cookie for \(group.domain)")
+
+                Button(role: .destructive, action: { delete(cookies: group.cookies) }) {
+                    Image(systemName: "trash")
+                        .font(.system(size: 8))
+                        .frame(width: 16, height: 16)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.red.opacity(0.75))
+                .help("Delete all cookies for \(group.domain)")
+            }
+            .padding(.top, 4)
+            .padding(.bottom, 2)
+
+            if isOpen {
+                if addingDomain == group.domain {
+                    CookieEditForm(
+                        initial: .blank(domain: group.domain),
+                        allowDomainEdit: false,
+                        onSave: { draft in save(draft: draft, replacing: nil) },
+                        onCancel: { addingDomain = nil }
+                    )
+                    .padding(.leading, 14)
+                    .padding(.vertical, 4)
+                }
+                ForEach(group.cookies, id: \.self) { cookie in
+                    cookieRow(cookie)
+                }
+            }
+        }
+    }
+
+    private func cookieRow(_ cookie: HTTPCookie) -> some View {
+        let key = Self.cookieKey(cookie)
+        let isEditing = editingKey == key
+        return VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Button(action: { toggleEditing(key) }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: isEditing ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 7, weight: .semibold))
+                            .frame(width: 10)
+                            .foregroundStyle(.tertiary)
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(cookie.name)
+                                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                .lineLimit(1)
+                            Text(Self.truncatedValue(cookie.value))
+                                .font(.system(size: 10, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                Spacer()
+                Button(role: .destructive, action: { delete(cookies: [cookie]) }) {
+                    Image(systemName: "xmark.circle")
+                        .font(.system(size: 9))
+                        .frame(width: 14, height: 14)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Delete cookie \(cookie.name)")
+            }
+            .padding(.leading, 14)
+            .padding(.vertical, 1)
+
+            if isEditing {
+                CookieEditForm(
+                    initial: .from(cookie: cookie),
+                    allowDomainEdit: false,
+                    onSave: { draft in save(draft: draft, replacing: cookie) },
+                    onCancel: { editingKey = nil },
+                    onDelete: { delete(cookies: [cookie]); editingKey = nil }
+                )
+                .padding(.leading, 24)
+                .padding(.trailing, 8)
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    private var toggleConfirmMessage: String {
+        if isPrivate {
+            return "Tabs will reload against the persistent store. Live JS state will be lost; previously-saved cookies become visible again."
+        }
+        return "Tabs will reload in a non-persistent session. Live JS state will be lost; cookies created in private mode are discarded on quit."
+    }
+
+    // MARK: - Cookie I/O
+
+    private struct CookieDomainGroup {
+        let domain: String
+        let cookies: [HTTPCookie]
+    }
+
+    private static func buildGroups(from cookies: [HTTPCookie]) -> [CookieDomainGroup] {
+        let grouped = Dictionary(grouping: cookies, by: { HTTPCookie.canonicalDomain($0.domain) })
+        return grouped
+            .map { CookieDomainGroup(domain: $0.key, cookies: $0.value.sorted { $0.name < $1.name }) }
+            .sorted { $0.domain < $1.domain }
+    }
+
+    private func refreshCookies() {
+        guard let coord = webPaneStore.coordinatorIfExists(for: paneID) else {
+            cookies = []
+            groupedCookies = []
+            return
+        }
+        isLoading = true
+        coord.dataStore.httpCookieStore.getAllCookies { fetched in
+            cookies = fetched
+            groupedCookies = Self.buildGroups(from: fetched)
+            isLoading = false
+        }
+    }
+
+    private func delete(cookies toDelete: [HTTPCookie]) {
+        guard let coord = webPaneStore.coordinatorIfExists(for: paneID) else { return }
+        let store = coord.dataStore.httpCookieStore
+        var remaining = toDelete.count
+        guard remaining > 0 else { return }
+        for cookie in toDelete {
+            store.delete(cookie) {
+                remaining -= 1
+                if remaining == 0 {
+                    refreshCookies()
+                }
+            }
+        }
+    }
+
+    private func clearAllSiteData() {
+        guard let coord = webPaneStore.coordinatorIfExists(for: paneID) else { return }
+        let store = coord.dataStore
+        let types = WKWebsiteDataStore.allWebsiteDataTypes()
+        store.removeData(ofTypes: types, modifiedSince: .distantPast) {
+            refreshCookies()
+        }
+    }
+
+    private func toggleExpanded(_ domain: String) {
+        if expandedDomains.contains(domain) {
+            expandedDomains.remove(domain)
+        } else {
+            expandedDomains.insert(domain)
+        }
+    }
+
+    private func toggleEditing(_ key: String) {
+        editingKey = (editingKey == key) ? nil : key
+        // Editing and adding are mutually exclusive — collapsing one
+        // when the other opens keeps the panel readable.
+        if editingKey != nil {
+            addingDomain = nil
+        }
+    }
+
+    private func beginAdd(forDomain domain: String) {
+        addingDomain = domain
+        editingKey = nil
+        if !domain.isEmpty {
+            expandedDomains.insert(domain)
+        }
+    }
+
+    /// Build an `HTTPCookie` from form input and persist it. If
+    /// `replacing` is non-nil, the original cookie is deleted first
+    /// (RFC 6265 identity is `domain|path|name` — when those don't
+    /// change WebKit replaces the value in place; we delete-then-set
+    /// unconditionally so a renamed cookie doesn't leave the old one
+    /// behind).
+    private func save(draft: CookieDraft, replacing existing: HTTPCookie?) {
+        guard let coord = webPaneStore.coordinatorIfExists(for: paneID) else { return }
+        let cookieStore = coord.dataStore.httpCookieStore
+
+        // HTTPCookie(properties:) treats `.secure` / HttpOnly as truthy
+        // whenever the key is present, regardless of value, so omit them
+        // unless they should be on.
+        var props: [HTTPCookiePropertyKey: Any] = [
+            .name: draft.name,
+            .value: draft.value,
+            .domain: draft.domain,
+            .path: draft.path.isEmpty ? "/" : draft.path
+        ]
+        if draft.isSecure {
+            props[.secure] = "TRUE"
+        }
+        if draft.isHTTPOnly {
+            props[HTTPCookiePropertyKey(rawValue: "HttpOnly")] = "TRUE"
+        }
+        if let expires = draft.expires {
+            props[.expires] = expires
+        }
+        guard let cookie = HTTPCookie(properties: props) else {
+            // Invalid combination (e.g. domain didn't validate).
+            // Surface a console log so an inspector run can pick it up.
+            NSLog("[StoragePanel] HTTPCookie(properties:) returned nil for draft: \(draft)")
+            return
+        }
+
+        let finish: () -> Void = {
+            cookieStore.setCookie(cookie) {
+                editingKey = nil
+                addingDomain = nil
+                refreshCookies()
+            }
+        }
+        if let existing {
+            cookieStore.delete(existing, completionHandler: finish)
+        } else {
+            finish()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func truncatedValue(_ value: String, max: Int = 60) -> String {
+        if value.count <= max { return value }
+        return String(value.prefix(max - 1)) + "…"
+    }
+
+    /// Stable identity for inline-edit state. RFC 6265 disambiguates
+    /// cookies by (domain, path, name); two cookies with the same name
+    /// on different paths are distinct, so include all three.
+    private static func cookieKey(_ cookie: HTTPCookie) -> String {
+        "\(cookie.domain)|\(cookie.path)|\(cookie.name)"
+    }
+}
+
+// MARK: - Cookie draft + edit form
+
+/// Editable cookie shape. Mirrors the subset of HTTPCookie fields
+/// the inline form exposes — name / value / domain / path / secure
+/// / expires. `isHTTPOnly` is preserved through edits but not
+/// user-editable (browser cookies set HttpOnly server-side; a UI
+/// toggle is debug-only and easy to mis-set).
+struct CookieDraft: Equatable {
+    var name: String
+    var value: String
+    var domain: String
+    var path: String
+    var isSecure: Bool
+    /// Carried from the source cookie so a save() that delete+recreates
+    /// doesn't silently strip HttpOnly. Not user-editable from the form.
+    var isHTTPOnly: Bool
+    /// nil = session cookie (no Expires header). Hidden behind a
+    /// "Session only" toggle in the form.
+    var expires: Date?
+
+    static func blank(domain: String = "") -> CookieDraft {
+        CookieDraft(
+            name: "",
+            value: "",
+            domain: domain,
+            path: "/",
+            isSecure: false,
+            isHTTPOnly: false,
+            expires: nil
+        )
+    }
+
+    static func from(cookie: HTTPCookie) -> CookieDraft {
+        CookieDraft(
+            name: cookie.name,
+            value: cookie.value,
+            domain: cookie.domain,
+            path: cookie.path,
+            isSecure: cookie.isSecure,
+            isHTTPOnly: cookie.isHTTPOnly,
+            expires: cookie.expiresDate
+        )
+    }
+}
+
+private struct CookieEditForm: View {
+    let initial: CookieDraft
+    let allowDomainEdit: Bool
+    let onSave: (CookieDraft) -> Void
+    let onCancel: () -> Void
+    var onDelete: (() -> Void)?
+
+    @State private var draft: CookieDraft
+    @State private var isSessionCookie: Bool
+    @State private var expires: Date
+
+    init(
+        initial: CookieDraft,
+        allowDomainEdit: Bool,
+        onSave: @escaping (CookieDraft) -> Void,
+        onCancel: @escaping () -> Void,
+        onDelete: (() -> Void)? = nil
+    ) {
+        self.initial = initial
+        self.allowDomainEdit = allowDomainEdit
+        self.onSave = onSave
+        self.onCancel = onCancel
+        self.onDelete = onDelete
+        _draft = State(initialValue: initial)
+        _isSessionCookie = State(initialValue: initial.expires == nil)
+        // Pre-fill the date picker even for session cookies so flipping
+        // the toggle off shows something sensible (30 days from now).
+        _expires = State(initialValue: initial.expires
+            ?? Date().addingTimeInterval(30 * 24 * 60 * 60))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            field(label: "Name", text: Binding(
+                get: { draft.name },
+                set: { draft.name = $0 }
+            ))
+            field(label: "Value", text: Binding(
+                get: { draft.value },
+                set: { draft.value = $0 }
+            ))
+            field(label: "Domain", text: Binding(
+                get: { draft.domain },
+                set: { draft.domain = $0 }
+            ), disabled: !allowDomainEdit)
+            field(label: "Path", text: Binding(
+                get: { draft.path },
+                set: { draft.path = $0 }
+            ))
+            HStack(spacing: 12) {
+                Toggle("Secure", isOn: Binding(
+                    get: { draft.isSecure },
+                    set: { draft.isSecure = $0 }
+                ))
+                .toggleStyle(.checkbox)
+                .controlSize(.small)
+
+                Toggle("Session only", isOn: $isSessionCookie)
+                    .toggleStyle(.checkbox)
+                    .controlSize(.small)
+            }
+            .font(.system(size: 10))
+
+            if !isSessionCookie {
+                HStack(spacing: 6) {
+                    Text("Expires")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 50, alignment: .trailing)
+                    DatePicker("", selection: $expires)
+                        .datePickerStyle(.compact)
+                        .controlSize(.small)
+                        .labelsHidden()
+                }
+            }
+
+            HStack(spacing: 6) {
+                if let onDelete {
+                    Button(role: .destructive, action: onDelete) {
+                        Text("Delete")
+                            .font(.system(size: 10))
+                    }
+                    .controlSize(.small)
+                }
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .controlSize(.small)
+                Button("Save", action: commit)
+                    .controlSize(.small)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!isValid)
+            }
+            .padding(.top, 4)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(Color.secondary.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 5)
+                .strokeBorder(Color.secondary.opacity(0.2), lineWidth: 0.5)
+        )
+    }
+
+    private var isValid: Bool {
+        !draft.name.trimmingCharacters(in: .whitespaces).isEmpty
+            && !draft.domain.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private func commit() {
+        var out = draft
+        out.name = out.name.trimmingCharacters(in: .whitespaces)
+        out.domain = out.domain.trimmingCharacters(in: .whitespaces)
+        out.path = out.path.trimmingCharacters(in: .whitespaces)
+        out.expires = isSessionCookie ? nil : expires
+        guard isValid else { return }
+        onSave(out)
+    }
+
+    private func field(
+        label: String,
+        text: Binding<String>,
+        disabled: Bool = false
+    ) -> some View {
+        HStack(spacing: 6) {
+            Text(label)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .frame(width: 50, alignment: .trailing)
+            TextField("", text: text)
+                .font(.system(size: 10, design: .monospaced))
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .disabled(disabled)
+                .opacity(disabled ? 0.6 : 1.0)
+        }
+    }
+}
+
+extension HTTPCookie {
+    /// Drops a single leading `.` so RFC-style `.example.com` matches
+    /// `example.com` for grouping + filtering.
+    static func canonicalDomain(_ domain: String) -> String {
+        domain.hasPrefix(".") ? String(domain.dropFirst()) : domain
+    }
+}
+
+extension WKHTTPCookieStore {
+    /// Fetches all cookies, deletes those matching `predicate`, and
+    /// invokes `completion` with the deleted count once every delete
+    /// completion has fired.
+    func deleteAll(
+        matching predicate: @escaping (HTTPCookie) -> Bool,
+        completion: @escaping (Int) -> Void
+    ) {
+        getAllCookies { cookies in
+            let matches = cookies.filter(predicate)
+            if matches.isEmpty {
+                completion(0)
+                return
+            }
+            var remaining = matches.count
+            let total = matches.count
+            for cookie in matches {
+                self.delete(cookie) {
+                    remaining -= 1
+                    if remaining == 0 {
+                        completion(total)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Nex/Features/WebPane/WebBatchInspectPanel.swift
+++ b/Nex/Features/WebPane/WebBatchInspectPanel.swift
@@ -1,0 +1,198 @@
+import SwiftUI
+
+/// Panel that appears in a web pane while a batch-annotate session
+/// is in progress. Lists every captured `BatchInspectItem` with an
+/// editable comment field; the user can remove individual entries or
+/// send the whole batch to the configured destination.
+struct WebBatchInspectPanel: View {
+    let items: [BatchInspectItem]
+    /// Display label for the destination pane, or "(local queue)"
+    /// when the batch is set to drop into the inspect-result queue
+    /// rather than paste anywhere.
+    let destinationLabel: String
+    /// Item with the bidirectional focus highlight. Set by either a
+    /// row tap or a page-side marker click.
+    let focusedItemID: UUID?
+    let onCommentChanged: (UUID, String) -> Void
+    let onRemoveItem: (UUID) -> Void
+    /// Fired on row click → triggers panel-originated focus (also
+    /// scrolls + pulses the page-side badge).
+    let onRowTapped: (UUID) -> Void
+    let onSend: () -> Void
+    let onCancel: () -> Void
+
+    /// Approximate height of one row (chip + selector + comment
+    /// field + padding + inter-row spacing). Used to size the
+    /// items area so it grows naturally up to `visibleRowCap` rows
+    /// then starts scrolling.
+    private static let rowHeight: CGFloat = 64
+    private static let visibleRowCap = 3
+    private static let listVerticalPadding: CGFloat = 12
+
+    /// Tracks which comment field currently has keyboard focus, so
+    /// stepping into one also fires the page-side highlight.
+    @FocusState private var focusedCommentID: UUID?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if items.isEmpty {
+                emptyHint
+            } else {
+                itemsList
+            }
+            Divider()
+            footer
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(alignment: .top) { Divider() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "scope")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+            Text("Batch annotate")
+                .font(.system(size: 11, weight: .semibold))
+            Text("→ \(destinationLabel)")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text("\(items.count) item\(items.count == 1 ? "" : "s")")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+    }
+
+    /// Items area. Grows naturally up to `visibleRowCap` rows tall;
+    /// over the cap the inner ScrollView takes over and we clamp the
+    /// height so the panel never dominates the pane.
+    private var itemsList: some View {
+        let visibleRows = min(items.count, Self.visibleRowCap)
+        let height = CGFloat(visibleRows) * Self.rowHeight + Self.listVerticalPadding
+        return ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 4) {
+                    ForEach(Array(items.enumerated()), id: \.element.id) { idx, item in
+                        row(item, index: idx)
+                            .id(item.id)
+                    }
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+            }
+            .frame(height: height)
+            .onChange(of: focusedItemID) { _, newValue in
+                guard let newValue else { return }
+                // Scroll the row into view…
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    proxy.scrollTo(newValue, anchor: .center)
+                }
+                // …and put keyboard focus into its comment field so
+                // the user can type immediately after each new pick.
+                if focusedCommentID != newValue {
+                    focusedCommentID = newValue
+                }
+            }
+        }
+    }
+
+    private var emptyHint: some View {
+        Text("Click elements in the page to add them. Esc cancels.")
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+    }
+
+    private func row(_ item: BatchInspectItem, index: Int) -> some View {
+        let isFocused = item.id == focusedItemID
+        return HStack(alignment: .top, spacing: 6) {
+            // Numbered chip matching the page badge.
+            Text("\(index + 1)")
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .frame(width: 18, height: 18)
+                .background(Circle().fill(Color.accentColor))
+                .foregroundStyle(.white)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Text(item.result.tag.uppercased())
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(Color.accentColor)
+                    Text(item.result.selector)
+                        .font(.system(size: 10, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .foregroundStyle(.primary)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture { onRowTapped(item.id) }
+
+                TextField(
+                    "Comment (optional)",
+                    text: Binding(
+                        get: { item.comment },
+                        set: { onCommentChanged(item.id, $0) }
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 11))
+                .focused($focusedCommentID, equals: item.id)
+                .onChange(of: focusedCommentID) { _, newValue in
+                    // Fire the page-side highlight when this field
+                    // gains focus (tab key, click, etc.). Other fields
+                    // losing focus also pass through here with their
+                    // own item.id, which we filter out below.
+                    if newValue == item.id {
+                        onRowTapped(item.id)
+                    }
+                }
+            }
+
+            Button(action: { onRemoveItem(item.id) }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Remove this item")
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isFocused ? Color.accentColor.opacity(0.18) : Color.secondary.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .strokeBorder(
+                    isFocused ? Color.accentColor.opacity(0.5) : Color.clear,
+                    lineWidth: 1
+                )
+        )
+        .animation(.easeOut(duration: 0.18), value: isFocused)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            Button("Cancel", action: onCancel)
+                .buttonStyle(.bordered)
+            Spacer()
+            Button("Send \(items.count)") {
+                onSend()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(items.isEmpty)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+    }
+}

--- a/Nex/Features/WebPane/WebBatchInspectPanel.swift
+++ b/Nex/Features/WebPane/WebBatchInspectPanel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Panel that appears in a web pane while a batch-annotate session
@@ -6,10 +7,9 @@ import SwiftUI
 /// send the whole batch to the configured destination.
 struct WebBatchInspectPanel: View {
     let items: [BatchInspectItem]
-    /// Display label for the destination pane, or "(local queue)"
-    /// when the batch is set to drop into the inspect-result queue
-    /// rather than paste anywhere.
-    let destinationLabel: String
+    /// Other panes available as paste targets. Surfaced in the
+    /// footer's destination picker.
+    let availableTargets: [InspectTargetOption]
     /// Item with the bidirectional focus highlight. Set by either a
     /// row tap or a page-side marker click.
     let focusedItemID: UUID?
@@ -18,8 +18,24 @@ struct WebBatchInspectPanel: View {
     /// Fired on row click → triggers panel-originated focus (also
     /// scrolls + pulses the page-side badge).
     let onRowTapped: (UUID) -> Void
-    let onSend: () -> Void
+    /// Send with the currently-selected destination. nil reserved for
+    /// a future "Local queue" picker entry; currently the picker only
+    /// offers pane targets and Send is disabled until one is selected.
+    let onSend: (UUID?) -> Void
     let onCancel: () -> Void
+    /// Last destination this pane was sent to in the current app
+    /// session, or `nil` on the first batch. Seeds the picker.
+    var initialSelection: BatchTargetMemory?
+
+    @State private var selection: TargetSelection = .unselected
+
+    /// `.unselected` blocks Send so the user can't accidentally
+    /// dispatch a batch to nowhere. Items still survive cancel via the
+    /// CLI's `nex web inspect-result` queue.
+    private enum TargetSelection: Equatable {
+        case unselected
+        case pane(UUID)
+    }
 
     /// Approximate height of one row (chip + selector + comment
     /// field + padding + inter-row spacing). Used to size the
@@ -47,6 +63,32 @@ struct WebBatchInspectPanel: View {
         }
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .top) { Divider() }
+        .onAppear { seedSelection() }
+        // The WKWebView underneath sets `cursor:crosshair` while the
+        // picker is armed. Without an explicit override, NSCursor
+        // would keep crosshair as the user moves into the SwiftUI
+        // panel (AppKit only resets when a fresh cursor-rect view
+        // claims the rect). Force arrow whenever the mouse is over
+        // the panel surface.
+        .onContinuousHover { phase in
+            if case .active = phase { NSCursor.arrow.set() }
+        }
+    }
+
+    /// Seed the picker from the per-pane "last destination" memory.
+    /// First batch of a session stays `.unselected` so the user has
+    /// to pick deliberately; Send is disabled until they do.
+    private func seedSelection() {
+        switch initialSelection {
+        case .none, .local:
+            selection = .unselected
+        case .pane(let id) where availableTargets.contains(where: { $0.id == id }):
+            selection = .pane(id)
+        case .pane:
+            // Remembered pane no longer exists — fall back rather
+            // than holding a dead id.
+            selection = .unselected
+        }
     }
 
     private var header: some View {
@@ -54,11 +96,8 @@ struct WebBatchInspectPanel: View {
             Image(systemName: "scope")
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(Color.accentColor)
-            Text("Batch annotate")
+            Text("Element pickup")
                 .font(.system(size: 11, weight: .semibold))
-            Text("→ \(destinationLabel)")
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundStyle(.secondary)
             Spacer()
             Text("\(items.count) item\(items.count == 1 ? "" : "s")")
                 .font(.system(size: 11))
@@ -186,13 +225,88 @@ struct WebBatchInspectPanel: View {
             Button("Cancel", action: onCancel)
                 .buttonStyle(.bordered)
             Spacer()
+            destinationPicker
             Button("Send \(items.count)") {
-                onSend()
+                if case .pane(let id) = selection { onSend(id) }
             }
             .buttonStyle(.borderedProminent)
-            .disabled(items.isEmpty)
+            .disabled(items.isEmpty || selection == .unselected)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
+        // If the chosen pane disappears mid-batch (closed by the
+        // user), fall back to unselected so they have to reconfirm
+        // instead of silently rerouting to whatever the picker shows.
+        .onChange(of: availableTargets) { _, newTargets in
+            if case .pane(let id) = selection,
+               !newTargets.contains(where: { $0.id == id }) {
+                selection = .unselected
+            }
+        }
+    }
+
+    /// Destination dropdown shown next to the Send button. Rendered
+    /// as a bordered button (rather than `.menuStyle(.borderlessButton)`
+    /// which collapses Text labels to icon-only on macOS) so the
+    /// current pick reads as a button with a label inside.
+    private var destinationPicker: some View {
+        Menu {
+            if availableTargets.isEmpty {
+                Text("No other panes open in this workspace")
+                    .font(.caption)
+            } else {
+                ForEach(availableTargets) { target in
+                    Button {
+                        selection = .pane(target.id)
+                    } label: {
+                        HStack {
+                            Text(target.label)
+                            if selection == .pane(target.id) {
+                                Spacer(); Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Text(currentTargetLabel)
+                    .foregroundStyle(selection == .unselected ? Color.secondary : Color.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .font(.system(size: 11))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .frame(minWidth: 140, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .strokeBorder(
+                        selection == .unselected
+                            ? Color.accentColor.opacity(0.6)
+                            : Color.secondary.opacity(0.35),
+                        lineWidth: selection == .unselected ? 1.0 : 0.5
+                    )
+            )
+        }
+        .menuStyle(.button)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Where to send this batch")
+    }
+
+    private var currentTargetLabel: String {
+        switch selection {
+        case .unselected: "Select destination…"
+        case .pane(let id):
+            availableTargets.first(where: { $0.id == id })?.label ?? "Select destination…"
+        }
     }
 }

--- a/Nex/Features/WebPane/WebPaneBatchMarkerScript.swift
+++ b/Nex/Features/WebPane/WebPaneBatchMarkerScript.swift
@@ -150,7 +150,13 @@ enum WebPaneBatchMarkerScript {
                 'pointer-events:auto',
                 'z-index:2147483647',
                 'display:none',
-                'box-sizing:border-box'
+                'box-sizing:border-box',
+                // While the picker is armed, the inspector script
+                // sets `cursor:crosshair` on documentElement, which
+                // the popover would otherwise inherit. Force a
+                // default cursor so hovering the popover (or its
+                // textarea / buttons) shows the right pointer.
+                'cursor:default'
             ].join(';');
 
             popoverLabel = document.createElement('div');

--- a/Nex/Features/WebPane/WebPaneBatchMarkerScript.swift
+++ b/Nex/Features/WebPane/WebPaneBatchMarkerScript.swift
@@ -1,0 +1,528 @@
+import Foundation
+
+/// JS that overlays numbered badges on every element captured during a
+/// batch-annotate session, plus a `nexBatchMarker` bridge for badge
+/// clicks and comment edits.
+///
+/// API exposed on `window`:
+/// - `__nexBatchSetMarkers([{id, selector, label, comment}])` — replace
+///   the current marker set. Skips entries whose selector no longer
+///   resolves.
+/// - `__nexBatchUpdateComment(id, comment)` — push an external (panel)
+///   comment edit into the page-side popover. No-op if the popover's
+///   textarea is currently being typed into (avoids clobbering the
+///   user's cursor).
+/// - `__nexBatchClearMarkers()` — remove every marker + popover.
+/// - `__nexBatchHighlight(id, scrollIntoView)` — focus a marker. Shows
+///   the comment popover next to its badge and draws the focus ring.
+/// - `__nexBatchUnfocus()` — hide the popover + focus ring.
+///
+/// Bridge messages:
+/// - `{ id }`                              — user clicked a badge.
+/// - `{ commentChanged: { id, comment } }` — popover textarea edit.
+/// - `{ dismiss: { id } }`                 — Done button / Esc in popover.
+/// - `{ remove:  { id } }`                 — Remove button in popover.
+enum WebPaneBatchMarkerScript {
+    static let source: String = """
+    (function() {
+        if (window.__nexBatchMarkersInstalled) return;
+        window.__nexBatchMarkersInstalled = true;
+
+        var bridge = (window.webkit && window.webkit.messageHandlers &&
+                      window.webkit.messageHandlers.nexBatchMarker);
+
+        var markers = {};       // id -> {selector, label, comment, badgeEl}
+        var container = null;
+        var focusRing = null;
+        var focusedID = null;
+        /// When `highlight(id)` arrives before `setMarkers` has
+        /// included that id, we remember it here and apply on the
+        /// next sync. Without this the focus ring gets dropped on
+        /// every other pick in batch mode (sync + highlight race).
+        var pendingFocusID = null;
+        var popover = null;
+        var popoverTextarea = null;
+        var popoverLabel = null;
+
+        function ensureContainer() {
+            if (container) return container;
+            container = document.createElement('div');
+            container.setAttribute('data-nex-batch-markers', '1');
+            container.style.cssText = [
+                'position:fixed', 'top:0', 'left:0',
+                'width:100%', 'height:100%',
+                'pointer-events:none',
+                'z-index:2147483646'
+            ].join(';');
+            (document.body || document.documentElement).appendChild(container);
+            return container;
+        }
+
+        function clearAll() {
+            for (var id in markers) {
+                if (markers[id].badgeEl) markers[id].badgeEl.remove();
+            }
+            markers = {};
+            clearFocusRing();
+            hidePopover();
+            popover = null;
+            popoverTextarea = null;
+            popoverLabel = null;
+            window.__nexBatchHasOpenPopover = false;
+            if (container) { container.remove(); container = null; }
+        }
+
+        function ensureFocusRing() {
+            if (focusRing) return focusRing;
+            focusRing = document.createElement('div');
+            focusRing.setAttribute('data-nex-batch-focus-ring', '1');
+            focusRing.style.cssText = [
+                'position:fixed', 'pointer-events:none',
+                'z-index:2147483645',
+                'border:2px solid #007AFF',
+                'border-radius:3px',
+                'background:rgba(0,122,255,0.12)',
+                'box-shadow:0 0 0 1px rgba(255,255,255,0.6), 0 0 12px rgba(0,122,255,0.5)',
+                'box-sizing:border-box',
+                'transition:left 80ms linear, top 80ms linear, width 80ms linear, height 80ms linear, opacity 120ms linear',
+                'display:none', 'opacity:0'
+            ].join(';');
+            ensureContainer().appendChild(focusRing);
+            return focusRing;
+        }
+
+        function clearFocusRing() {
+            focusedID = null;
+            pendingFocusID = null;
+            if (focusRing) {
+                focusRing.style.display = 'none';
+                focusRing.style.opacity = '0';
+            }
+        }
+
+        function positionFocusRing() {
+            if (!focusedID) return;
+            var m = markers[focusedID];
+            if (!m) { clearFocusRing(); return; }
+            var el = queryElement(m.selector);
+            if (!el) { clearFocusRing(); return; }
+            var rect = el.getBoundingClientRect();
+            var vw = window.innerWidth;
+            var vh = window.innerHeight;
+            var collapsed = rect.width === 0 && rect.height === 0;
+            var offscreen = rect.bottom <= 0 || rect.right <= 0 ||
+                            rect.top >= vh || rect.left >= vw;
+            if (collapsed || offscreen) {
+                if (focusRing) {
+                    focusRing.style.display = 'none';
+                    focusRing.style.opacity = '0';
+                }
+                return;
+            }
+            var ring = ensureFocusRing();
+            ring.style.display = 'block';
+            ring.style.opacity = '1';
+            ring.style.left = (rect.left - 3) + 'px';
+            ring.style.top = (rect.top - 3) + 'px';
+            ring.style.width = (rect.width + 6) + 'px';
+            ring.style.height = (rect.height + 6) + 'px';
+        }
+
+        function queryElement(selector) {
+            if (!selector) return null;
+            try { return document.querySelector(selector); }
+            catch (e) { return null; }
+        }
+
+        function ensurePopover() {
+            if (popover) return popover;
+            popover = document.createElement('div');
+            popover.setAttribute('data-nex-batch-popover', '1');
+            popover.style.cssText = [
+                'position:fixed',
+                'min-width:200px', 'max-width:260px',
+                'background:#1c1c1e', 'color:#fff',
+                'border:1px solid rgba(255,255,255,0.18)',
+                'border-radius:6px',
+                'box-shadow:0 6px 24px rgba(0,0,0,0.4)',
+                'padding:8px',
+                'font:11px -apple-system,system-ui,sans-serif',
+                'pointer-events:auto',
+                'z-index:2147483647',
+                'display:none',
+                'box-sizing:border-box'
+            ].join(';');
+
+            popoverLabel = document.createElement('div');
+            popoverLabel.style.cssText = [
+                'color:#5AC8FA',
+                'font:600 10px/14px ui-monospace,SFMono-Regular,Menlo,monospace',
+                'margin-bottom:4px',
+                'white-space:nowrap',
+                'overflow:hidden',
+                'text-overflow:ellipsis'
+            ].join(';');
+
+            popoverTextarea = document.createElement('textarea');
+            popoverTextarea.setAttribute('rows', '3');
+            popoverTextarea.setAttribute('placeholder', 'Add a comment…');
+            popoverTextarea.style.cssText = [
+                'width:100%', 'box-sizing:border-box',
+                'background:rgba(255,255,255,0.06)',
+                'color:#fff',
+                'border:1px solid rgba(255,255,255,0.18)',
+                'border-radius:4px',
+                'padding:4px 6px',
+                'font:12px -apple-system,system-ui,sans-serif',
+                'resize:vertical',
+                'min-height:48px',
+                'outline:none'
+            ].join(';');
+
+            popoverTextarea.addEventListener('input', function() {
+                if (!focusedID) return;
+                var marker = markers[focusedID];
+                if (marker) marker.comment = popoverTextarea.value;
+                try {
+                    bridge && bridge.postMessage({
+                        commentChanged: { id: focusedID, comment: popoverTextarea.value }
+                    });
+                } catch (e) {}
+            });
+            // Esc inside the popover = Done. Don't let it bubble to
+            // the inspector picker (which uses Esc to cancel arming
+            // entirely).
+            popoverTextarea.addEventListener('keydown', function(ev) {
+                if (ev.key === 'Escape') {
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    if (focusedID) sendDismiss(focusedID);
+                }
+            });
+            // Stop clicks inside the popover from bubbling up to
+            // page-level handlers (the editable textarea is its own
+            // interactive surface).
+            popoverTextarea.addEventListener('click', function(ev) {
+                ev.stopPropagation();
+            });
+            popoverTextarea.addEventListener('mousedown', function(ev) {
+                ev.stopPropagation();
+            });
+
+            // Footer row with Remove + Done buttons.
+            var footer = document.createElement('div');
+            footer.style.cssText = [
+                'display:flex', 'align-items:center',
+                'justify-content:space-between',
+                'gap:6px',
+                'margin-top:6px'
+            ].join(';');
+
+            var removeBtn = makePopoverButton('Remove', {
+                background: 'transparent',
+                color: '#FF6B6B',
+                border: '1px solid rgba(255,107,107,0.4)'
+            });
+            removeBtn.addEventListener('click', function(ev) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                if (focusedID) sendRemove(focusedID);
+            });
+
+            var doneBtn = makePopoverButton('Done', {
+                background: '#007AFF',
+                color: '#fff',
+                border: '1px solid #007AFF'
+            });
+            doneBtn.addEventListener('click', function(ev) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                if (focusedID) sendDismiss(focusedID);
+            });
+
+            footer.appendChild(removeBtn);
+            footer.appendChild(doneBtn);
+
+            popover.appendChild(popoverLabel);
+            popover.appendChild(popoverTextarea);
+            popover.appendChild(footer);
+            ensureContainer().appendChild(popover);
+            return popover;
+        }
+
+        function makePopoverButton(label, palette) {
+            var btn = document.createElement('button');
+            btn.type = 'button';
+            btn.textContent = label;
+            btn.style.cssText = [
+                'background:' + palette.background,
+                'color:' + palette.color,
+                'border:' + palette.border,
+                'border-radius:4px',
+                'padding:3px 10px',
+                'font:600 11px -apple-system,system-ui,sans-serif',
+                'cursor:pointer',
+                'min-width:60px'
+            ].join(';');
+            btn.addEventListener('mousedown', function(ev) {
+                ev.stopPropagation();
+            });
+            return btn;
+        }
+
+        function sendDismiss(id) {
+            try {
+                bridge && bridge.postMessage({ dismiss: { id: String(id) } });
+            } catch (e) {}
+        }
+
+        function sendRemove(id) {
+            try {
+                bridge && bridge.postMessage({ remove: { id: String(id) } });
+            } catch (e) {}
+        }
+
+        function hidePopover() {
+            if (popover) popover.style.display = 'none';
+            window.__nexBatchHasOpenPopover = false;
+        }
+
+        function positionPopover() {
+            if (!focusedID) { hidePopover(); return; }
+            var m = markers[focusedID];
+            if (!m) { hidePopover(); return; }
+            var el = queryElement(m.selector);
+            if (!el) { hidePopover(); return; }
+            var rect = el.getBoundingClientRect();
+            var vw = window.innerWidth;
+            var vh = window.innerHeight;
+            var collapsed = rect.width === 0 && rect.height === 0;
+            var offscreen = rect.bottom <= 0 || rect.right <= 0 ||
+                            rect.top >= vh || rect.left >= vw;
+            if (collapsed || offscreen) { hidePopover(); return; }
+            var pop = ensurePopover();
+            pop.style.display = 'block';
+
+            // Placement: below the element when there's room, else
+            // above. Horizontally centered to the viewport (not the
+            // element) so the popover always lands in a predictable
+            // spot regardless of where on the page the picked
+            // element sits. Clamped to the viewport with an 8px
+            // margin.
+            var popWidth = 260;
+            var popHeight = pop.offsetHeight || 120;
+            var roomBelow = vh - rect.bottom;
+            var roomAbove = rect.top;
+            var top;
+            if (roomBelow >= popHeight + 16 || roomBelow >= roomAbove) {
+                top = rect.bottom + 8;
+            } else {
+                top = rect.top - popHeight - 8;
+            }
+            if (top + popHeight > vh - 8) top = vh - popHeight - 8;
+            if (top < 8) top = 8;
+
+            var left = Math.round((vw - popWidth) / 2);
+            if (left < 8) left = 8;
+            if (left + popWidth > vw - 8) left = vw - popWidth - 8;
+
+            pop.style.left = left + 'px';
+            pop.style.top = top + 'px';
+            // Set the picker-gating flag every time we (re)show
+            // the popover. Cross-script signal — read in the
+            // inspector picker's onClick / onMove.
+            window.__nexBatchHasOpenPopover = true;
+        }
+
+        function syncPopoverContent() {
+            if (!focusedID || !popover) return;
+            var m = markers[focusedID];
+            if (!m) return;
+            if (popoverLabel) {
+                popoverLabel.textContent = (m.label != null ? '#' + m.label + ' ' : '') + (m.selector || '');
+            }
+            // Only overwrite the textarea when the user isn't
+            // actively typing (avoids clobbering their cursor).
+            if (popoverTextarea && document.activeElement !== popoverTextarea) {
+                popoverTextarea.value = m.comment || '';
+            }
+        }
+
+        function updateExternalComment(id, comment) {
+            var key = String(id);
+            var m = markers[key];
+            if (!m) return;
+            m.comment = comment || '';
+            if (focusedID === key &&
+                popoverTextarea &&
+                document.activeElement !== popoverTextarea) {
+                popoverTextarea.value = m.comment;
+            }
+        }
+
+        function positionBadge(marker) {
+            if (!marker.badgeEl) return;
+            var el = queryElement(marker.selector);
+            if (!el) { marker.badgeEl.style.display = 'none'; return; }
+            var rect = el.getBoundingClientRect();
+            // Hide when the element is collapsed (display:none) or
+            // fully outside the viewport — clamping the badge to the
+            // viewport edge would otherwise leave dots floating with
+            // no obvious owner once the user scrolls.
+            var vw = window.innerWidth;
+            var vh = window.innerHeight;
+            var collapsed = rect.width === 0 && rect.height === 0;
+            var offscreen = rect.bottom <= 0 || rect.right <= 0 ||
+                            rect.top >= vh || rect.left >= vw;
+            if (collapsed || offscreen) {
+                marker.badgeEl.style.display = 'none';
+                return;
+            }
+            marker.badgeEl.style.display = 'flex';
+            // Place at top-left, slightly outside the element so it
+            // doesn't cover the content. Follow the element off-screen
+            // (no clamp) so partially-visible elements show the badge
+            // beside them rather than pinned to the corner.
+            marker.badgeEl.style.left = (rect.left - 6) + 'px';
+            marker.badgeEl.style.top = (rect.top - 6) + 'px';
+        }
+
+        function refreshAll() {
+            for (var id in markers) positionBadge(markers[id]);
+            positionFocusRing();
+            positionPopover();
+        }
+
+        function createBadge(marker) {
+            var el = document.createElement('div');
+            el.setAttribute('data-nex-batch-marker', '1');
+            el.style.cssText = [
+                'position:fixed',
+                'min-width:18px', 'height:18px',
+                'padding:0 5px',
+                'border-radius:9px',
+                'background:#007AFF', 'color:white',
+                'font:600 11px/18px -apple-system,system-ui,sans-serif',
+                'text-align:center',
+                'box-sizing:content-box',
+                'border:2px solid white',
+                'box-shadow:0 1px 4px rgba(0,0,0,0.35)',
+                'cursor:pointer',
+                'pointer-events:auto',
+                'z-index:2147483646',
+                'user-select:none',
+                'transition:transform 180ms ease',
+                'display:flex', 'align-items:center', 'justify-content:center'
+            ].join(';');
+            el.textContent = String(marker.label);
+            el.addEventListener('click', function(ev) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                try { bridge && bridge.postMessage({ id: marker.id }); } catch (e) {}
+            });
+            return el;
+        }
+
+        function setMarkers(items) {
+            // Diff-rebuild without clearing focusedID — a full
+            // clearAll() would drop the focus ring + popover state
+            // on every state change (every new pick, every comment
+            // edit on the panel side, …) and the user would see
+            // the ring vanish for items 2+.
+            for (var id in markers) {
+                if (markers[id].badgeEl) markers[id].badgeEl.remove();
+            }
+            markers = {};
+            if (!items || !items.length) {
+                // Nothing to mark; tear down the focus surfaces too.
+                clearFocusRing();
+                hidePopover();
+                if (container) { container.remove(); container = null; }
+                return;
+            }
+            ensureContainer();
+            items.forEach(function(item, i) {
+                if (!item || !item.selector) return;
+                if (!queryElement(item.selector)) return;
+                var marker = {
+                    id: String(item.id || ''),
+                    selector: item.selector,
+                    label: String(item.label != null ? item.label : (i + 1)),
+                    comment: String(item.comment || ''),
+                    badgeEl: null
+                };
+                var badge = createBadge(marker);
+                container.appendChild(badge);
+                marker.badgeEl = badge;
+                markers[marker.id] = marker;
+                positionBadge(marker);
+            });
+            // Apply any pending focus request that arrived before
+            // this sync (highlight-before-setMarkers race).
+            if (pendingFocusID && markers[pendingFocusID]) {
+                focusedID = pendingFocusID;
+                pendingFocusID = null;
+            }
+            // Restore (or clean up) the focus surfaces depending on
+            // whether the focused item is still in the set.
+            if (focusedID && !markers[focusedID]) {
+                clearFocusRing();
+                hidePopover();
+            } else if (focusedID) {
+                syncPopoverContent();
+                positionFocusRing();
+                positionPopover();
+            }
+        }
+
+        function highlight(id, scrollIntoView) {
+            var key = String(id);
+            var m = markers[key];
+            if (!m) {
+                // Marker not yet synced (highlight arrived first in
+                // the merge); remember and apply once setMarkers
+                // catches up.
+                pendingFocusID = key;
+                return;
+            }
+            pendingFocusID = null;
+            focusedID = key;
+            var shouldScroll = scrollIntoView !== false;
+            var el = queryElement(m.selector);
+            if (el && shouldScroll) {
+                try { el.scrollIntoView({ behavior: 'smooth', block: 'center' }); }
+                catch (e) { el.scrollIntoView(); }
+            }
+            // Pulse the badge so a returning user sees which one is
+            // currently selected.
+            if (m.badgeEl) {
+                m.badgeEl.style.transform = 'scale(1.6)';
+                setTimeout(function() {
+                    if (m.badgeEl) m.badgeEl.style.transform = 'scale(1)';
+                }, 320);
+            }
+            // Draw the focus ring + popover immediately at the
+            // current rect; reposition after the scroll animation
+            // settles so they stay anchored.
+            syncPopoverContent();
+            positionFocusRing();
+            positionPopover();
+            if (shouldScroll) setTimeout(refreshAll, 400);
+        }
+
+        function unfocus() {
+            clearFocusRing();
+            hidePopover();
+        }
+
+        window.addEventListener('scroll', refreshAll, true);
+        window.addEventListener('resize', refreshAll, true);
+
+        window.__nexBatchSetMarkers = setMarkers;
+        window.__nexBatchClearMarkers = clearAll;
+        window.__nexBatchHighlight = highlight;
+        window.__nexBatchUnfocus = unfocus;
+        window.__nexBatchUpdateComment = updateExternalComment;
+    })();
+    """
+}

--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -1,0 +1,157 @@
+import AppKit
+import SwiftUI
+
+/// Slim chrome strip at the top of a web pane: back / forward / reload
+/// buttons + URL bar. Phase 1 keeps the surface intentionally small —
+/// the tab strip arrives in Phase 2 and favourites in Phase 4.
+struct WebPaneChrome: View {
+    let paneID: UUID
+    let displayedURL: String
+    let canGoBack: Bool
+    let canGoForward: Bool
+    let isLoading: Bool
+    let onBack: () -> Void
+    let onForward: () -> Void
+    let onReload: () -> Void
+    let onNavigate: (String) -> Void
+    let onInspect: () -> Void
+
+    /// Set non-nil to programmatically promote the URL bar to first
+    /// responder (consumed by the priority key layer for ⌘L).
+    let focusRequestToken: UInt64
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Button(action: onBack) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 11, weight: .medium))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!canGoBack)
+            .opacity(canGoBack ? 0.8 : 0.3)
+            .help("Back (⌘[)")
+
+            Button(action: onForward) {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .medium))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!canGoForward)
+            .opacity(canGoForward ? 0.8 : 0.3)
+            .help("Forward (⌘])")
+
+            Button(action: onReload) {
+                Image(systemName: isLoading ? "xmark" : "arrow.clockwise")
+                    .font(.system(size: 11, weight: .medium))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .opacity(0.8)
+            .help("Reload (⌘R)")
+
+            WebURLBar(
+                initialURL: displayedURL,
+                paneID: paneID,
+                focusRequestToken: focusRequestToken,
+                onSubmit: onNavigate
+            )
+            .frame(maxWidth: .infinity)
+
+            Button(action: onInspect) {
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
+                    .font(.system(size: 11, weight: .medium))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .opacity(0.8)
+            .help("Toggle Safari Web Inspector")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+}
+
+// MARK: - URL bar
+
+/// `NSTextField`-backed URL bar. SwiftUI's `TextField` doesn't expose
+/// first-responder control cleanly, and we need that for ⌘L (focus URL
+/// bar) and for the "select-all-on-focus" behaviour every browser
+/// gives you. Using AppKit directly avoids ad-hoc workarounds.
+struct WebURLBar: NSViewRepresentable {
+    let initialURL: String
+    let paneID: UUID
+    let focusRequestToken: UInt64
+    let onSubmit: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onSubmit: onSubmit)
+    }
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field = NSTextField()
+        field.isBezeled = true
+        field.bezelStyle = .roundedBezel
+        field.isEditable = true
+        field.isSelectable = true
+        field.drawsBackground = true
+        field.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        field.placeholderString = "Enter URL"
+        field.stringValue = initialURL
+        field.delegate = context.coordinator
+        context.coordinator.field = field
+        context.coordinator.lastSeenToken = focusRequestToken
+        context.coordinator.lastSeenURL = initialURL
+        return field
+    }
+
+    func updateNSView(_ field: NSTextField, context: Context) {
+        let coord = context.coordinator
+        // Only overwrite the URL bar when the underlying URL actually
+        // changes and the user isn't actively editing — otherwise the
+        // user's in-progress typing would be wiped on every render.
+        if coord.lastSeenURL != initialURL,
+           field.window?.firstResponder !== field.currentEditor() {
+            field.stringValue = initialURL
+            coord.lastSeenURL = initialURL
+        }
+        if coord.lastSeenToken != focusRequestToken {
+            coord.lastSeenToken = focusRequestToken
+            DispatchQueue.main.async { [weak field] in
+                guard let field, let window = field.window else { return }
+                window.makeFirstResponder(field)
+                field.currentEditor()?.selectAll(nil)
+            }
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        let onSubmit: (String) -> Void
+        weak var field: NSTextField?
+        var lastSeenToken: UInt64 = 0
+        var lastSeenURL: String = ""
+
+        init(onSubmit: @escaping (String) -> Void) {
+            self.onSubmit = onSubmit
+        }
+
+        func control(_: NSControl, textView _: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                if let value = field?.stringValue {
+                    onSubmit(value)
+                }
+                return true
+            }
+            return false
+        }
+    }
+}

--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -1,26 +1,46 @@
 import AppKit
 import SwiftUI
 
-/// Slim chrome strip at the top of a web pane: back / forward / reload
-/// buttons + URL bar. Phase 1 keeps the surface intentionally small —
-/// the tab strip arrives in Phase 2 and favourites in Phase 4.
+/// Chrome strip at the top of a web pane: nav buttons + URL bar +
+/// inspector toggle, with a tab strip below. The tab strip and `+`
+/// button are hidden when only one tab is open so single-tab panes
+/// stay visually quiet.
 struct WebPaneChrome: View {
     let paneID: UUID
     let displayedURL: String
     let canGoBack: Bool
     let canGoForward: Bool
     let isLoading: Bool
+    /// All open tabs. Used by the tab strip to render pills.
+    let tabs: [WebTab]
+    let activeTabID: UUID?
     let onBack: () -> Void
     let onForward: () -> Void
     let onReload: () -> Void
     let onNavigate: (String) -> Void
     let onInspect: () -> Void
+    let onTabSelect: (UUID) -> Void
+    let onTabClose: (UUID) -> Void
+    let onTabNew: () -> Void
 
     /// Set non-nil to programmatically promote the URL bar to first
     /// responder (consumed by the priority key layer for ⌘L).
     let focusRequestToken: UInt64
 
     var body: some View {
+        VStack(spacing: 0) {
+            navAndURLBar
+            if tabs.count > 1 {
+                tabStrip
+            }
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+
+    private var navAndURLBar: some View {
         HStack(spacing: 6) {
             Button(action: onBack) {
                 Image(systemName: "chevron.left")
@@ -62,6 +82,16 @@ struct WebPaneChrome: View {
             )
             .frame(maxWidth: .infinity)
 
+            Button(action: onTabNew) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .medium))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .opacity(0.8)
+            .help("New tab (⌘T)")
+
             Button(action: onInspect) {
                 Image(systemName: "chevron.left.forwardslash.chevron.right")
                     .font(.system(size: 11, weight: .medium))
@@ -74,10 +104,73 @@ struct WebPaneChrome: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .background(Color(nsColor: .windowBackgroundColor))
-        .overlay(alignment: .bottom) {
-            Divider()
+    }
+
+    private var tabStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4) {
+                ForEach(tabs) { tab in
+                    WebTabPill(
+                        tab: tab,
+                        isActive: tab.id == activeTabID,
+                        onSelect: { onTabSelect(tab.id) },
+                        onClose: { onTabClose(tab.id) }
+                    )
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.bottom, 4)
         }
+    }
+}
+
+/// A single tab pill in the strip. Shows the tab's title (or host as
+/// a fallback) plus a close `x`. Click anywhere on the pill to select;
+/// hovering reveals the close button.
+private struct WebTabPill: View {
+    let tab: WebTab
+    let isActive: Bool
+    let onSelect: () -> Void
+    let onClose: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(tab.displayLabel)
+                .font(.system(size: 11, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .foregroundStyle(isActive ? Color.primary : Color.secondary)
+
+            if isHovered || isActive {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 14, height: 14)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Close tab (⌘W)")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .frame(maxWidth: 180, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isActive ? Color.accentColor.opacity(0.18) : Color.secondary.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .strokeBorder(
+                    isActive ? Color.accentColor.opacity(0.4) : Color.clear,
+                    lineWidth: 1
+                )
+        )
+        .onTapGesture(perform: onSelect)
+        .onHover { isHovered = $0 }
     }
 }
 

--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -11,6 +11,12 @@ struct WebPaneChrome: View {
     let canGoBack: Bool
     let canGoForward: Bool
     let isLoading: Bool
+    /// 0..1 progress through the current load (`WKWebView.estimatedProgress`).
+    /// Drives the Safari-style accent strip at the bottom of the chrome.
+    var loadProgress: Double = 0
+    /// True while the strip should be visible — covers both the live
+    /// load and the short fade-out after completion.
+    var loadProgressVisible: Bool = false
     /// All open tabs. Used by the tab strip to render pills.
     let tabs: [WebTab]
     let activeTabID: UUID?
@@ -60,8 +66,28 @@ struct WebPaneChrome: View {
         }
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .bottom) {
-            Divider()
+            ZStack(alignment: .leading) {
+                Divider()
+                progressStrip
+            }
         }
+    }
+
+    /// Safari-style accent strip pinned to the bottom edge of the
+    /// chrome. Width is bound to `loadProgress` so the bar fills as
+    /// the load progresses; opacity is bound to `loadProgressVisible`
+    /// so it fades out cleanly after completion.
+    private var progressStrip: some View {
+        GeometryReader { geo in
+            Rectangle()
+                .fill(Color.accentColor)
+                .frame(width: max(0, geo.size.width * loadProgress), height: 2)
+                .opacity(loadProgressVisible ? 1 : 0)
+                .animation(.easeOut(duration: 0.2), value: loadProgress)
+                .animation(.easeInOut(duration: 0.25), value: loadProgressVisible)
+        }
+        .frame(height: 2)
+        .allowsHitTesting(false)
     }
 
     private var bookmarksMenuButton: some View {

--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -41,6 +41,14 @@ struct WebPaneChrome: View {
     /// Set non-nil to programmatically promote the URL bar to first
     /// responder (consumed by the priority key layer for ⌘L).
     let focusRequestToken: UInt64
+    var favourites: [Favourite] = []
+    var onToggleStar: (() -> Void)?
+    var onOpenFavourite: ((String) -> Void)?
+
+    /// `showSettingsWindow:` via `NSApp.sendAction` with a nil target
+    /// doesn't always reach the Settings scene through the responder
+    /// chain; `openSettings()` is the supported entry point.
+    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         VStack(spacing: 0) {
@@ -54,6 +62,60 @@ struct WebPaneChrome: View {
             Divider()
         }
     }
+
+    private var bookmarksMenuButton: some View {
+        Menu {
+            if favourites.isEmpty {
+                Text("No favourites yet")
+                Text("Click the star to save the current page")
+                    .font(.caption)
+            } else {
+                ForEach(favourites) { fav in
+                    Button(Self.truncatedMenuLabel(fav.displayLabel)) {
+                        onOpenFavourite?(fav.url)
+                    }
+                }
+            }
+            Divider()
+            Button("Manage favourites…") {
+                // Stash for cold-open (no listener yet); also post so
+                // an already-mounted Settings scene flips immediately.
+                WebPaneChrome.pendingSettingsTab = .web
+                openSettings()
+                NotificationCenter.default.post(
+                    name: WebPaneChrome.openSettingsTabNotification, object: SettingsTab.web
+                )
+            }
+        } label: {
+            Image(systemName: "book")
+                .font(.system(size: 11, weight: .medium))
+                .frame(width: 22, height: 22)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 22, height: 22)
+        .opacity(0.8)
+        .help("Bookmarks")
+    }
+
+    /// Mid-truncates with `…` so both ends of a long page title stay
+    /// visible in the menu (a leading-only ellipsis loses the host;
+    /// trailing-only loses the page name). Full title is in Settings.
+    static func truncatedMenuLabel(_ label: String, max: Int = 50) -> String {
+        guard label.count > max else { return label }
+        let head = label.prefix(max / 2)
+        let tail = label.suffix(max / 2 - 1)
+        return "\(head)…\(tail)"
+    }
+
+    static let openSettingsTabNotification = Notification.Name("nex.settings.openTab")
+
+    /// Cross-scene hand-off: the notification posted alongside
+    /// `openSettings()` doesn't reach a Settings view that hasn't
+    /// mounted yet, so the requested tab is also stashed here and
+    /// consumed by `SettingsView.onAppear`.
+    nonisolated(unsafe) static var pendingSettingsTab: SettingsTab?
 
     private var navAndURLBar: some View {
         HStack(spacing: 6) {
@@ -93,9 +155,14 @@ struct WebPaneChrome: View {
                 initialURL: displayedURL,
                 paneID: paneID,
                 focusRequestToken: focusRequestToken,
-                onSubmit: onNavigate
+                onSubmit: onNavigate,
+                isStarred: favourites.firstMatching(url: displayedURL) != nil,
+                canStar: !displayedURL.isEmpty,
+                onToggleStar: onToggleStar
             )
             .frame(maxWidth: .infinity)
+
+            bookmarksMenuButton
 
             Button(action: onTabNew) {
                 Image(systemName: "plus")
@@ -268,11 +335,65 @@ private struct WebTabPill: View {
 
 // MARK: - URL bar
 
-/// `NSTextField`-backed URL bar. SwiftUI's `TextField` doesn't expose
-/// first-responder control cleanly, and we need that for ⌘L (focus URL
-/// bar) and for the "select-all-on-focus" behaviour every browser
-/// gives you. Using AppKit directly avoids ad-hoc workarounds.
-struct WebURLBar: NSViewRepresentable {
+/// Composite URL bar: an unbezeled `NSTextField` plus a trailing star
+/// toggle, both wrapped in a single rounded border so the star looks
+/// embedded inside the URL bar rather than hovering next to it. The
+/// AppKit field is kept (rather than swapping to SwiftUI's TextField)
+/// because we need first-responder + select-all-on-focus for ⌘L —
+/// see `WebURLField` below.
+struct WebURLBar: View {
+    let initialURL: String
+    let paneID: UUID
+    let focusRequestToken: UInt64
+    let onSubmit: (String) -> Void
+    /// Star state for the embedded toggle. Star is shown disabled
+    /// (and unclickable) when the URL is empty so a brand-new tab
+    /// can't get a meaningless favourite.
+    var isStarred: Bool = false
+    var canStar: Bool = false
+    var onToggleStar: (() -> Void)?
+
+    var body: some View {
+        HStack(spacing: 4) {
+            WebURLField(
+                initialURL: initialURL,
+                paneID: paneID,
+                focusRequestToken: focusRequestToken,
+                onSubmit: onSubmit
+            )
+            .padding(.leading, 6)
+            .frame(maxWidth: .infinity)
+
+            Button(action: { onToggleStar?() }) {
+                Image(systemName: isStarred ? "star.fill" : "star")
+                    .font(.system(size: 10, weight: .medium))
+                    .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
+                    .foregroundStyle(isStarred ? Color.yellow : Color.secondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canStar)
+            .opacity(canStar ? 1.0 : 0.3)
+            .help(isStarred ? "Remove from favourites" : "Add to favourites")
+            .padding(.trailing, 3)
+        }
+        .frame(height: 21)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color(nsColor: .textBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(Color.secondary.opacity(0.35), lineWidth: 0.5)
+        )
+    }
+}
+
+/// The actual text field. Kept as a thin `NSViewRepresentable` so
+/// `WebURLBar` can compose it with the star button under a shared
+/// SwiftUI border without giving up first-responder control or the
+/// select-all-on-focus behaviour.
+struct WebURLField: NSViewRepresentable {
     let initialURL: String
     let paneID: UUID
     let focusRequestToken: UInt64
@@ -284,11 +405,12 @@ struct WebURLBar: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSTextField {
         let field = NSTextField()
-        field.isBezeled = true
-        field.bezelStyle = .roundedBezel
+        field.isBezeled = false
+        field.isBordered = false
         field.isEditable = true
         field.isSelectable = true
-        field.drawsBackground = true
+        field.drawsBackground = false
+        field.focusRingType = .none
         field.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
         field.placeholderString = "Enter URL"
         field.stringValue = initialURL

--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -14,11 +14,19 @@ struct WebPaneChrome: View {
     /// All open tabs. Used by the tab strip to render pills.
     let tabs: [WebTab]
     let activeTabID: UUID?
+    /// True when the pane is running against a `nonPersistent()`
+    /// data store — surfaced as a filled-lock icon on the storage
+    /// chrome button.
+    var isPrivate: Bool = false
+    /// True while the storage / cookies disclosure panel is open
+    /// (the button shows accent fill while the panel is visible).
+    var storagePanelVisible: Bool = false
     let onBack: () -> Void
     let onForward: () -> Void
     let onReload: () -> Void
     let onNavigate: (String) -> Void
     let onInspect: () -> Void
+    var onToggleStoragePanel: (() -> Void)?
     let onTabSelect: (UUID) -> Void
     let onTabClose: (UUID) -> Void
     let onTabNew: () -> Void
@@ -169,6 +177,8 @@ struct WebPaneChrome: View {
 
             inspectPickupControl
 
+            storageControl
+
             Button(action: onInspect) {
                 Image(systemName: "chevron.left.forwardslash.chevron.right")
                     .font(.system(size: 11, weight: .medium))
@@ -181,6 +191,26 @@ struct WebPaneChrome: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
+    }
+
+    private var storageControl: some View {
+        Button(action: { onToggleStoragePanel?() }) {
+            Image(systemName: isPrivate ? "lock.fill" : "lock")
+                .font(.system(size: 11, weight: storagePanelVisible ? .semibold : .medium))
+                .frame(width: 22, height: 22)
+                .contentShape(Rectangle())
+                .foregroundStyle(
+                    (isPrivate || storagePanelVisible)
+                        ? Color.accentColor
+                        : Color.primary.opacity(0.8)
+                )
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(storagePanelVisible ? Color.accentColor.opacity(0.18) : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .help(isPrivate ? "Storage (private mode)" : "Storage / cookies")
     }
 
     private var inspectPickupControl: some View {

--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -22,21 +22,14 @@ struct WebPaneChrome: View {
     let onTabSelect: (UUID) -> Void
     let onTabClose: (UUID) -> Void
     let onTabNew: () -> Void
-    /// Other panes in the same workspace, available as inspect-pickup
-    /// targets. Empty array hides the menu items (button still
-    /// dispatches a "no-target arm" so the click result lands in the
-    /// inspect queue for later draining).
-    var availableInspectTargets: [InspectTargetOption] = []
-    /// True while the picker is armed for this pane.
+    /// True while the panel is visible AND the page picker is armed.
     var inspectorArmed: Bool = false
-    /// Arm the picker; `sendTo` nil means queue-only.
-    var onArmInspectorPickup: ((UUID?) -> Void)?
-    /// Cancel an active arm without picking.
-    var onDisarmInspectorPickup: (() -> Void)?
-    /// True while a batch-annotate session is in progress.
-    var batchInspectActive: Bool = false
-    /// Begin a batch-annotate session for the resolved destination.
-    var onStartBatchInspect: ((UUID?) -> Void)?
+    /// Pending batch item count — drives the numeric badge on the
+    /// scope icon so a closed panel still surfaces "items waiting".
+    var pendingItemCount: Int = 0
+    /// Toggle the element-pickup panel. Reducer handles start / hide /
+    /// show based on current state; items persist across hide/show.
+    var onTogglePickup: (() -> Void)?
 
     /// Set non-nil to programmatically promote the URL bar to first
     /// responder (consumed by the priority key layer for ⌘L).
@@ -190,72 +183,43 @@ struct WebPaneChrome: View {
         .padding(.vertical, 4)
     }
 
-    /// Element-pickup control. When unarmed, click opens a menu of
-    /// target panes to send the next click's payload to. When armed,
-    /// click cancels. Mirrors `nex web inspect --send-to <pane>` for
-    /// users who'd rather drive it from the UI.
-    @ViewBuilder
     private var inspectPickupControl: some View {
-        if inspectorArmed {
-            Button(action: { onDisarmInspectorPickup?() }) {
-                Image(systemName: batchInspectActive ? "scope" : "scope")
-                    .font(.system(size: 11, weight: .semibold))
-                    .frame(width: 22, height: 22)
-                    .contentShape(Rectangle())
-                    .foregroundStyle(Color.accentColor)
-                    .background(
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(Color.accentColor.opacity(0.18))
-                    )
-            }
-            .buttonStyle(.plain)
-            .help(batchInspectActive
-                ? "Cancel batch annotate (Esc in page)"
-                : "Cancel inspect pickup (Esc in page)")
-        } else {
-            Menu {
-                if availableInspectTargets.isEmpty {
-                    Button("Queue locally (no target)") {
-                        onArmInspectorPickup?(nil)
-                    }
-                    Button("Batch annotate (queue locally)") {
-                        onStartBatchInspect?(nil)
-                    }
-                } else {
-                    Section("Send next click to…") {
-                        ForEach(availableInspectTargets) { target in
-                            Button(target.label) {
-                                onArmInspectorPickup?(target.id)
-                            }
-                        }
-                    }
-                    Section("Batch annotate, send to…") {
-                        ForEach(availableInspectTargets) { target in
-                            Button(target.label) {
-                                onStartBatchInspect?(target.id)
-                            }
-                        }
-                    }
-                    Divider()
-                    Button("Queue locally (no target)") {
-                        onArmInspectorPickup?(nil)
-                    }
-                    Button("Batch annotate (queue locally)") {
-                        onStartBatchInspect?(nil)
+        Button(action: { onTogglePickup?() }) {
+            Image(systemName: "scope")
+                .font(.system(size: 11, weight: inspectorArmed ? .semibold : .medium))
+                .frame(width: 22, height: 22)
+                .contentShape(Rectangle())
+                .foregroundStyle(inspectorArmed ? Color.accentColor : Color.primary.opacity(0.8))
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(inspectorArmed ? Color.accentColor.opacity(0.18) : Color.clear)
+                )
+                .overlay(alignment: .topTrailing) {
+                    if pendingItemCount > 0 {
+                        Text("\(pendingItemCount)")
+                            .font(.system(size: 8, weight: .bold, design: .rounded))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 3)
+                            .frame(minWidth: 12, minHeight: 12)
+                            .background(
+                                Capsule().fill(Color.accentColor)
+                            )
+                            .offset(x: 5, y: -3)
                     }
                 }
-            } label: {
-                Image(systemName: "scope")
-                    .font(.system(size: 11, weight: .medium))
-                    .frame(width: 22, height: 22)
-                    .contentShape(Rectangle())
-            }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .frame(width: 22, height: 22)
-            .opacity(0.8)
-            .help("Pick an element & send to another pane")
         }
+        .buttonStyle(.plain)
+        .help(scopeButtonHelpText)
+    }
+
+    private var scopeButtonHelpText: String {
+        if inspectorArmed {
+            return "Close element pickup (items kept)"
+        }
+        if pendingItemCount > 0 {
+            return "Reopen element pickup (\(pendingItemCount) item\(pendingItemCount == 1 ? "" : "s") waiting)"
+        }
+        return "Pick elements to send to another pane"
     }
 
     private var tabStrip: some View {

--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -22,6 +22,21 @@ struct WebPaneChrome: View {
     let onTabSelect: (UUID) -> Void
     let onTabClose: (UUID) -> Void
     let onTabNew: () -> Void
+    /// Other panes in the same workspace, available as inspect-pickup
+    /// targets. Empty array hides the menu items (button still
+    /// dispatches a "no-target arm" so the click result lands in the
+    /// inspect queue for later draining).
+    var availableInspectTargets: [InspectTargetOption] = []
+    /// True while the picker is armed for this pane.
+    var inspectorArmed: Bool = false
+    /// Arm the picker; `sendTo` nil means queue-only.
+    var onArmInspectorPickup: ((UUID?) -> Void)?
+    /// Cancel an active arm without picking.
+    var onDisarmInspectorPickup: (() -> Void)?
+    /// True while a batch-annotate session is in progress.
+    var batchInspectActive: Bool = false
+    /// Begin a batch-annotate session for the resolved destination.
+    var onStartBatchInspect: ((UUID?) -> Void)?
 
     /// Set non-nil to programmatically promote the URL bar to first
     /// responder (consumed by the priority key layer for ⌘L).
@@ -92,6 +107,8 @@ struct WebPaneChrome: View {
             .opacity(0.8)
             .help("New tab (⌘T)")
 
+            inspectPickupControl
+
             Button(action: onInspect) {
                 Image(systemName: "chevron.left.forwardslash.chevron.right")
                     .font(.system(size: 11, weight: .medium))
@@ -104,6 +121,74 @@ struct WebPaneChrome: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
+    }
+
+    /// Element-pickup control. When unarmed, click opens a menu of
+    /// target panes to send the next click's payload to. When armed,
+    /// click cancels. Mirrors `nex web inspect --send-to <pane>` for
+    /// users who'd rather drive it from the UI.
+    @ViewBuilder
+    private var inspectPickupControl: some View {
+        if inspectorArmed {
+            Button(action: { onDisarmInspectorPickup?() }) {
+                Image(systemName: batchInspectActive ? "scope" : "scope")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+                    .foregroundStyle(Color.accentColor)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color.accentColor.opacity(0.18))
+                    )
+            }
+            .buttonStyle(.plain)
+            .help(batchInspectActive
+                ? "Cancel batch annotate (Esc in page)"
+                : "Cancel inspect pickup (Esc in page)")
+        } else {
+            Menu {
+                if availableInspectTargets.isEmpty {
+                    Button("Queue locally (no target)") {
+                        onArmInspectorPickup?(nil)
+                    }
+                    Button("Batch annotate (queue locally)") {
+                        onStartBatchInspect?(nil)
+                    }
+                } else {
+                    Section("Send next click to…") {
+                        ForEach(availableInspectTargets) { target in
+                            Button(target.label) {
+                                onArmInspectorPickup?(target.id)
+                            }
+                        }
+                    }
+                    Section("Batch annotate, send to…") {
+                        ForEach(availableInspectTargets) { target in
+                            Button(target.label) {
+                                onStartBatchInspect?(target.id)
+                            }
+                        }
+                    }
+                    Divider()
+                    Button("Queue locally (no target)") {
+                        onArmInspectorPickup?(nil)
+                    }
+                    Button("Batch annotate (queue locally)") {
+                        onStartBatchInspect?(nil)
+                    }
+                }
+            } label: {
+                Image(systemName: "scope")
+                    .font(.system(size: 11, weight: .medium))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .frame(width: 22, height: 22)
+            .opacity(0.8)
+            .help("Pick an element & send to another pane")
+        }
     }
 
     private var tabStrip: some View {
@@ -122,6 +207,13 @@ struct WebPaneChrome: View {
             .padding(.bottom, 4)
         }
     }
+}
+
+/// One row in the inspect-pickup menu. `id` is the target pane's
+/// UUID; `label` is what the user sees.
+struct InspectTargetOption: Identifiable, Equatable {
+    let id: UUID
+    let label: String
 }
 
 /// A single tab pill in the strip. Shows the tab's title (or host as

--- a/Nex/Features/WebPane/WebPaneConsoleScript.swift
+++ b/Nex/Features/WebPane/WebPaneConsoleScript.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+/// JS source injected into every WKWebView under a Nex web pane.
+/// Wraps the standard console methods + window error events, posting
+/// a structured record back to the native `nexConsole` script handler.
+///
+/// The wrapper is idempotent: it stashes the originals under
+/// `__nexConsoleOriginals` and bails on re-injection so two
+/// document-start firings (e.g. cross-origin iframe → main frame
+/// navigation) don't double up captured lines.
+///
+/// Serialisation: each argument is run through `JSON.stringify` with
+/// a fallback to `String(arg)` for cyclic / unserialisable values
+/// (DOM nodes, Errors, etc.). The native handler receives a single
+/// `message` string per call so the buffer doesn't need to know
+/// about argument boundaries.
+enum WebPaneConsoleScript {
+    static let source: String = """
+    (function() {
+        if (window.__nexConsoleInstalled) { return; }
+        window.__nexConsoleInstalled = true;
+
+        var bridge = (window.webkit && window.webkit.messageHandlers &&
+                      window.webkit.messageHandlers.nexConsole);
+        if (!bridge) { return; }
+
+        function safeString(v) {
+            try {
+                if (v === undefined) return 'undefined';
+                if (v === null) return 'null';
+                if (typeof v === 'string') return v;
+                if (typeof v === 'function') return v.toString();
+                if (v instanceof Error) return (v.stack || (v.name + ': ' + v.message));
+                var seen = new WeakSet();
+                return JSON.stringify(v, function(k, val) {
+                    if (typeof val === 'object' && val !== null) {
+                        if (seen.has(val)) return '[Circular]';
+                        seen.add(val);
+                    }
+                    return val;
+                });
+            } catch (e) {
+                try { return String(v); } catch (e2) { return '[Unserialisable]'; }
+            }
+        }
+
+        function joinArgs(args) {
+            var parts = [];
+            for (var i = 0; i < args.length; i++) {
+                parts.push(safeString(args[i]));
+            }
+            return parts.join(' ');
+        }
+
+        // Some WebKit builds make `console.error` (and occasionally
+        // other methods) a non-writable own property of `console`,
+        // so a plain `console.error = ...` assignment silently
+        // no-ops and the wrapper never runs. Use defineProperty
+        // with writable+configurable so the override sticks
+        // regardless of the original descriptor.
+        var levels = ['log', 'debug', 'info', 'warn', 'error'];
+        window.__nexConsoleOriginals = {};
+        for (var i = 0; i < levels.length; i++) {
+            (function(level) {
+                var original = console[level] ? console[level].bind(console) : null;
+                window.__nexConsoleOriginals[level] = original;
+                var wrapped = function() {
+                    try {
+                        bridge.postMessage({
+                            level: level,
+                            message: joinArgs(arguments),
+                            url: location.href
+                        });
+                    } catch (postErr) { /* swallow — never break the page */ }
+                    if (original) { try { original.apply(console, arguments); } catch (e) {} }
+                };
+                try {
+                    Object.defineProperty(console, level, {
+                        value: wrapped,
+                        writable: true,
+                        configurable: true
+                    });
+                } catch (defineErr) {
+                    // Last-resort fallback: plain assignment. Some
+                    // hardened consoles disallow defineProperty too,
+                    // in which case neither approach works and we
+                    // just lose this level.
+                    try { console[level] = wrapped; } catch (assignErr) {}
+                }
+            })(levels[i]);
+        }
+
+        // `console.exception` and `console.assert(false, ...)` are
+        // alternate paths some libraries use for error reporting;
+        // route them through the same channel at level=error so
+        // callers don't have to know which one fired.
+        try {
+            var origException = console.exception;
+            Object.defineProperty(console, 'exception', {
+                value: function() {
+                    try {
+                        bridge.postMessage({
+                            level: 'error',
+                            message: joinArgs(arguments),
+                            url: location.href
+                        });
+                    } catch (e) {}
+                    if (origException) { try { origException.apply(console, arguments); } catch (e) {} }
+                },
+                writable: true, configurable: true
+            });
+        } catch (e) {}
+
+        try {
+            var origAssert = console.assert;
+            Object.defineProperty(console, 'assert', {
+                value: function(condition) {
+                    if (!condition) {
+                        var rest = Array.prototype.slice.call(arguments, 1);
+                        try {
+                            bridge.postMessage({
+                                level: 'error',
+                                message: 'Assertion failed: ' + joinArgs(rest),
+                                url: location.href
+                            });
+                        } catch (e) {}
+                    }
+                    if (origAssert) { try { origAssert.apply(console, arguments); } catch (e) {} }
+                },
+                writable: true, configurable: true
+            });
+        } catch (e) {}
+
+        // Uncaught errors. Hook both `window.onerror` and the
+        // addEventListener channel — different page configurations
+        // surface errors through one or the other (older pages with
+        // `window.onerror = ...` would shadow our addEventListener
+        // listener otherwise). Capture phase gives us the event
+        // before any page-level handler can call preventDefault.
+        function reportPageError(message, source, lineno, colno, error) {
+            try {
+                var msgParts = [];
+                if (error && error.stack) {
+                    msgParts.push(error.stack);
+                } else if (message) {
+                    msgParts.push(String(message));
+                }
+                if (source) {
+                    msgParts.push('(' + source + ':' + (lineno || 0) + ':' + (colno || 0) + ')');
+                }
+                bridge.postMessage({
+                    level: 'error',
+                    message: msgParts.join(' ') || 'Script error',
+                    url: location.href,
+                    lineNumber: lineno || null,
+                    columnNumber: colno || null
+                });
+            } catch (e) {}
+        }
+
+        window.addEventListener('error', function(ev) {
+            reportPageError(
+                ev.message, ev.filename, ev.lineno, ev.colno, ev.error
+            );
+        }, true);
+
+        var prevOnError = window.onerror;
+        window.onerror = function(msg, src, lineno, colno, error) {
+            reportPageError(msg, src, lineno, colno, error);
+            if (typeof prevOnError === 'function') {
+                try { return prevOnError.apply(this, arguments); } catch (e) {}
+            }
+            // Return false so the browser still surfaces the error
+            // to the Inspector / page handler chain.
+            return false;
+        };
+
+        window.addEventListener('unhandledrejection', function(ev) {
+            var reason = ev && ev.reason;
+            try {
+                bridge.postMessage({
+                    level: 'error',
+                    message: 'Unhandled promise rejection: ' + safeString(reason),
+                    url: location.href
+                });
+            } catch (e) {}
+        }, true);
+
+        // Subresource load failures (<img>, <script>, <link>, <video>,
+        // <audio>, <iframe>). The `error` event fires on the element
+        // itself and does not bubble, but it does propagate through
+        // the capture phase — listening at `window` with `capture:true`
+        // is the standard pattern. The `ev.target !== window` guard
+        // distinguishes these from script-level errors which are
+        // already handled by the regular `error` listener above.
+        window.addEventListener('error', function(ev) {
+            var target = ev.target;
+            if (!target || target === window) return;
+            try {
+                var tag = (target.tagName || '').toLowerCase();
+                var src = target.src || target.href || target.currentSrc || '';
+                bridge.postMessage({
+                    level: 'error',
+                    message: 'resource load failed: <' + tag + '> ' + src,
+                    url: location.href
+                });
+            } catch (e) {}
+        }, true);
+
+        // Content Security Policy violations.
+        window.addEventListener('securitypolicyviolation', function(ev) {
+            try {
+                bridge.postMessage({
+                    level: 'error',
+                    message: 'CSP violation: ' + (ev.violatedDirective || '') +
+                        ' — blocked ' + (ev.blockedURI || '') +
+                        ' (effective: ' + (ev.effectiveDirective || '') + ')',
+                    url: location.href
+                });
+            } catch (e) {}
+        }, true);
+
+        // Network-level error capture. WebKit emits `Failed to load
+        // resource`, CORS errors, and fetch failures to the Inspector
+        // directly from its C++ networking stack — those never touch
+        // JS console.error, so the wrappers above can't see them.
+        // Hook `fetch` and `XMLHttpRequest` instead so any failed
+        // request surfaces through the same channel.
+
+        var originalFetch = window.fetch;
+        if (typeof originalFetch === 'function') {
+            window.fetch = function() {
+                var url = '';
+                try {
+                    var arg = arguments[0];
+                    url = (typeof arg === 'string') ? arg : (arg && arg.url) || '';
+                } catch (e) {}
+                return originalFetch.apply(this, arguments).then(
+                    function(response) {
+                        try {
+                            if (!response.ok) {
+                                bridge.postMessage({
+                                    level: 'error',
+                                    message: 'fetch ' + response.status + ' ' + (response.statusText || '') +
+                                        ' — ' + url,
+                                    url: location.href
+                                });
+                            }
+                        } catch (e) {}
+                        return response;
+                    },
+                    function(err) {
+                        try {
+                            bridge.postMessage({
+                                level: 'error',
+                                message: 'fetch failed — ' + (err && err.message ? err.message : String(err)) +
+                                    ' — ' + url,
+                                url: location.href
+                            });
+                        } catch (postErr) {}
+                        throw err;
+                    }
+                );
+            };
+        }
+
+        try {
+            var XHRProto = XMLHttpRequest.prototype;
+            var originalOpen = XHRProto.open;
+            var originalSend = XHRProto.send;
+            XHRProto.open = function(method, requestURL) {
+                try { this.__nexMethod = method; this.__nexURL = requestURL; } catch (e) {}
+                return originalOpen.apply(this, arguments);
+            };
+            XHRProto.send = function() {
+                var xhr = this;
+                function reportFailure(kind, detail) {
+                    try {
+                        bridge.postMessage({
+                            level: 'error',
+                            message: 'XHR ' + kind + ' — ' + (xhr.__nexMethod || 'GET') + ' ' +
+                                (xhr.__nexURL || '') + (detail ? ' — ' + detail : ''),
+                            url: location.href
+                        });
+                    } catch (e) {}
+                }
+                xhr.addEventListener('error', function() { reportFailure('error'); });
+                xhr.addEventListener('timeout', function() { reportFailure('timeout'); });
+                xhr.addEventListener('abort', function() { reportFailure('abort'); });
+                xhr.addEventListener('load', function() {
+                    if (xhr.status >= 400) {
+                        reportFailure(String(xhr.status), xhr.statusText || '');
+                    }
+                });
+                return originalSend.apply(this, arguments);
+            };
+        } catch (e) {}
+    })();
+    """
+}

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -2,11 +2,10 @@ import AppKit
 import Foundation
 import WebKit
 
-/// Per-pane owner of WKWebView instances. Phase 1 ships with a single
-/// tab per coordinator; Phase 2 grows this to N tabs sharing one
-/// `WKWebsiteDataStore`.
+/// Per-pane owner of WKWebView instances, one per tab, all sharing
+/// the pane's `WKWebsiteDataStore`.
 ///
-/// Lifecycle contract — mirrors `SurfaceManager` for terminal panes:
+/// Lifecycle contract, mirrors `SurfaceManager` for terminal panes:
 /// - `WebPaneStore` creates the coordinator lazily on first access.
 /// - `WebPaneView.makeNSView` retrieves the active tab's WKWebView and
 ///   embeds it; if the surrounding split is later torn down by a layout
@@ -20,8 +19,7 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
     let paneID: UUID
     let dataStore: WKWebsiteDataStore
 
-    /// Per-tab WKWebView. Phase 1 keeps at most one entry; the
-    /// dictionary shape lets Phase 2 add tabs without refactoring.
+    /// Per-tab WKWebView. Keyed by tab id.
     private var webViews: [UUID: WKWebView] = [:]
     /// Per-tab frame-based container around the WKWebView. Acts as
     /// the "attachment view" the Inspector docks into — see
@@ -78,8 +76,30 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         return host
     }
 
-    /// Get-or-create the WebView for the given tab. Phase 1's view code
-    /// only ever asks for `activeTab.id`.
+    /// Look up the existing container without creating one. Used by
+    /// the multi-tab host view to enumerate already-mounted tabs
+    /// without forcing a load.
+    func containerIfExists(tabID: UUID) -> WebPaneTabContainer? {
+        containers[tabID]
+    }
+
+    /// Tear down a single tab — invalidates its KVO tokens, drops
+    /// its WKWebView from the dict, removes its container from the
+    /// view hierarchy. Used by `webPaneTabClose` to release resources
+    /// without affecting sibling tabs.
+    func destroyTab(tabID: UUID) {
+        if let tokens = kvoTokens.removeValue(forKey: tabID) {
+            for token in tokens {
+                token.invalidate()
+            }
+        }
+        if let container = containers.removeValue(forKey: tabID) {
+            container.removeFromSuperview()
+        }
+        webViews.removeValue(forKey: tabID)
+    }
+
+    /// Get-or-create the WebView for the given tab.
     func webView(for tab: WebTab) -> WKWebView {
         if let existing = webViews[tab.id] { return existing }
 
@@ -108,7 +128,7 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         // `pane web url` reply. The KVO closure is `@Sendable`
         // under Swift 6 strict concurrency, so we can't read
         // `webView.url` / `webView.title` (both main-actor) from
-        // it directly — capture the webView pointer and read on
+        // it directly; capture the webView pointer and read on
         // the main actor inside Task.
         let tabID = tab.id
         let snapshotAndPost: @Sendable (WKWebView?) -> Void = { [weak self] webView in

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -32,8 +32,56 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
     /// `title`.
     static let stateDidChangeNotification = Notification.Name("WebPaneCoordinator.stateDidChange")
 
+    /// Notification posted for every captured console line.
+    /// User info: `paneID`, `tabID`, `level`, `message`, `url`,
+    /// optional `lineNumber`, `columnNumber`.
+    static let consoleLineNotification = Notification.Name("WebPaneCoordinator.consoleLine")
+
+    /// Notification posted for every accepted (main-frame, nonce-
+    /// matched) inspect-result payload. User info: `paneID`, `tabID`,
+    /// `payload: [String: Any]` (the raw JSON from the picker JS).
+    static let inspectResultNotification = Notification.Name("WebPaneCoordinator.inspectResult")
+
+    /// Notification posted when the user clicks a batch-marker badge
+    /// rendered on the page. User info: `paneID`, `tabID`, `itemID`
+    /// (the BatchInspectItem.id passed in via `setBatchMarkers`).
+    static let batchMarkerClickedNotification = Notification.Name("WebPaneCoordinator.batchMarkerClicked")
+
+    /// Notification posted when the user types in the on-page comment
+    /// popover. User info: `paneID`, `tabID`, `itemID`, `comment`.
+    static let batchCommentEditedNotification = Notification.Name("WebPaneCoordinator.batchCommentEdited")
+
+    /// Notification posted when the user clicks Done (or hits Esc)
+    /// in the page popover. User info: `paneID`, `tabID`, `itemID`.
+    static let batchPopoverDismissedNotification = Notification.Name("WebPaneCoordinator.batchPopoverDismissed")
+
+    /// Notification posted when the user clicks Remove in the page
+    /// popover. User info: `paneID`, `tabID`, `itemID`.
+    static let batchItemRemovedFromPopoverNotification = Notification.Name("WebPaneCoordinator.batchItemRemovedFromPopover")
+
     /// KVO tokens per webview, so deinit (or destroy) can detach.
     private var kvoTokens: [UUID: [NSKeyValueObservation]] = [:]
+
+    // MARK: - Inspector arm state
+
+    /// Currently-armed inspector tab. Used to validate inspect
+    /// payloads and to disarm on tab switch/close.
+    private(set) var armedInspectorTabID: UUID?
+    /// Nonce installed at arm time. Compared against every inspect
+    /// payload's `nonce`; mismatch → drop.
+    private(set) var armedInspectorNonce: String?
+    /// True when the picker should remain armed across multiple
+    /// clicks (batch annotate mode). The coordinator stops auto-
+    /// disarming on inbound `nexInspect` messages while this is set;
+    /// the page-side picker also keeps its overlay/listeners attached.
+    private(set) var armedInspectorIsSticky: Bool = false
+
+    /// URL we last asked each tab's WKWebView to load via
+    /// `navigate(tab:to:)`. On a load failure the WKWebView's `url`
+    /// property reverts to `about:blank` or the previous successful
+    /// URL; we re-emit this value through `stateDidChangeNotification`
+    /// so the URL bar keeps showing what the user tried.
+    private var lastAttemptedURL: [UUID: String] = [:]
 
     init(
         paneID: UUID,
@@ -97,6 +145,16 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
             container.removeFromSuperview()
         }
         webViews.removeValue(forKey: tabID)
+        lastAttemptedURL.removeValue(forKey: tabID)
+        showingErrorPage.remove(tabID)
+        // Drop the inspector arm if it pointed at the destroyed tab
+        // — a late click against the gone WebView could otherwise
+        // route an inspect payload nowhere useful.
+        if armedInspectorTabID == tabID {
+            armedInspectorTabID = nil
+            armedInspectorNonce = nil
+            armedInspectorIsSticky = false
+        }
     }
 
     /// Get-or-create the WebView for the given tab.
@@ -114,7 +172,36 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         // is the well-known reliable path for a developer-facing
         // browser.
         config.preferences.setValue(true, forKey: "developerExtrasEnabled")
-        // No script handlers in Phase 1 — they arrive in Phase 3.
+
+        // Phase 3: console + inspector scripts. A weak proxy receives
+        // the script messages so the WKWebView ↔ message-handler edge
+        // doesn't retain the coordinator (the store owns the
+        // coordinator; we want it released on pane close).
+        let handler = WebPaneScriptHandler(coordinator: self, tabID: tab.id)
+        config.userContentController.add(handler, name: "nexConsole")
+        config.userContentController.add(handler, name: "nexInspect")
+        config.userContentController.add(handler, name: "nexBatchMarker")
+        // Console wraps `console.*` so we want it to run before page
+        // code; `forMainFrameOnly: false` so cross-origin iframes
+        // also report (still scoped to this pane's WebView).
+        config.userContentController.addUserScript(WKUserScript(
+            source: WebPaneConsoleScript.source,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false
+        ))
+        // Inspector + batch markers only run in the main frame —
+        // iframe support is out of scope and would also leak overlays
+        // across origins.
+        config.userContentController.addUserScript(WKUserScript(
+            source: WebPaneInspectorScript.source,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        ))
+        config.userContentController.addUserScript(WKUserScript(
+            source: WebPaneBatchMarkerScript.source,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        ))
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = self
@@ -178,25 +265,61 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         let urlString = Self.normalizeURLInput(rawURLString)
         guard let url = URL(string: urlString) else { return nil }
         let webView = webView(for: tab)
+        lastAttemptedURL[tab.id] = url.absoluteString
+        showingErrorPage.remove(tab.id)
         webView.load(URLRequest(url: url))
         return url
     }
 
+    /// Reverse-lookup helper for `WKNavigationDelegate` callbacks —
+    /// the callbacks deliver the `WKWebView` but we key everything
+    /// off the tab id.
+    private func tabID(for webView: WKWebView) -> UUID? {
+        webViews.first(where: { $0.value === webView })?.key
+    }
+
     /// Promote a user-typed URL bar value into something `URL` can
-    /// parse. "example.com" → "https://example.com"; an existing
-    /// scheme is left intact. Nonisolated so the reducer (which
-    /// isn't always on the main actor) can call it before dispatch.
+    /// parse. Defaults to `https://` for typical hostnames and to
+    /// `http://` for local / private hosts (localhost, 127.0.0.1,
+    /// `.local`, RFC 1918 ranges, single-label hosts) where dev
+    /// servers usually aren't TLS-terminated. An existing scheme
+    /// is left intact. Nonisolated so the reducer (which isn't
+    /// always on the main actor) can call it before dispatch.
     nonisolated static func normalizeURLInput(_ raw: String) -> String {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return trimmed }
         if trimmed.contains("://") { return trimmed }
         if trimmed.hasPrefix("about:") { return trimmed }
-        return "https://\(trimmed)"
+
+        // Extract the host portion ("host[:port]/path?..." → "host").
+        let beforePath = trimmed.split(separator: "/", maxSplits: 1).first.map(String.init) ?? trimmed
+        let hostOnly = beforePath.split(separator: ":").first.map(String.init) ?? beforePath
+        let scheme = isLocalOrInternalHost(hostOnly) ? "http" : "https"
+        return "\(scheme)://\(trimmed)"
+    }
+
+    nonisolated static func isLocalOrInternalHost(_ host: String) -> Bool {
+        let lower = host.lowercased()
+        if lower.isEmpty { return false }
+        if lower == "localhost" || lower == "127.0.0.1" || lower == "0.0.0.0" || lower == "::1" { return true }
+        if lower.hasSuffix(".local") || lower.hasSuffix(".localhost") { return true }
+        // Single-label (no dot) → assume internal hostname / mDNS.
+        if !lower.contains(".") { return true }
+        // RFC 1918 IPv4 ranges + link-local.
+        let parts = lower.split(separator: ".").compactMap { Int($0) }
+        if parts.count == 4 {
+            if parts[0] == 10 { return true }
+            if parts[0] == 192, parts[1] == 168 { return true }
+            if parts[0] == 172, (16 ... 31).contains(parts[1]) { return true }
+            if parts[0] == 169, parts[1] == 254 { return true }
+        }
+        return false
     }
 
     @discardableResult
     func goBack(tabID: UUID) -> Bool {
         guard let webView = webViews[tabID], webView.canGoBack else { return false }
+        showingErrorPage.remove(tabID)
         webView.goBack()
         return true
     }
@@ -204,6 +327,7 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
     @discardableResult
     func goForward(tabID: UUID) -> Bool {
         guard let webView = webViews[tabID], webView.canGoForward else { return false }
+        showingErrorPage.remove(tabID)
         webView.goForward()
         return true
     }
@@ -211,6 +335,15 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
     @discardableResult
     func reload(tabID: UUID, hard: Bool = false) -> Bool {
         guard let webView = webViews[tabID] else { return false }
+        // Reload while sitting on our error stub should retry the
+        // original URL, not redraw the stub.
+        if showingErrorPage.contains(tabID),
+           let attempted = lastAttemptedURL[tabID],
+           let url = URL(string: attempted) {
+            showingErrorPage.remove(tabID)
+            webView.load(URLRequest(url: url))
+            return true
+        }
         if hard {
             webView.reloadFromOrigin()
         } else {
@@ -335,10 +468,497 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         }
     }
 
-    // WKNavigationDelegate methods are intentionally left at default
-    // (.allow) for Phase 1 — link clicks navigate in-place. Phase 4
-    // will likely intercept .linkActivated to support "open in new
-    // tab".
+    // MARK: - WKNavigationDelegate
+
+    @preconcurrency
+    nonisolated func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation _: WKNavigation!,
+        withError error: Error
+    ) {
+        let message = (error as NSError).localizedDescription
+        Task { @MainActor [weak self, weak webView] in
+            self?.presentLoadFailure(on: webView, message: message)
+        }
+    }
+
+    @preconcurrency
+    nonisolated func webView(
+        _ webView: WKWebView,
+        didFail _: WKNavigation!,
+        withError error: Error
+    ) {
+        let message = (error as NSError).localizedDescription
+        Task { @MainActor [weak self, weak webView] in
+            self?.presentLoadFailure(on: webView, message: message)
+        }
+    }
+
+    @preconcurrency
+    nonisolated func webView(
+        _ webView: WKWebView,
+        didStartProvisionalNavigation navigation: WKNavigation!
+    ) {
+        // Any real provisional navigation (URL bar, Retry link,
+        // back/forward, page-initiated nav) means the user is
+        // leaving the error stub. Clear the flag so a subsequent
+        // didFinish for the new load is allowed to clear
+        // lastAttemptedURL. Skips clearing for the stub's own
+        // navigation (identified by identity) — that load is the
+        // error page itself, not a recovery attempt.
+        Task { @MainActor [weak self, weak webView] in
+            guard let self, let webView, let tabID = tabID(for: webView) else { return }
+            if let navigation, stubNavigations.remove(ObjectIdentifier(navigation)) != nil {
+                return
+            }
+            showingErrorPage.remove(tabID)
+        }
+    }
+
+    @preconcurrency
+    nonisolated func webView(
+        _ webView: WKWebView,
+        didFinish _: WKNavigation!
+    ) {
+        // Successful nav clears the attempted-URL backstop so a
+        // subsequent failure on a different page doesn't resurrect
+        // the previous attempt. Skips clearing when the just-loaded
+        // page is our own error stub — that's a "failed" page, not
+        // a successful load.
+        Task { @MainActor [weak self, weak webView] in
+            guard let self, let webView, let tabID = tabID(for: webView) else { return }
+            if showingErrorPage.contains(tabID) { return }
+            lastAttemptedURL.removeValue(forKey: tabID)
+        }
+    }
+
+    /// Tabs that are currently displaying our inline error stub
+    /// instead of real content. Used to suppress the `didFinish`
+    /// clear of `lastAttemptedURL` and to skip "page reload" type
+    /// behaviours that don't make sense on an error page.
+    private var showingErrorPage: Set<UUID> = []
+
+    /// Identities of `WKNavigation` instances returned by
+    /// `loadHTMLString` for the error stub. `didStartProvisionalNavigation`
+    /// uses these to recognise the stub's own provisional load and
+    /// skip clearing `showingErrorPage` for it — every other
+    /// provisional nav means the user is recovering from the error.
+    private var stubNavigations: Set<ObjectIdentifier> = []
+
+    /// Replace the WKWebView's content with a small dark error page
+    /// instead of leaving a blank surface after a navigation failure.
+    /// Using `baseURL = <failed URL>` makes WKWebView's `url` property
+    /// report the failed URL, so the URL bar naturally stays on what
+    /// the user tried (no manual re-emit shim needed).
+    private func presentLoadFailure(on webView: WKWebView?, message: String) {
+        guard let webView, let tabID = tabID(for: webView) else { return }
+        let failedURL = lastAttemptedURL[tabID]
+            ?? webView.url?.absoluteString
+            ?? ""
+        let html = Self.errorPageHTML(failedURL: failedURL, message: message)
+        let baseURL = URL(string: failedURL)
+        showingErrorPage.insert(tabID)
+        if let nav = webView.loadHTMLString(html, baseURL: baseURL) {
+            stubNavigations.insert(ObjectIdentifier(nav))
+        }
+    }
+
+    /// Build the inline error page HTML. Plain, dark, single-file,
+    /// no external assets so it always renders regardless of network
+    /// state. The Retry button is a normal anchor — clicking it
+    /// re-issues a navigation through the same delegate chain.
+    private static func errorPageHTML(failedURL: String, message: String) -> String {
+        /// Escape for HTML attribute / text. We're embedding inside
+        /// a literal string so just neutralise the obvious unsafe
+        /// characters.
+        func escape(_ s: String) -> String {
+            s.replacingOccurrences(of: "&", with: "&amp;")
+                .replacingOccurrences(of: "<", with: "&lt;")
+                .replacingOccurrences(of: ">", with: "&gt;")
+                .replacingOccurrences(of: "\"", with: "&quot;")
+        }
+        let displayURL = escape(failedURL.isEmpty ? "(unknown)" : failedURL)
+        let displayMessage = escape(message.isEmpty ? "The page could not be loaded." : message)
+        let retryHref = escape(failedURL)
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <title>Couldn't load page</title>
+        <style>
+        :root { color-scheme: dark; }
+        html, body {
+            height: 100%; margin: 0;
+            background: #1c1c1e; color: #f2f2f7;
+            font: 14px -apple-system, system-ui, sans-serif;
+        }
+        .wrap {
+            min-height: 100%; display: flex;
+            align-items: center; justify-content: center;
+            padding: 32px;
+        }
+        .card {
+            max-width: 480px;
+            background: rgba(255,255,255,0.04);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 10px;
+            padding: 24px 28px;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.4);
+        }
+        .icon {
+            width: 32px; height: 32px;
+            border-radius: 50%;
+            background: rgba(255,69,58,0.18);
+            color: #FF453A;
+            display: flex; align-items: center; justify-content: center;
+            font: 700 16px/1 -apple-system, system-ui, sans-serif;
+            margin-bottom: 14px;
+        }
+        h1 {
+            font-size: 16px; font-weight: 600;
+            margin: 0 0 6px;
+        }
+        .url {
+            font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+            color: #5AC8FA;
+            word-break: break-all;
+            margin: 0 0 14px;
+        }
+        p.message {
+            margin: 0 0 18px;
+            color: rgba(242,242,247,0.75);
+            line-height: 1.45;
+        }
+        .actions { display: flex; gap: 8px; }
+        a.btn {
+            display: inline-block;
+            padding: 6px 14px;
+            border-radius: 6px;
+            background: #0A84FF;
+            color: white;
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 12px;
+        }
+        a.btn.ghost {
+            background: transparent;
+            color: rgba(242,242,247,0.85);
+            border: 1px solid rgba(255,255,255,0.18);
+        }
+        a.btn:hover { filter: brightness(1.1); }
+        </style>
+        </head>
+        <body>
+        <div class="wrap">
+        <div class="card">
+        <div class="icon">!</div>
+        <h1>Couldn't load page</h1>
+        <p class="url">\(displayURL)</p>
+        <p class="message">\(displayMessage)</p>
+        <div class="actions">
+        <a class="btn" href="\(retryHref)">Retry</a>
+        </div>
+        </div>
+        </div>
+        </body>
+        </html>
+        """
+    }
+
+    // MARK: - Inspector arm/disarm (Phase 3)
+
+    /// Arm the element picker for the named tab. Generates a 128-bit
+    /// nonce, stashes it for validation, and tells the in-page picker
+    /// to listen for the next click. `sticky: true` keeps the picker
+    /// armed after each click (used by batch-annotate mode); the
+    /// default single-shot path disarms automatically on the next
+    /// delivered message.
+    @discardableResult
+    func armInspector(tabID: UUID, sticky: Bool = false) -> String? {
+        guard let webView = webViews[tabID] else { return nil }
+        // Disarm any previous arm first — both nonce-side and
+        // page-side. This handles the "user re-fires `nex web inspect`
+        // before clicking" case cleanly.
+        if let prev = armedInspectorTabID, prev != tabID,
+           let prevWebView = webViews[prev] {
+            prevWebView.evaluateJavaScript("__nexInspectorDisable && __nexInspectorDisable();")
+        }
+        let nonce = Self.makeNonce()
+        armedInspectorTabID = tabID
+        armedInspectorNonce = nonce
+        armedInspectorIsSticky = sticky
+        // Escape the nonce as JS string literal. Our nonce is hex
+        // only so `'\(nonce)'` is safe, but be defensive in case
+        // the format ever changes.
+        let stickyArg = sticky ? "true" : "false"
+        let js = "window.__nexInspectorEnable && window.__nexInspectorEnable('\(nonce)', \(stickyArg));"
+        webView.evaluateJavaScript(js)
+        return nonce
+    }
+
+    /// Symmetric tear-down. Clears the armed-nonce state and tells
+    /// the in-page picker to clean up its overlay + listeners.
+    func disarmInspector() {
+        let tabID = armedInspectorTabID
+        armedInspectorTabID = nil
+        armedInspectorNonce = nil
+        armedInspectorIsSticky = false
+        guard let tabID, let webView = webViews[tabID] else { return }
+        webView.evaluateJavaScript("__nexInspectorDisable && __nexInspectorDisable();")
+    }
+
+    /// Generate a 128-bit hex nonce. Good enough — the channel is
+    /// in-process and the nonce only needs to defend against a page
+    /// JS attacker spoofing inspect messages while the picker is
+    /// armed on this exact pane.
+    private static func makeNonce() -> String {
+        var bytes = [UInt8](repeating: 0, count: 16)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - WKScriptMessageHandler bridge (Phase 3)
+
+    /// Handle a `nexConsole` message. Always main-actor — `userInfo`
+    /// is built and posted synchronously so the reducer sees lines
+    /// in the order WebKit fired them.
+    fileprivate func handleConsoleMessage(tabID: UUID, body: Any) {
+        guard let dict = body as? [String: Any] else { return }
+        let level = (dict["level"] as? String) ?? "log"
+        let message = (dict["message"] as? String) ?? ""
+        let url = (dict["url"] as? String) ?? ""
+        var userInfo: [AnyHashable: Any] = [
+            "paneID": paneID,
+            "tabID": tabID,
+            "level": level,
+            "message": message,
+            "url": url
+        ]
+        if let line = dict["lineNumber"] as? Int { userInfo["lineNumber"] = line }
+        if let col = dict["columnNumber"] as? Int { userInfo["columnNumber"] = col }
+        NotificationCenter.default.post(
+            name: Self.consoleLineNotification,
+            object: nil,
+            userInfo: userInfo
+        )
+    }
+
+    /// Handle a `nexInspect` message. Validates main frame + nonce
+    /// against the currently-armed state before posting; mismatched
+    /// messages are dropped silently to avoid hinting to page JS
+    /// that the channel exists.
+    fileprivate func handleInspectMessage(tabID: UUID, body: Any, isMainFrame: Bool) {
+        guard isMainFrame else { return }
+        guard let armedTab = armedInspectorTabID, armedTab == tabID else { return }
+        guard let armedNonce = armedInspectorNonce else { return }
+        guard let dict = body as? [String: Any] else { return }
+        guard let nonce = dict["nonce"] as? String, nonce == armedNonce else { return }
+
+        // Escape hatch: picker may report a user-cancelled arm
+        // (e.g. user pressed Escape). Disarm here, don't surface
+        // a result.
+        if (dict["cancelled"] as? Bool) == true {
+            disarmInspector()
+            return
+        }
+
+        // Single-shot mode disarms before posting so observers see
+        // consistent post-click state. Sticky (batch) mode keeps the
+        // arm live; the reducer is responsible for explicitly
+        // disarming when the batch is sent or cancelled.
+        let wasSticky = armedInspectorIsSticky
+        if !wasSticky {
+            disarmInspector()
+        }
+
+        NotificationCenter.default.post(
+            name: Self.inspectResultNotification,
+            object: nil,
+            userInfo: [
+                "paneID": paneID,
+                "tabID": tabID,
+                "payload": dict
+            ]
+        )
+    }
+
+    // MARK: - Batch markers (Phase 3.5)
+
+    /// Push the full list of batch-annotate items to the named tab so
+    /// the page renders numbered badges over each captured element.
+    /// The selector is re-queried in JS on every redraw so badges
+    /// follow live DOM changes (responsive layouts, post-mount React
+    /// reflows, etc.) rather than the rect snapshot captured at
+    /// click time.
+    func syncBatchMarkers(tabID: UUID, items: [BatchMarkerInput]) {
+        guard let webView = webViews[tabID] else { return }
+        let dicts: [[String: Any]] = items.map {
+            [
+                "id": $0.id.uuidString,
+                "selector": $0.selector,
+                "label": $0.label,
+                "comment": $0.comment
+            ]
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: dicts),
+              let json = String(data: data, encoding: .utf8) else { return }
+        let js = "window.__nexBatchSetMarkers && window.__nexBatchSetMarkers(\(json));"
+        webView.evaluateJavaScript(js)
+    }
+
+    /// Hide the page popover + focus ring without removing any
+    /// markers. Used when the user clicks Done / presses Esc in the
+    /// popover so they can pick the next element.
+    func unfocusBatch(tabID: UUID) {
+        guard let webView = webViews[tabID] else { return }
+        webView.evaluateJavaScript("window.__nexBatchUnfocus && window.__nexBatchUnfocus();")
+    }
+
+    /// Push a single external (panel-side) comment update into the
+    /// page popover. JS no-ops the update if the textarea is being
+    /// typed into, so cross-side edits don't clobber the cursor.
+    func pushBatchComment(tabID: UUID, itemID: UUID, comment: String) {
+        guard let webView = webViews[tabID] else { return }
+        let escaped: String = {
+            guard let data = try? JSONSerialization.data(withJSONObject: [comment]),
+                  let s = String(data: data, encoding: .utf8) else { return "\"\"" }
+            // strip the leading "[" and trailing "]" to get the JSON string literal
+            return String(s.dropFirst().dropLast())
+        }()
+        let js = "window.__nexBatchUpdateComment && " +
+            "window.__nexBatchUpdateComment('\(itemID.uuidString)', \(escaped));"
+        webView.evaluateJavaScript(js)
+    }
+
+    func clearBatchMarkers(tabID: UUID) {
+        guard let webView = webViews[tabID] else { return }
+        webView.evaluateJavaScript("window.__nexBatchClearMarkers && window.__nexBatchClearMarkers();")
+    }
+
+    /// Pulse the named item's badge and draw the persistent focus
+    /// ring around its element. When `scrollIntoView` is true (panel-
+    /// originated focus) the page also scrolls the element into view;
+    /// for page-originated clicks the element is already under the
+    /// user's cursor so we skip the scroll. `itemID` is the
+    /// BatchInspectItem.id passed via `syncBatchMarkers`. Safe to
+    /// call when the marker isn't on the page — JS no-ops.
+    func highlightBatchMarker(tabID: UUID, itemID: UUID, scrollIntoView: Bool = true) {
+        guard let webView = webViews[tabID] else { return }
+        let scrollArg = scrollIntoView ? "true" : "false"
+        let js = "window.__nexBatchHighlight && window.__nexBatchHighlight('\(itemID.uuidString)', \(scrollArg));"
+        webView.evaluateJavaScript(js)
+    }
+
+    /// Handle a `nexBatchMarker` message — either a badge click or a
+    /// popover textarea edit. Two envelopes:
+    ///   `{ id }`                                — badge clicked
+    ///   `{ commentChanged: { id, comment } }`   — popover textarea
+    fileprivate func handleBatchMarkerMessage(tabID: UUID, body: Any, isMainFrame: Bool) {
+        guard isMainFrame else { return }
+        guard let dict = body as? [String: Any] else { return }
+
+        // Envelope-typed branches first (more specific than the
+        // bare `{ id }` badge-click form).
+        if let edit = dict["commentChanged"] as? [String: Any],
+           let idString = edit["id"] as? String,
+           let itemID = UUID(uuidString: idString) {
+            let comment = (edit["comment"] as? String) ?? ""
+            NotificationCenter.default.post(
+                name: Self.batchCommentEditedNotification,
+                object: nil,
+                userInfo: [
+                    "paneID": paneID,
+                    "tabID": tabID,
+                    "itemID": itemID,
+                    "comment": comment
+                ]
+            )
+            return
+        }
+        if let dismiss = dict["dismiss"] as? [String: Any],
+           let idString = dismiss["id"] as? String,
+           let itemID = UUID(uuidString: idString) {
+            NotificationCenter.default.post(
+                name: Self.batchPopoverDismissedNotification,
+                object: nil,
+                userInfo: ["paneID": paneID, "tabID": tabID, "itemID": itemID]
+            )
+            return
+        }
+        if let remove = dict["remove"] as? [String: Any],
+           let idString = remove["id"] as? String,
+           let itemID = UUID(uuidString: idString) {
+            NotificationCenter.default.post(
+                name: Self.batchItemRemovedFromPopoverNotification,
+                object: nil,
+                userInfo: ["paneID": paneID, "tabID": tabID, "itemID": itemID]
+            )
+            return
+        }
+
+        guard let idString = dict["id"] as? String,
+              let itemID = UUID(uuidString: idString) else { return }
+        NotificationCenter.default.post(
+            name: Self.batchMarkerClickedNotification,
+            object: nil,
+            userInfo: [
+                "paneID": paneID,
+                "tabID": tabID,
+                "itemID": itemID
+            ]
+        )
+    }
+}
+
+/// Bridge between WKScriptMessageHandler (which Cocoa retains
+/// strongly) and `WebPaneCoordinator` (owned by `WebPaneStore`).
+/// Holds a weak ref so the coordinator can deallocate when its pane
+/// closes, even if WebKit hasn't torn down its content controller
+/// yet.
+@MainActor
+private final class WebPaneScriptHandler: NSObject, WKScriptMessageHandler {
+    weak var coordinator: WebPaneCoordinator?
+    let tabID: UUID
+
+    init(coordinator: WebPaneCoordinator, tabID: UUID) {
+        self.coordinator = coordinator
+        self.tabID = tabID
+        super.init()
+    }
+
+    @preconcurrency
+    nonisolated func userContentController(
+        _: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        let name = message.name
+        let body = message.body
+        let isMainFrame = message.frameInfo.isMainFrame
+        let tabID = tabID
+        Task { @MainActor [weak self] in
+            guard let coord = self?.coordinator else { return }
+            switch name {
+            case "nexConsole":
+                coord.handleConsoleMessage(tabID: tabID, body: body)
+            case "nexInspect":
+                coord.handleInspectMessage(tabID: tabID, body: body, isMainFrame: isMainFrame)
+            case "nexBatchMarker":
+                coord.handleBatchMarkerMessage(tabID: tabID, body: body, isMainFrame: isMainFrame)
+            default:
+                break
+            }
+        }
+    }
+}
+
+/// Sendable record passed to `syncBatchMarkers` from the reducer.
+struct BatchMarkerInput: Equatable {
+    let id: UUID
+    let selector: String
+    let label: String
+    let comment: String
 }
 
 /// Frame-based NSView that holds a WKWebView and gives the Safari Web

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -32,6 +32,12 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
     /// `title`.
     static let stateDidChangeNotification = Notification.Name("WebPaneCoordinator.stateDidChange")
 
+    /// Notification posted on every `estimatedProgress` or `isLoading`
+    /// transition so `WebPaneView` can drive the Safari-style progress
+    /// strip in the chrome. User info: `paneID`, `tabID`,
+    /// `progress: Double` (0..1), `isLoading: Bool`.
+    static let loadProgressDidChangeNotification = Notification.Name("WebPaneCoordinator.loadProgressDidChange")
+
     /// Notification posted for every captured console line.
     /// User info: `paneID`, `tabID`, `level`, `message`, `url`,
     /// optional `lineNumber`, `columnNumber`.
@@ -61,6 +67,12 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
 
     /// KVO tokens per webview, so deinit (or destroy) can detach.
     private var kvoTokens: [UUID: [NSKeyValueObservation]] = [:]
+
+    /// Last `(progress, isLoading)` posted per tab. `estimatedProgress`
+    /// and `isLoading` both fire `progressPost` reading the *current*
+    /// values, so a single transition (e.g. `isLoading=false` + final
+    /// `estimatedProgress=1.0`) easily double-posts identical payloads.
+    private var lastPostedProgress: [UUID: (Double, Bool)] = [:]
 
     // MARK: - Inspector arm state
 
@@ -146,6 +158,7 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         }
         webViews.removeValue(forKey: tabID)
         lastAttemptedURL.removeValue(forKey: tabID)
+        lastPostedProgress.removeValue(forKey: tabID)
         showingErrorPage.remove(tabID)
         // Drop the inspector arm if it pointed at the destroyed tab
         // — a late click against the gone WebView could otherwise
@@ -234,7 +247,27 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         let titleToken = webView.observe(\.title, options: [.new]) { [weak webView] _, _ in
             snapshotAndPost(webView)
         }
-        kvoTokens[tab.id] = [urlToken, titleToken]
+        // Drive the Safari-style progress strip — both fire frequently
+        // during a single page load (subresource fetches bump progress,
+        // navigation start / finish flip isLoading), so they share one
+        // post helper that captures the current values together.
+        let progressPost: @Sendable (WKWebView?) -> Void = { [weak self] webView in
+            Task { @MainActor [weak self, weak webView] in
+                guard let self, let webView else { return }
+                postLoadProgress(
+                    tabID: tabID,
+                    progress: webView.estimatedProgress,
+                    isLoading: webView.isLoading
+                )
+            }
+        }
+        let progressToken = webView.observe(\.estimatedProgress, options: [.new]) { [weak webView] _, _ in
+            progressPost(webView)
+        }
+        let loadingToken = webView.observe(\.isLoading, options: [.new]) { [weak webView] _, _ in
+            progressPost(webView)
+        }
+        kvoTokens[tab.id] = [urlToken, titleToken, progressToken, loadingToken]
 
         if let url = URL(string: tab.url) {
             // Mirror what `navigate(tab:to:)` does so the reload
@@ -258,6 +291,21 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
                 "tabID": tabID,
                 "url": url,
                 "title": title
+            ]
+        )
+    }
+
+    private func postLoadProgress(tabID: UUID, progress: Double, isLoading: Bool) {
+        if let last = lastPostedProgress[tabID], last == (progress, isLoading) { return }
+        lastPostedProgress[tabID] = (progress, isLoading)
+        NotificationCenter.default.post(
+            name: Self.loadProgressDidChangeNotification,
+            object: nil,
+            userInfo: [
+                "paneID": paneID,
+                "tabID": tabID,
+                "progress": progress,
+                "isLoading": isLoading
             ]
         )
     }

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -1,0 +1,348 @@
+import AppKit
+import Foundation
+import WebKit
+
+/// Per-pane owner of WKWebView instances. Phase 1 ships with a single
+/// tab per coordinator; Phase 2 grows this to N tabs sharing one
+/// `WKWebsiteDataStore`.
+///
+/// Lifecycle contract — mirrors `SurfaceManager` for terminal panes:
+/// - `WebPaneStore` creates the coordinator lazily on first access.
+/// - `WebPaneView.makeNSView` retrieves the active tab's WKWebView and
+///   embeds it; if the surrounding split is later torn down by a layout
+///   transition, `WebPaneView.dismantleNSView` only detaches from
+///   superview. The coordinator (and the WebView) lives on.
+/// - The coordinator is destroyed only when the pane itself is closed,
+///   via `WebPaneStore.destroyCoordinator(paneID:)` invoked from the
+///   `.closePane` effect in `WorkspaceFeature`.
+@MainActor
+final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
+    let paneID: UUID
+    let dataStore: WKWebsiteDataStore
+
+    /// Per-tab WKWebView. Phase 1 keeps at most one entry; the
+    /// dictionary shape lets Phase 2 add tabs without refactoring.
+    private var webViews: [UUID: WKWebView] = [:]
+    /// Per-tab frame-based container around the WKWebView. Acts as
+    /// the "attachment view" the Inspector docks into — see
+    /// `container(for:)` for the rationale.
+    private var containers: [UUID: WebPaneTabContainer] = [:]
+
+    /// Notification posted when a WebView's URL or title changes. Used
+    /// by `WebPaneView` to mirror state into the store (which the CLI
+    /// `pane web url` reads). User info: `paneID`, `tabID`, `url`,
+    /// `title`.
+    static let stateDidChangeNotification = Notification.Name("WebPaneCoordinator.stateDidChange")
+
+    /// KVO tokens per webview, so deinit (or destroy) can detach.
+    private var kvoTokens: [UUID: [NSKeyValueObservation]] = [:]
+
+    init(
+        paneID: UUID,
+        dataStore: WKWebsiteDataStore
+    ) {
+        self.paneID = paneID
+        self.dataStore = dataStore
+        super.init()
+    }
+
+    deinit {
+        // KVO observations have to be invalidated before their host
+        // object goes away; left dangling they fire selector calls
+        // against deallocated memory at app teardown.
+        for tokens in kvoTokens.values {
+            for token in tokens {
+                token.invalidate()
+            }
+        }
+    }
+
+    // MARK: - Tab access
+
+    /// Get-or-create the frame-based container hosting the active
+    /// tab's WKWebView. The container exists so the Safari Web
+    /// Inspector can dock itself in attached mode: WebKit attaches by
+    /// inserting an inspector view as a sibling of the WKWebView and
+    /// resizing both via direct frame manipulation. Auto Layout
+    /// constraints between the WKWebView and its parent block that
+    /// (silent attach failure — "show succeeds but no inspector
+    /// surface"). The container fixes both halves: itself fills the
+    /// outer (Auto Layout) parent, but lets its children float on
+    /// `autoresizingMask`, leaving WebKit free to insert and resize
+    /// the inspector view alongside the WKWebView.
+    func container(for tab: WebTab) -> WebPaneTabContainer {
+        if let existing = containers[tab.id] { return existing }
+        let webView = webView(for: tab)
+        let host = WebPaneTabContainer(webView: webView)
+        containers[tab.id] = host
+        return host
+    }
+
+    /// Get-or-create the WebView for the given tab. Phase 1's view code
+    /// only ever asks for `activeTab.id`.
+    func webView(for tab: WebTab) -> WKWebView {
+        if let existing = webViews[tab.id] { return existing }
+
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = dataStore
+        // Belt-and-braces: enable WebKit's developer extras on the
+        // configuration's preferences in addition to the public
+        // `isInspectable` flag below. The public API alone is supposed
+        // to enable the "Inspect Element" context menu item on
+        // macOS 13.3+, but some WebKit builds also check this older
+        // private preference before showing the entry. Setting both
+        // is the well-known reliable path for a developer-facing
+        // browser.
+        config.preferences.setValue(true, forKey: "developerExtrasEnabled")
+        // No script handlers in Phase 1 — they arrive in Phase 3.
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+        // Right-click → Inspect Element opens the native Safari Web
+        // Inspector. macOS 13.3+ only; project min is 14.0 so safe.
+        webView.isInspectable = true
+
+        webViews[tab.id] = webView
+
+        // Track url + title for the chrome's URL bar and the
+        // `pane web url` reply. The KVO closure is `@Sendable`
+        // under Swift 6 strict concurrency, so we can't read
+        // `webView.url` / `webView.title` (both main-actor) from
+        // it directly — capture the webView pointer and read on
+        // the main actor inside Task.
+        let tabID = tab.id
+        let snapshotAndPost: @Sendable (WKWebView?) -> Void = { [weak self] webView in
+            Task { @MainActor [weak self, weak webView] in
+                guard let self, let webView else { return }
+                postStateChange(
+                    tabID: tabID,
+                    url: webView.url?.absoluteString ?? "",
+                    title: webView.title ?? ""
+                )
+            }
+        }
+        let urlToken = webView.observe(\.url, options: [.new]) { [weak webView] _, _ in
+            snapshotAndPost(webView)
+        }
+        let titleToken = webView.observe(\.title, options: [.new]) { [weak webView] _, _ in
+            snapshotAndPost(webView)
+        }
+        kvoTokens[tab.id] = [urlToken, titleToken]
+
+        if let url = URL(string: tab.url) {
+            webView.load(URLRequest(url: url))
+        }
+        return webView
+    }
+
+    private func postStateChange(tabID: UUID, url: String, title: String) {
+        NotificationCenter.default.post(
+            name: Self.stateDidChangeNotification,
+            object: nil,
+            userInfo: [
+                "paneID": paneID,
+                "tabID": tabID,
+                "url": url,
+                "title": title
+            ]
+        )
+    }
+
+    // MARK: - Navigation
+
+    /// Load a new URL in the given tab (creating its WKWebView if needed).
+    /// Accepts bare hostnames ("example.com") by prepending `https://`
+    /// when no scheme is present.
+    @discardableResult
+    func navigate(tab: WebTab, to rawURLString: String) -> URL? {
+        let urlString = Self.normalizeURLInput(rawURLString)
+        guard let url = URL(string: urlString) else { return nil }
+        let webView = webView(for: tab)
+        webView.load(URLRequest(url: url))
+        return url
+    }
+
+    /// Promote a user-typed URL bar value into something `URL` can
+    /// parse. "example.com" → "https://example.com"; an existing
+    /// scheme is left intact. Nonisolated so the reducer (which
+    /// isn't always on the main actor) can call it before dispatch.
+    nonisolated static func normalizeURLInput(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return trimmed }
+        if trimmed.contains("://") { return trimmed }
+        if trimmed.hasPrefix("about:") { return trimmed }
+        return "https://\(trimmed)"
+    }
+
+    @discardableResult
+    func goBack(tabID: UUID) -> Bool {
+        guard let webView = webViews[tabID], webView.canGoBack else { return false }
+        webView.goBack()
+        return true
+    }
+
+    @discardableResult
+    func goForward(tabID: UUID) -> Bool {
+        guard let webView = webViews[tabID], webView.canGoForward else { return false }
+        webView.goForward()
+        return true
+    }
+
+    @discardableResult
+    func reload(tabID: UUID, hard: Bool = false) -> Bool {
+        guard let webView = webViews[tabID] else { return false }
+        if hard {
+            webView.reloadFromOrigin()
+        } else {
+            webView.reload()
+        }
+        return true
+    }
+
+    /// Toggle the Safari Web Inspector docked inside the tab's
+    /// `WebPaneTabContainer` via WebKit's private `_inspector` SPI.
+    /// Closes the inspector if it's currently visible; otherwise
+    /// opens and docks it. Returns false if the SPI isn't present on
+    /// this WebKit build (older macOS).
+    ///
+    /// Order matters on open: `show` first, then `attach`. Calling
+    /// `attach` before `show` is a no-op because the inspector window
+    /// hasn't been instantiated yet, so the inspector falls back to
+    /// its persisted state (detached by default on first launch, or
+    /// whatever the user last left it in — which is what right-click
+    /// "Inspect Element" also obeys).
+    @discardableResult
+    func toggleInspector(tabID: UUID) -> Bool {
+        guard let webView = webViews[tabID] else { return false }
+
+        let inspectorSel = NSSelectorFromString("_inspector")
+        if webView.responds(to: inspectorSel),
+           let inspectorAny = webView.perform(inspectorSel)?.takeUnretainedValue(),
+           let inspector = inspectorAny as? NSObject {
+            let isVisible = (inspector.value(forKey: "visible") as? Bool) ?? false
+            if isVisible {
+                let closeSel = NSSelectorFromString("close")
+                let hideSel = NSSelectorFromString("hide")
+                if inspector.responds(to: closeSel) {
+                    inspector.perform(closeSel)
+                    return true
+                } else if inspector.responds(to: hideSel) {
+                    inspector.perform(hideSel)
+                    return true
+                }
+                return false
+            }
+
+            let showSel = NSSelectorFromString("show")
+            let showWithArg = NSSelectorFromString("show:")
+            if inspector.responds(to: showSel) {
+                inspector.perform(showSel)
+            } else if inspector.responds(to: showWithArg) {
+                inspector.perform(showWithArg, with: nil)
+            } else {
+                return false
+            }
+            // Defer the attach by a runloop tick — the inspector
+            // window needs to finish mounting before `attach` can
+            // re-dock it. This also flips WebKit's persisted dock
+            // preference so subsequent right-click "Inspect Element"
+            // opens stay docked.
+            let attachSel = NSSelectorFromString("attachBottom")
+            let attachFallback = NSSelectorFromString("attach")
+            DispatchQueue.main.async { [inspector] in
+                if inspector.responds(to: attachSel) {
+                    inspector.perform(attachSel)
+                } else if inspector.responds(to: attachFallback) {
+                    inspector.perform(attachFallback)
+                }
+            }
+            return true
+        }
+        // Legacy fallback for older WebKit builds.
+        let legacy = NSSelectorFromString("_showWebInspector")
+        if webView.responds(to: legacy) {
+            webView.perform(legacy)
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Inspection
+
+    /// Current URL + title for the named tab. Falls back to the cached
+    /// state when no WKWebView has been built yet (e.g. immediately
+    /// after restore but before the pane has rendered).
+    func currentURLAndTitle(tabID: UUID) -> (url: String, title: String)? {
+        guard let webView = webViews[tabID] else { return nil }
+        return (webView.url?.absoluteString ?? "", webView.title ?? "")
+    }
+
+    /// Visible text in the active tab. Returns the empty string when
+    /// no page has finished loading yet. JS injection runs on the main
+    /// frame only; cross-origin iframes are not stitched together in
+    /// Phase 1.
+    func captureText(tabID: UUID, maxBytes: Int = 1_000_000) async -> String {
+        guard let webView = webViews[tabID] else { return "" }
+        let result = try? await webView.evaluateJavaScript(
+            "document.body ? document.body.innerText : ''"
+        )
+        guard let text = result as? String else { return "" }
+        if text.utf8.count <= maxBytes { return text }
+        // Truncate to byte budget while staying on a UTF-8 boundary.
+        var truncated = text
+        while truncated.utf8.count > maxBytes {
+            truncated.removeLast()
+        }
+        return truncated + "\n[truncated]"
+    }
+
+    /// Capture the visible viewport as a PNG. Returns the raw bytes;
+    /// callers decide whether to inline as base64 or spill to a file.
+    func captureScreenshot(tabID: UUID) async -> Data? {
+        guard let webView = webViews[tabID] else { return nil }
+        let config = WKSnapshotConfiguration()
+        config.afterScreenUpdates = true
+        do {
+            let image = try await webView.takeSnapshot(configuration: config)
+            guard
+                let tiff = image.tiffRepresentation,
+                let rep = NSBitmapImageRep(data: tiff),
+                let png = rep.representation(using: .png, properties: [:])
+            else { return nil }
+            return png
+        } catch {
+            return nil
+        }
+    }
+
+    // WKNavigationDelegate methods are intentionally left at default
+    // (.allow) for Phase 1 — link clicks navigate in-place. Phase 4
+    // will likely intercept .linkActivated to support "open in new
+    // tab".
+}
+
+/// Frame-based NSView that holds a WKWebView and gives the Safari Web
+/// Inspector a place to dock. Auto Layout constraints between the
+/// WKWebView and the surrounding SwiftUI hierarchy stop the inspector
+/// from attaching (it needs to resize the WKWebView and add a sibling
+/// view), so we sit this container in the middle: Auto Layout fills
+/// it from above (PaneFocusView), and its children float on
+/// `autoresizingMask` from below.
+@MainActor
+final class WebPaneTabContainer: NSView {
+    let webView: WKWebView
+
+    init(webView: WKWebView) {
+        self.webView = webView
+        super.init(frame: NSRect(x: 0, y: 0, width: 100, height: 100))
+        autoresizesSubviews = true
+        webView.frame = bounds
+        webView.autoresizingMask = [.width, .height]
+        addSubview(webView)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -344,7 +344,28 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return trimmed }
         if trimmed.contains("://") { return trimmed }
-        if trimmed.hasPrefix("about:") { return trimmed }
+
+        // Recognise opaque schemes that don't use `://` — `data:`,
+        // `javascript:`, `mailto:`, `tel:`, `about:`, `file:` and the
+        // like. Distinguish a real scheme from a `host:port` pair by
+        // looking at what follows the colon: a port is digits, a
+        // scheme value starts with anything else. Without this, e.g.
+        // `data:text/html,<h1>x</h1>` would be prefixed with
+        // `https://` and never load (caught by PR #147 cua validation).
+        if let colonIdx = trimmed.firstIndex(of: ":"),
+           let firstChar = trimmed.first,
+           firstChar.isLetter {
+            let scheme = trimmed[..<colonIdx]
+            let validSchemeChars = scheme.allSatisfy { ch in
+                ch.isLetter || ch.isNumber || ch == "+" || ch == "-" || ch == "."
+            }
+            let afterIdx = trimmed.index(after: colonIdx)
+            let afterColon = trimmed[afterIdx...]
+            let looksLikePort = afterColon.first?.isNumber == true
+            if validSchemeChars, !looksLikePort {
+                return trimmed
+            }
+        }
 
         // Extract the host portion ("host[:port]/path?..." → "host").
         let beforePath = trimmed.split(separator: "/", maxSplits: 1).first.map(String.init) ?? trimmed

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -237,6 +237,13 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         kvoTokens[tab.id] = [urlToken, titleToken]
 
         if let url = URL(string: tab.url) {
+            // Mirror what `navigate(tab:to:)` does so the reload
+            // button and the error stub's Retry anchor have a URL
+            // to fall back to when the initial restore load fails.
+            // Without this seed, `presentLoadFailure` ends up with
+            // an empty `failedURL` and the stub renders with an
+            // empty href; reload() then has nothing to retry.
+            lastAttemptedURL[tab.id] = url.absoluteString
             webView.load(URLRequest(url: url))
         }
         return webView

--- a/Nex/Features/WebPane/WebPaneInspectorScript.swift
+++ b/Nex/Features/WebPane/WebPaneInspectorScript.swift
@@ -1,0 +1,316 @@
+import Foundation
+
+/// JS source for the element-picker overlay used by `nex web inspect`.
+/// Injected at document-start into the main frame only. Two global
+/// hooks are exposed:
+///
+/// - `__nexInspectorEnable(nonce)` — arm the picker; the next click
+///   serialises the clicked element and posts to the `nexInspect`
+///   native handler with the nonce so spoofed messages from page
+///   JS are rejected by the Swift side.
+/// - `__nexInspectorDisable()` — symmetric tear-down. Removes the
+///   overlay, restores the cursor, and detaches event listeners.
+///
+/// Arming is single-shot: the click handler calls `disable()` after
+/// posting so the inspector can't leak into the next click cycle.
+enum WebPaneInspectorScript {
+    static let source: String = """
+    (function() {
+        if (window.__nexInspectorInstalled) { return; }
+        window.__nexInspectorInstalled = true;
+
+        var bridge = (window.webkit && window.webkit.messageHandlers &&
+                      window.webkit.messageHandlers.nexInspect);
+
+        var state = {
+            armed: false,
+            sticky: false,
+            nonce: null,
+            overlay: null,
+            previousCursor: null,
+            onMove: null,
+            onClick: null,
+            onKey: null
+        };
+
+        function ensureOverlay() {
+            if (state.overlay) return state.overlay;
+            var div = document.createElement('div');
+            div.setAttribute('data-nex-overlay', '1');
+            div.style.cssText = [
+                'position:fixed', 'pointer-events:none', 'z-index:2147483647',
+                'border:2px solid #007AFF', 'background:rgba(0,122,255,0.18)',
+                'border-radius:2px', 'box-sizing:border-box',
+                'transition:left 60ms linear, top 60ms linear, width 60ms linear, height 60ms linear',
+                'display:none'
+            ].join(';');
+            (document.body || document.documentElement).appendChild(div);
+            state.overlay = div;
+            return div;
+        }
+
+        function moveOverlay(rect) {
+            var o = ensureOverlay();
+            o.style.display = 'block';
+            o.style.left = rect.left + 'px';
+            o.style.top = rect.top + 'px';
+            o.style.width = rect.width + 'px';
+            o.style.height = rect.height + 'px';
+        }
+
+        function hideOverlay() {
+            if (state.overlay) state.overlay.style.display = 'none';
+        }
+
+        function elementAt(x, y) {
+            var el = document.elementFromPoint(x, y);
+            // Walk up through pointer-events:none overlays our own
+            // overlay is hidden during elementFromPoint via z-index/
+            // pointer-events, but just in case.
+            while (el && el.hasAttribute && el.hasAttribute('data-nex-overlay')) {
+                el = el.parentElement;
+            }
+            return el;
+        }
+
+        /// True when `node` (or any ancestor) is part of Nex's own
+        /// overlay surface — picker overlay, batch marker container,
+        /// numbered badge, focus ring, or comment popover. Clicks on
+        /// these shouldn't capture another element into the batch,
+        /// and hover-tracking shouldn't outline them either.
+        function isOurOverlay(node) {
+            while (node) {
+                if (node.nodeType === 1 && node.hasAttribute) {
+                    if (node.hasAttribute('data-nex-overlay') ||
+                        node.hasAttribute('data-nex-batch-marker') ||
+                        node.hasAttribute('data-nex-batch-markers') ||
+                        node.hasAttribute('data-nex-batch-popover') ||
+                        node.hasAttribute('data-nex-batch-focus-ring')) {
+                        return true;
+                    }
+                }
+                node = node.parentNode;
+                if (node === document.body || node === document.documentElement) break;
+            }
+            return false;
+        }
+
+        function getXPath(el) {
+            if (!el) return '';
+            if (el.id) return '//*[@id=' + JSON.stringify(el.id) + ']';
+            var parts = [];
+            var node = el;
+            while (node && node.nodeType === 1 && node !== document.documentElement) {
+                var ix = 1;
+                var sib = node.previousSibling;
+                while (sib) {
+                    if (sib.nodeType === 1 && sib.tagName === node.tagName) ix++;
+                    sib = sib.previousSibling;
+                }
+                parts.unshift(node.tagName.toLowerCase() + '[' + ix + ']');
+                node = node.parentElement;
+            }
+            return '/html/' + parts.join('/');
+        }
+
+        function escapeCSS(s) {
+            try { return CSS.escape(s); }
+            catch (e) { return s.replace(/[^A-Za-z0-9_-]/g, '\\\\$&'); }
+        }
+
+        function getCSSSelector(el) {
+            if (!el) return '';
+            // Prefer stable identifiers in priority order: id,
+            // data-testid, data-test, name. Falls back to a chained
+            // tag>tag selector when none are present.
+            if (el.id) return '#' + escapeCSS(el.id);
+            var testid = el.getAttribute && (el.getAttribute('data-testid') ||
+                                             el.getAttribute('data-test'));
+            if (testid) return '[data-testid=' + JSON.stringify(testid) + ']';
+            var name = el.getAttribute && el.getAttribute('name');
+            if (name && el.tagName) {
+                return el.tagName.toLowerCase() + '[name=' + JSON.stringify(name) + ']';
+            }
+            var parts = [];
+            var node = el;
+            while (node && node.nodeType === 1 && parts.length < 6 && node !== document.documentElement) {
+                var part = node.tagName.toLowerCase();
+                if (node.id) { parts.unshift(part + '#' + escapeCSS(node.id)); break; }
+                var classes = (node.getAttribute('class') || '').trim().split(/\\s+/).filter(Boolean);
+                if (classes.length) part += '.' + classes.slice(0, 2).map(escapeCSS).join('.');
+                var idx = 1, sib = node.previousElementSibling;
+                while (sib) {
+                    if (sib.tagName === node.tagName) idx++;
+                    sib = sib.previousElementSibling;
+                }
+                part += ':nth-of-type(' + idx + ')';
+                parts.unshift(part);
+                node = node.parentElement;
+            }
+            return parts.join(' > ');
+        }
+
+        function attributesOf(el) {
+            var out = {};
+            if (!el || !el.attributes) return out;
+            for (var i = 0; i < el.attributes.length; i++) {
+                var a = el.attributes[i];
+                out[a.name] = a.value;
+            }
+            return out;
+        }
+
+        function surroundingText(el) {
+            try {
+                var t = (el && el.textContent) ? el.textContent.trim() : '';
+                if (t.length <= 200) return t;
+                return t.slice(0, 200) + '…';
+            } catch (e) { return ''; }
+        }
+
+        function contextHTML(el) {
+            try {
+                var parent = el && el.parentElement;
+                if (!parent) return '';
+                var html = parent.outerHTML || '';
+                if (html.length <= 4096) return html;
+                return html.slice(0, 4096);
+            } catch (e) { return ''; }
+        }
+
+        function capture(el) {
+            if (!el) return null;
+            var rect = el.getBoundingClientRect();
+            return {
+                nonce: state.nonce,
+                selector: getCSSSelector(el),
+                xpath: getXPath(el),
+                tag: (el.tagName || '').toLowerCase(),
+                element_id: el.id || '',
+                outer_html: el.outerHTML || '',
+                attributes: attributesOf(el),
+                rect: {
+                    x: rect.left, y: rect.top,
+                    w: rect.width, h: rect.height
+                },
+                text: surroundingText(el),
+                context_html: contextHTML(el),
+                url: location.href,
+                captured_at: new Date().toISOString()
+            };
+        }
+
+        function onMove(ev) {
+            if (!state.armed) return;
+            // While the batch comment popover is open, suspend the
+            // hover outline entirely — the user is authoring a
+            // comment, not picking. They Done/Remove first.
+            if (window.__nexBatchHasOpenPopover) {
+                hideOverlay();
+                return;
+            }
+            var el = ev.target;
+            if (!el || el === state.overlay) return;
+            // Don't outline our own overlay surfaces (numbered badges,
+            // comment popover, focus ring) when hovered — they aren't
+            // valid pick targets.
+            if (isOurOverlay(el)) {
+                hideOverlay();
+                return;
+            }
+            var rect = el.getBoundingClientRect();
+            moveOverlay({
+                left: rect.left, top: rect.top,
+                width: rect.width, height: rect.height
+            });
+        }
+
+        function onClick(ev) {
+            if (!state.armed) return;
+            // Clicks that land on our own overlay surface — a badge,
+            // the comment popover, the focus ring — should NOT be
+            // treated as new picks. Let the event pass through to its
+            // normal handlers (badge click → focuses that marker;
+            // popover textarea → text input).
+            if (isOurOverlay(ev.target)) return;
+            // Comment popover is open — the user has unfinished
+            // business with the current item. Don't create another
+            // pick until they hit Done or Remove. Let the click
+            // through to the page (no preventDefault) so existing
+            // page interaction isn't blocked either.
+            if (window.__nexBatchHasOpenPopover) return;
+            ev.preventDefault();
+            ev.stopPropagation();
+            ev.stopImmediatePropagation();
+            var payload = capture(ev.target);
+            if (payload && bridge) {
+                try { bridge.postMessage(payload); } catch (e) {}
+            }
+            // In sticky mode the picker stays armed for the next
+            // click — batch annotation uses this to collect several
+            // elements without round-tripping through Swift for
+            // re-arm. Single-shot mode (default) disables here.
+            if (!state.sticky) {
+                disable();
+            }
+        }
+
+        function onKey(ev) {
+            if (state.armed && ev.key === 'Escape') {
+                // While the batch popover is open, Esc belongs to the
+                // popover (its textarea handler dismisses just that
+                // popover so the user can pick the next element).
+                // Without this skip, the capture-phase listener here
+                // wins the event before it reaches the textarea and
+                // disarms the whole batch instead.
+                if (window.__nexBatchHasOpenPopover) return;
+                ev.preventDefault();
+                ev.stopPropagation();
+                // Snapshot the nonce BEFORE disable() — it clears
+                // state.nonce, and the Swift coordinator drops any
+                // cancel message whose nonce doesn't match the
+                // currently-armed one. Without this capture the JS
+                // disarms but the Swift-side picker stays armed.
+                var nonceAtCancel = state.nonce;
+                disable();
+                try { bridge && bridge.postMessage({ nonce: nonceAtCancel, cancelled: true }); }
+                catch (e) {}
+            }
+        }
+
+        function enable(nonce, sticky) {
+            if (state.armed) disable();
+            state.armed = true;
+            state.sticky = sticky === true;
+            state.nonce = String(nonce || '');
+            state.previousCursor = document.documentElement.style.cursor;
+            document.documentElement.style.cursor = 'crosshair';
+
+            state.onMove = onMove;
+            state.onClick = onClick;
+            state.onKey = onKey;
+            // Use capture so we win against page-level handlers.
+            document.addEventListener('mousemove', state.onMove, true);
+            document.addEventListener('click', state.onClick, true);
+            document.addEventListener('keydown', state.onKey, true);
+        }
+
+        function disable() {
+            if (!state.armed) return;
+            state.armed = false;
+            state.sticky = false;
+            state.nonce = null;
+            document.documentElement.style.cursor = state.previousCursor || '';
+            state.previousCursor = null;
+            hideOverlay();
+            if (state.onMove) document.removeEventListener('mousemove', state.onMove, true);
+            if (state.onClick) document.removeEventListener('click', state.onClick, true);
+            if (state.onKey) document.removeEventListener('keydown', state.onKey, true);
+            state.onMove = state.onClick = state.onKey = null;
+        }
+
+        window.__nexInspectorEnable = enable;
+        window.__nexInspectorDisable = disable;
+    })();
+    """
+}

--- a/Nex/Features/WebPane/WebPaneState.swift
+++ b/Nex/Features/WebPane/WebPaneState.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// A single tab inside a `.web` pane. Phase 1 ships with at most one
+/// tab per pane; the type carries an `id` already so Phase 2 can add
+/// the tab strip without re-shaping persisted state.
+struct WebTab: Equatable, Identifiable, Codable {
+    let id: UUID
+    var url: String
+    var title: String
+
+    init(id: UUID = UUID(), url: String, title: String = "") {
+        self.id = id
+        self.url = url
+        self.title = title
+    }
+}
+
+/// Sidecar state for a `.web` pane. Lives on `WorkspaceFeature.State`
+/// in the `webPanes: [UUID: WebPaneState]` dictionary, keyed by pane
+/// id. Kept off the `Pane` struct itself so consumers that don't care
+/// about web pane internals don't have to learn the type.
+///
+/// Phase 1 fields only — Phase 3 adds the console buffer and inspector
+/// state alongside these.
+struct WebPaneState: Equatable {
+    var tabs: [WebTab]
+    var activeTabID: UUID?
+    var isPrivate: Bool
+
+    init(tabs: [WebTab] = [], activeTabID: UUID? = nil, isPrivate: Bool = false) {
+        self.tabs = tabs
+        self.activeTabID = activeTabID
+        self.isPrivate = isPrivate
+    }
+
+    /// Convenience: the active tab, or `tabs.first` if `activeTabID`
+    /// is stale (e.g. just after a tab close). Returns nil for an
+    /// empty-tab pane.
+    var activeTab: WebTab? {
+        if let id = activeTabID, let tab = tabs.first(where: { $0.id == id }) {
+            return tab
+        }
+        return tabs.first
+    }
+}
+
+/// `nex web capture` modes. `meta` returns just URL + title; `text`
+/// adds visible page text; `screenshot` adds a PNG (inline base64
+/// or `/tmp` path depending on size).
+enum WebCaptureMode: String {
+    case meta
+    case text
+    case screenshot
+}

--- a/Nex/Features/WebPane/WebPaneState.swift
+++ b/Nex/Features/WebPane/WebPaneState.swift
@@ -67,25 +67,25 @@ struct BatchInspectItem: Equatable, Identifiable {
 /// `BatchInspectItem`; the user finalises with `webBatchInspectSend`
 /// or aborts with `webBatchInspectCancel`.
 struct BatchInspectState: Equatable {
-    /// Destination pane id. Nil = queue locally; the batch is
-    /// dropped into the inspect-result queue on Send so
-    /// `nex web inspect-result` can drain it.
-    var sendTo: UUID?
     var items: [BatchInspectItem]
     /// Item currently focused for bidirectional list↔page sync. Set
     /// when the user taps a panel row or clicks a numbered badge on
     /// the page; the row gets a brief highlight, the page scrolls
     /// the matching element into view, and the badge pulses.
     var focusedItemID: UUID?
+    /// Panel on screen + page picker armed. Toggled by the scope
+    /// chrome button; items persist across hide/show. On-page markers
+    /// follow this flag.
+    var panelVisible: Bool
 
     init(
-        sendTo: UUID? = nil,
         items: [BatchInspectItem] = [],
-        focusedItemID: UUID? = nil
+        focusedItemID: UUID? = nil,
+        panelVisible: Bool = true
     ) {
-        self.sendTo = sendTo
         self.items = items
         self.focusedItemID = focusedItemID
+        self.panelVisible = panelVisible
     }
 }
 
@@ -109,6 +109,20 @@ struct InspectResult: Equatable {
     /// "queue locally" path stamps each result with the user's
     /// per-item comment before enqueueing.
     var comment: String = ""
+}
+
+/// Remembered destination from the previous batch in this app
+/// session. Two distinct cases (rather than `Optional<UUID>`) so the
+/// "Local queue" pick is durable: `Optional<UUID>` would collapse it
+/// back to "no selection".
+///
+/// Note: the `.local` case is currently unreachable from the panel
+/// (the picker only offers pane targets and disables Send until one
+/// is picked) but is kept so the eventual "Local queue" picker entry
+/// has a place to land.
+enum BatchTargetMemory: Equatable {
+    case local
+    case pane(UUID)
 }
 
 /// Sidecar state for a `.web` pane. Lives on `WorkspaceFeature.State`
@@ -144,6 +158,12 @@ struct WebPaneState: Equatable {
     /// Active batch-annotate session — see BatchInspectState. nil
     /// when no batch is in progress (the default).
     var batchInspect: BatchInspectState?
+    /// Last destination the user picked for a batch on this pane in
+    /// the current app run. Drives the panel's initial picker
+    /// selection so a second batch defaults to the previous target.
+    /// Nil on the very first batch (and on fresh launch — not
+    /// serialised) so the user must pick deliberately.
+    var lastBatchTarget: BatchTargetMemory?
 
     init(tabs: [WebTab] = [], activeTabID: UUID? = nil, isPrivate: Bool = false) {
         self.tabs = tabs

--- a/Nex/Features/WebPane/WebPaneState.swift
+++ b/Nex/Features/WebPane/WebPaneState.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-/// A single tab inside a `.web` pane. Phase 1 ships with at most one
-/// tab per pane; the type carries an `id` already so Phase 2 can add
-/// the tab strip without re-shaping persisted state.
+/// A single tab inside a `.web` pane.
 struct WebTab: Equatable, Identifiable, Codable {
     let id: UUID
     var url: String
@@ -13,15 +11,22 @@ struct WebTab: Equatable, Identifiable, Codable {
         self.url = url
         self.title = title
     }
+
+    /// Title used in the pane header and the chrome tab pill. Falls
+    /// back through title -> host -> url -> "New Tab" so a tab that
+    /// hasn't reported a title yet still shows something meaningful.
+    var displayLabel: String {
+        if !title.isEmpty { return title }
+        if let host = URL(string: url)?.host, !host.isEmpty { return host }
+        if !url.isEmpty { return url }
+        return "New Tab"
+    }
 }
 
 /// Sidecar state for a `.web` pane. Lives on `WorkspaceFeature.State`
 /// in the `webPanes: [UUID: WebPaneState]` dictionary, keyed by pane
 /// id. Kept off the `Pane` struct itself so consumers that don't care
 /// about web pane internals don't have to learn the type.
-///
-/// Phase 1 fields only — Phase 3 adds the console buffer and inspector
-/// state alongside these.
 struct WebPaneState: Equatable {
     var tabs: [WebTab]
     var activeTabID: UUID?
@@ -41,6 +46,14 @@ struct WebPaneState: Equatable {
             return tab
         }
         return tabs.first
+    }
+
+    func index(of tabID: UUID) -> Int? {
+        tabs.firstIndex(where: { $0.id == tabID })
+    }
+
+    func contains(tabID: UUID) -> Bool {
+        tabs.contains(where: { $0.id == tabID })
     }
 }
 

--- a/Nex/Features/WebPane/WebPaneState.swift
+++ b/Nex/Features/WebPane/WebPaneState.swift
@@ -23,6 +23,94 @@ struct WebTab: Equatable, Identifiable, Codable {
     }
 }
 
+/// One captured console line from a web pane.
+struct ConsoleLine: Equatable {
+    enum Level: String, Equatable, Codable {
+        case log, debug, info, warn, error
+    }
+
+    /// Tab the line came from. Phase 3 attributes every line to the
+    /// active tab at the time the script handler fired; cross-tab
+    /// filtering uses this.
+    let tabID: UUID
+    let level: Level
+    /// Pre-joined argument string (JS-side `args.map(String).join(' ')`).
+    let message: String
+    let url: String
+    let lineNumber: Int?
+    let columnNumber: Int?
+    let capturedAt: Date
+}
+
+/// Which side of the list↔page sync initiated a focus event.
+enum BatchFocusOrigin: Equatable {
+    case panel
+    case page
+}
+
+/// One item collected during batch-annotate mode — the captured
+/// inspect result plus the user's free-form comment.
+struct BatchInspectItem: Equatable, Identifiable {
+    let id: UUID
+    var result: InspectResult
+    var comment: String
+
+    init(id: UUID = UUID(), result: InspectResult, comment: String = "") {
+        self.id = id
+        self.result = result
+        self.comment = comment
+    }
+}
+
+/// Active batch-annotate session on a web pane. The picker stays
+/// armed (sticky) while this is set so each click adds another
+/// `BatchInspectItem`; the user finalises with `webBatchInspectSend`
+/// or aborts with `webBatchInspectCancel`.
+struct BatchInspectState: Equatable {
+    /// Destination pane id. Nil = queue locally; the batch is
+    /// dropped into the inspect-result queue on Send so
+    /// `nex web inspect-result` can drain it.
+    var sendTo: UUID?
+    var items: [BatchInspectItem]
+    /// Item currently focused for bidirectional list↔page sync. Set
+    /// when the user taps a panel row or clicks a numbered badge on
+    /// the page; the row gets a brief highlight, the page scrolls
+    /// the matching element into view, and the badge pulses.
+    var focusedItemID: UUID?
+
+    init(
+        sendTo: UUID? = nil,
+        items: [BatchInspectItem] = [],
+        focusedItemID: UUID? = nil
+    ) {
+        self.sendTo = sendTo
+        self.items = items
+        self.focusedItemID = focusedItemID
+    }
+}
+
+/// One captured inspect-result payload from the picker.
+struct InspectResult: Equatable {
+    let tabID: UUID
+    let selector: String
+    let xpath: String
+    let tag: String
+    let elementID: String
+    let outerHTML: String
+    /// Attribute name → value, as captured.
+    let attributes: [String: String]
+    let rect: CGRect
+    let text: String
+    let contextHTML: String
+    let url: String
+    let capturedAt: Date
+    /// Free-form annotation. Always empty for results captured by a
+    /// single-shot picker arm; populated when the batch-annotate
+    /// "queue locally" path stamps each result with the user's
+    /// per-item comment before enqueueing.
+    var comment: String = ""
+}
+
 /// Sidecar state for a `.web` pane. Lives on `WorkspaceFeature.State`
 /// in the `webPanes: [UUID: WebPaneState]` dictionary, keyed by pane
 /// id. Kept off the `Pane` struct itself so consumers that don't care
@@ -31,6 +119,31 @@ struct WebPaneState: Equatable {
     var tabs: [WebTab]
     var activeTabID: UUID?
     var isPrivate: Bool
+
+    // MARK: - Phase 3 fields (console + inspector)
+
+    /// Rolling buffer of console output captured from this pane's
+    /// WKWebViews. Cap is 1000 lines per the plan; oldest is dropped
+    /// when full and reported via `droppedSinceLastDrain`.
+    var consoleBuffer: RingBuffer<ConsoleLine> = .init(capacity: 1000)
+    /// True while the element picker is armed for the next click.
+    /// Single-shot: cleared automatically once a click delivers.
+    var inspectorArmed: Bool = false
+    /// Set on `nex web inspect --send-to <target>` arms. The reducer
+    /// reads this when an inspect result arrives, formats the payload,
+    /// and pastes it via `paneSendText` to the named pane (resolved
+    /// via the usual label/UUID rules at arm time and stashed here).
+    var pendingInspectSendTo: UUID?
+    /// Set at arm time; checked against the nonce embedded in every
+    /// `nexInspect.postMessage` payload. Mismatch → drop. Prevents
+    /// page-injected JS from spoofing the channel.
+    var pendingInspectNonce: String?
+    /// Past inspect-result payloads not yet drained by
+    /// `nex web inspect-result`. Capped at 32 entries; oldest dropped.
+    var inspectResultQueue: [InspectResult] = []
+    /// Active batch-annotate session — see BatchInspectState. nil
+    /// when no batch is in progress (the default).
+    var batchInspect: BatchInspectState?
 
     init(tabs: [WebTab] = [], activeTabID: UUID? = nil, isPrivate: Bool = false) {
         self.tabs = tabs

--- a/Nex/Features/WebPane/WebPaneStore.swift
+++ b/Nex/Features/WebPane/WebPaneStore.swift
@@ -41,6 +41,15 @@ final class WebPaneStore: Sendable {
         _ = lock.withLock { coordinators.removeValue(forKey: paneID) }
     }
 
+    /// Tear down a single tab inside a pane. No-op when the pane's
+    /// coordinator hasn't been created yet (the tab's WKWebView was
+    /// never built either).
+    @MainActor
+    func destroyTab(paneID: UUID, tabID: UUID) {
+        guard let coordinator = lock.withLock({ coordinators[paneID] }) else { return }
+        coordinator.destroyTab(tabID: tabID)
+    }
+
     @MainActor
     func destroyAll() {
         _ = lock.withLock {
@@ -70,5 +79,5 @@ extension DependencyValues {
 import SwiftUI
 
 extension EnvironmentValues {
-    @Entry var webPaneStore: WebPaneStore = WebPaneStore.liveValue
+    @Entry var webPaneStore: WebPaneStore = .liveValue
 }

--- a/Nex/Features/WebPane/WebPaneStore.swift
+++ b/Nex/Features/WebPane/WebPaneStore.swift
@@ -17,7 +17,7 @@ final class WebPaneStore: Sendable {
     private nonisolated(unsafe) var coordinators: [UUID: WebPaneCoordinator] = [:]
 
     @MainActor
-    func coordinator(for paneID: UUID, isPrivate: Bool = false) -> WebPaneCoordinator {
+    func coordinator(for paneID: UUID, isPrivate: Bool) -> WebPaneCoordinator {
         if let existing = lock.withLock({ coordinators[paneID] }) {
             return existing
         }

--- a/Nex/Features/WebPane/WebPaneStore.swift
+++ b/Nex/Features/WebPane/WebPaneStore.swift
@@ -1,0 +1,74 @@
+import ComposableArchitecture
+import Foundation
+import WebKit
+
+/// Process-wide registry of `WebPaneCoordinator` instances, keyed by
+/// pane id. Mirrors `SurfaceManager` for terminal panes: the coordinator
+/// (and its WKWebView) survives SwiftUI view rebuilds — `WebPaneView`
+/// only re-parents an existing WebView into the new container during
+/// layout transitions.
+///
+/// Coordinators are created lazily by `WebPaneView.makeNSView` (or by
+/// the reducer when the pane is first opened) and destroyed only via
+/// `destroyCoordinator(paneID:)` from the pane-close path.
+final class WebPaneStore: Sendable {
+    private let lock = NSLock()
+    /// nonisolated(unsafe) because access is protected by lock
+    private nonisolated(unsafe) var coordinators: [UUID: WebPaneCoordinator] = [:]
+
+    @MainActor
+    func coordinator(for paneID: UUID, isPrivate: Bool = false) -> WebPaneCoordinator {
+        if let existing = lock.withLock({ coordinators[paneID] }) {
+            return existing
+        }
+        let dataStore: WKWebsiteDataStore = isPrivate
+            ? .nonPersistent()
+            : .default()
+        let coord = WebPaneCoordinator(
+            paneID: paneID,
+            dataStore: dataStore
+        )
+        lock.withLock { coordinators[paneID] = coord }
+        return coord
+    }
+
+    func coordinatorIfExists(for paneID: UUID) -> WebPaneCoordinator? {
+        lock.withLock { coordinators[paneID] }
+    }
+
+    @MainActor
+    func destroyCoordinator(paneID: UUID) {
+        _ = lock.withLock { coordinators.removeValue(forKey: paneID) }
+    }
+
+    @MainActor
+    func destroyAll() {
+        _ = lock.withLock {
+            let copy = coordinators
+            coordinators.removeAll()
+            return copy
+        }
+    }
+}
+
+// MARK: - TCA Dependency
+
+extension WebPaneStore: DependencyKey {
+    static let liveValue = WebPaneStore()
+    static let testValue = WebPaneStore()
+}
+
+extension DependencyValues {
+    var webPaneStore: WebPaneStore {
+        get { self[WebPaneStore.self] }
+        set { self[WebPaneStore.self] = newValue }
+    }
+}
+
+// MARK: - SwiftUI Environment
+
+import SwiftUI
+
+extension EnvironmentValues {
+    @Entry var webPaneStore: WebPaneStore = WebPaneStore.liveValue
+}

--- a/Nex/Features/WebPane/WebPaneView.swift
+++ b/Nex/Features/WebPane/WebPaneView.swift
@@ -1,0 +1,198 @@
+import AppKit
+import SwiftUI
+import WebKit
+
+/// SwiftUI wrapper for a `.web` pane. Composes the chrome strip
+/// (URL bar + nav buttons) over a `NSViewRepresentable` host that
+/// owns the WKWebView lifecycle: the WebView is fetched from
+/// `WebPaneStore` on first render and re-parented across SwiftUI
+/// rebuilds during layout transitions (sibling close, workspace
+/// switch).
+struct WebPaneView: View {
+    let paneID: UUID
+    let tab: WebTab?
+    let isFocused: Bool
+    /// Bumped by parent (PaneGridView) when ⌘L fires for this pane —
+    /// the chrome promotes the URL bar to first responder.
+    let focusURLBarToken: UInt64
+    let onNavigate: (String) -> Void
+    let onBack: () -> Void
+    let onForward: () -> Void
+    let onReload: () -> Void
+
+    @Environment(\.webPaneStore) private var webPaneStore
+    @State private var displayedURL: String = ""
+    @State private var canGoBack: Bool = false
+    @State private var canGoForward: Bool = false
+    @State private var isLoading: Bool = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            WebPaneChrome(
+                paneID: paneID,
+                displayedURL: displayedURL,
+                canGoBack: canGoBack,
+                canGoForward: canGoForward,
+                isLoading: isLoading,
+                onBack: onBack,
+                onForward: onForward,
+                onReload: onReload,
+                onNavigate: onNavigate,
+                onInspect: toggleInspector,
+                focusRequestToken: focusURLBarToken
+            )
+
+            if let tab {
+                WebPaneHost(
+                    paneID: paneID,
+                    tabID: tab.id,
+                    initialURL: tab.url,
+                    isFocused: isFocused
+                )
+            } else {
+                emptyState
+            }
+        }
+        .background(Color(nsColor: .textBackgroundColor))
+        .onAppear(perform: refreshState)
+        .onChange(of: tab?.id) { _, _ in refreshState() }
+        .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.stateDidChangeNotification)) { note in
+            guard
+                let info = note.userInfo,
+                let firedPane = info["paneID"] as? UUID,
+                firedPane == paneID,
+                let firedTab = info["tabID"] as? UUID,
+                firedTab == tab?.id
+            else { return }
+            displayedURL = (info["url"] as? String) ?? displayedURL
+            refreshNavState()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "globe")
+                .font(.system(size: 32))
+                .foregroundStyle(.tertiary)
+            Text("New web pane")
+                .foregroundStyle(.secondary)
+                .font(.callout)
+            Text("Type a URL above and press Return")
+                .foregroundStyle(.tertiary)
+                .font(.caption)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func toggleInspector() {
+        guard let tab else { return }
+        let coord = webPaneStore.coordinator(for: paneID)
+        let ok = coord.toggleInspector(tabID: tab.id)
+        if !ok {
+            NSLog("WebPaneView: Web Inspector SPI not available on this WebKit build")
+        }
+    }
+
+    private func refreshState() {
+        guard let tab else {
+            displayedURL = ""
+            canGoBack = false
+            canGoForward = false
+            return
+        }
+        let coord = webPaneStore.coordinatorIfExists(for: paneID)
+        if let snapshot = coord?.currentURLAndTitle(tabID: tab.id), !snapshot.url.isEmpty {
+            displayedURL = snapshot.url
+        } else {
+            displayedURL = tab.url
+        }
+        refreshNavState()
+    }
+
+    private func refreshNavState() {
+        guard let tab,
+              let webView = webPaneStore.coordinatorIfExists(for: paneID)?.webView(for: tab) else {
+            canGoBack = false
+            canGoForward = false
+            isLoading = false
+            return
+        }
+        canGoBack = webView.canGoBack
+        canGoForward = webView.canGoForward
+        isLoading = webView.isLoading
+    }
+}
+
+// MARK: - WKWebView host
+
+/// Re-parents the active tab's WKWebView into a fresh container each
+/// time SwiftUI rebuilds the surrounding pane (layout transition,
+/// sibling close, workspace switch). The store retains the WebView so
+/// `dismantleNSView` only needs to detach it from the superview —
+/// destruction happens centrally via `WebPaneStore.destroyCoordinator`.
+private struct WebPaneHost: NSViewRepresentable {
+    let paneID: UUID
+    let tabID: UUID
+    let initialURL: String
+    let isFocused: Bool
+
+    @Environment(\.webPaneStore) private var webPaneStore
+
+    func makeNSView(context _: Context) -> PaneFocusView {
+        let focus = PaneFocusView(paneID: paneID)
+        let coord = webPaneStore.coordinator(for: paneID)
+        // The tab the caller passed isn't necessarily registered with
+        // the coordinator yet, so synthesise a stub for the lookup —
+        // the coordinator's get-or-create logic will build the WebView
+        // and its host container on demand.
+        let tab = WebTab(id: tabID, url: initialURL)
+        let tabContainer = coord.container(for: tab)
+        focus.embed(tabContainer)
+        if isFocused {
+            Self.claimFirstResponder(for: tabContainer.webView, allowDuringTextEditing: true)
+        }
+        return focus
+    }
+
+    func updateNSView(_ focus: PaneFocusView, context _: Context) {
+        let coord = webPaneStore.coordinator(for: paneID)
+        let tab = WebTab(id: tabID, url: initialURL)
+        let tabContainer = coord.container(for: tab)
+
+        for subview in focus.subviews where subview !== tabContainer {
+            subview.removeFromSuperview()
+        }
+        if tabContainer.superview !== focus {
+            tabContainer.removeFromSuperview()
+            focus.embed(tabContainer)
+        }
+        if isFocused {
+            Self.claimFirstResponder(for: tabContainer.webView, allowDuringTextEditing: false)
+        }
+    }
+
+    /// Promote `webView` to first responder if it isn't already and the
+    /// URL bar isn't actively editing. Skips synchronously when the
+    /// state is already correct so SwiftUI's frequent `updateNSView`
+    /// calls don't queue redundant main-actor hops.
+    private static func claimFirstResponder(for webView: WKWebView, allowDuringTextEditing: Bool) {
+        if let window = webView.window {
+            if window.firstResponder === webView { return }
+            if !allowDuringTextEditing, window.firstResponder is NSText { return }
+        }
+        DispatchQueue.main.async { [weak webView] in
+            guard let webView, let window = webView.window else { return }
+            if window.firstResponder === webView { return }
+            if !allowDuringTextEditing, window.firstResponder is NSText { return }
+            window.makeFirstResponder(webView)
+        }
+    }
+
+    static func dismantleNSView(_ container: PaneFocusView, coordinator _: ()) {
+        // Detach only — the WKWebView and its coordinator are owned by
+        // WebPaneStore. The store releases them on pane close.
+        for sub in container.subviews {
+            sub.removeFromSuperview()
+        }
+    }
+}

--- a/Nex/Features/WebPane/WebPaneView.swift
+++ b/Nex/Features/WebPane/WebPaneView.swift
@@ -15,6 +15,11 @@ struct WebPaneView: View {
     let tabs: [WebTab]
     /// Currently visible tab. nil falls back to `tabs.first`.
     let activeTabID: UUID?
+    /// Whether the pane runs against a `nonPersistent()` data store.
+    /// The host uses this to pick the right coordinator at first
+    /// mount, and to detect when a toggle requires destroying +
+    /// rebuilding the coordinator against the new store.
+    let isPrivate: Bool
     let isFocused: Bool
     /// Bumped by parent (PaneGridView) when ⌘L fires for this pane,
     /// the chrome promotes the URL bar to first responder.
@@ -26,6 +31,11 @@ struct WebPaneView: View {
     let onTabSelect: (UUID) -> Void
     let onTabClose: (UUID) -> Void
     let onTabNew: () -> Void
+    /// Flip between persistent + nonPersistent data stores. The
+    /// reducer warns the user about the loss of live JS state /
+    /// cookies before calling through, so this is unconditional at
+    /// the view layer.
+    var onTogglePrivate: (() -> Void)?
     /// Sibling panes in the same workspace, surfaced in the panel's
     /// destination picker at send time.
     let availableInspectTargets: [InspectTargetOption]
@@ -48,6 +58,7 @@ struct WebPaneView: View {
     let onOpenFavourite: (String) -> Void
 
     @Environment(\.webPaneStore) private var webPaneStore
+    @State private var storagePanelVisible: Bool = false
     @State private var displayedURL: String = ""
     /// Title that pairs with `displayedURL`. Updated from the same
     /// stateDidChange notification so the star toggle never saves a
@@ -76,11 +87,14 @@ struct WebPaneView: View {
                 isLoading: isLoading,
                 tabs: tabs,
                 activeTabID: active?.id,
+                isPrivate: isPrivate,
+                storagePanelVisible: storagePanelVisible,
                 onBack: onBack,
                 onForward: onForward,
                 onReload: onReload,
                 onNavigate: onNavigate,
                 onInspect: toggleInspector,
+                onToggleStoragePanel: { storagePanelVisible.toggle() },
                 onTabSelect: onTabSelect,
                 onTabClose: onTabClose,
                 onTabNew: onTabNew,
@@ -94,6 +108,15 @@ struct WebPaneView: View {
                 },
                 onOpenFavourite: onOpenFavourite
             )
+
+            if storagePanelVisible {
+                StoragePanel(
+                    paneID: paneID,
+                    isPrivate: isPrivate,
+                    onTogglePrivate: { onTogglePrivate?() },
+                    onClose: { storagePanelVisible = false }
+                )
+            }
 
             if let batchInspect, batchInspect.panelVisible {
                 WebBatchInspectPanel(
@@ -116,6 +139,7 @@ struct WebPaneView: View {
                     paneID: paneID,
                     tabs: tabs,
                     activeTab: active,
+                    isPrivate: isPrivate,
                     isFocused: isFocused
                 )
             }
@@ -161,7 +185,7 @@ struct WebPaneView: View {
 
     private func toggleInspector() {
         guard let tab = activeTab else { return }
-        webPaneStore.coordinator(for: paneID).toggleInspector(tabID: tab.id)
+        webPaneStore.coordinator(for: paneID, isPrivate: isPrivate).toggleInspector(tabID: tab.id)
     }
 
     private func refreshState() {
@@ -217,13 +241,14 @@ private struct WebPaneHost: NSViewRepresentable {
     /// Pre-resolved by `WebPaneView` so this host and the chrome
     /// agree on which tab is visible (no double fallback).
     let activeTab: WebTab?
+    let isPrivate: Bool
     let isFocused: Bool
 
     @Environment(\.webPaneStore) private var webPaneStore
 
     func makeNSView(context _: Context) -> PaneFocusView {
         let focus = PaneFocusView(paneID: paneID)
-        let coord = webPaneStore.coordinator(for: paneID)
+        let coord = webPaneStore.coordinator(for: paneID, isPrivate: isPrivate)
         for tab in tabs {
             let tabContainer = coord.container(for: tab)
             focus.embed(tabContainer)
@@ -239,7 +264,19 @@ private struct WebPaneHost: NSViewRepresentable {
     }
 
     func updateNSView(_ focus: PaneFocusView, context _: Context) {
-        let coord = webPaneStore.coordinator(for: paneID)
+        // Privacy-mode mismatch: WKWebsiteDataStore is sealed at
+        // WKWebView config time, so toggling between persistent /
+        // nonPersistent stores requires tearing down the coordinator
+        // and rebuilding fresh tabs. The reducer also destroys on
+        // flag change; this is a defence-in-depth backstop in case
+        // SwiftUI re-renders before that effect lands.
+        if let existing = webPaneStore.coordinatorIfExists(for: paneID) {
+            let wantsPersistent = !isPrivate
+            if existing.dataStore.isPersistent != wantsPersistent {
+                webPaneStore.destroyCoordinator(paneID: paneID)
+            }
+        }
+        let coord = webPaneStore.coordinator(for: paneID, isPrivate: isPrivate)
         let liveContainers = tabs.map { coord.container(for: $0) }
         let liveContainerSet = Set(liveContainers.map { ObjectIdentifier($0) })
 

--- a/Nex/Features/WebPane/WebPaneView.swift
+++ b/Nex/Features/WebPane/WebPaneView.swift
@@ -67,6 +67,15 @@ struct WebPaneView: View {
     @State private var canGoBack: Bool = false
     @State private var canGoForward: Bool = false
     @State private var isLoading: Bool = false
+    /// 0..1, WKWebView's `estimatedProgress`. Driven by KVO via the
+    /// coordinator notification. Held at 1.0 briefly after a load
+    /// completes so the chrome progress strip can fade out from full
+    /// instead of snapping to zero.
+    @State private var loadProgress: Double = 0
+    /// Visibility / fade state of the chrome progress strip — true
+    /// while loading and during the brief fade-out after completion.
+    @State private var loadProgressVisible: Bool = false
+    @State private var loadProgressFadeOutTask: Task<Void, Never>?
 
     /// Single source of truth for which tab is active. The host and
     /// chrome both read this so they never disagree about the
@@ -85,6 +94,8 @@ struct WebPaneView: View {
                 canGoBack: canGoBack,
                 canGoForward: canGoForward,
                 isLoading: isLoading,
+                loadProgress: loadProgress,
+                loadProgressVisible: loadProgressVisible,
                 tabs: tabs,
                 activeTabID: active?.id,
                 isPrivate: isPrivate,
@@ -166,6 +177,49 @@ struct WebPaneView: View {
             }
             refreshNavState()
         }
+        .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.loadProgressDidChangeNotification)) { note in
+            guard
+                let info = note.userInfo,
+                let firedPane = info["paneID"] as? UUID,
+                firedPane == paneID,
+                let firedTab = info["tabID"] as? UUID,
+                firedTab == active?.id
+            else { return }
+            let progress = (info["progress"] as? Double) ?? 0
+            let loading = (info["isLoading"] as? Bool) ?? false
+            applyLoadProgress(progress: progress, loading: loading)
+        }
+    }
+
+    private func applyLoadProgress(progress: Double, loading: Bool) {
+        isLoading = loading
+        if loading {
+            loadProgressFadeOutTask?.cancel()
+            loadProgressFadeOutTask = nil
+            if !loadProgressVisible {
+                loadProgressVisible = true
+                loadProgress = max(progress, 0.05) // small head-start so click registers
+            } else {
+                loadProgress = progress
+            }
+        } else {
+            // Race: KVO can fire `isLoading=false` before the final
+            // `estimatedProgress=1.0` arrives. Bump the bar to full
+            // either way so the fade-out reads as completion.
+            loadProgress = 1.0
+            loadProgressFadeOutTask?.cancel()
+            loadProgressFadeOutTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(300))
+                guard !Task.isCancelled else { return }
+                loadProgressVisible = false
+                // Brief settle before resetting to 0 so a stale
+                // notification right after the fade doesn't redraw
+                // the bar at 100% for one frame.
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled else { return }
+                loadProgress = 0
+            }
+        }
     }
 
     private var emptyState: some View {
@@ -194,6 +248,7 @@ struct WebPaneView: View {
             displayedTitle = ""
             canGoBack = false
             canGoForward = false
+            snapLoadProgressForActiveTab()
             return
         }
         let coord = webPaneStore.coordinatorIfExists(for: paneID)
@@ -205,6 +260,7 @@ struct WebPaneView: View {
             displayedTitle = tab.title
         }
         refreshNavState()
+        snapLoadProgressForActiveTab()
     }
 
     private func refreshNavState() {
@@ -218,6 +274,27 @@ struct WebPaneView: View {
         canGoBack = webView.canGoBack
         canGoForward = webView.canGoForward
         isLoading = webView.isLoading
+    }
+
+    /// Sync the progress strip to the now-active tab's WKWebView.
+    /// Without this, a slow tab switched away mid-load leaves its
+    /// strip frozen on screen (the notification filter ignores its
+    /// progress/completion posts while another tab is active) and a
+    /// switch into a tab that's loading shows nothing until the next
+    /// estimatedProgress tick.
+    private func snapLoadProgressForActiveTab() {
+        loadProgressFadeOutTask?.cancel()
+        loadProgressFadeOutTask = nil
+        guard let tab = activeTab,
+              let webView = webPaneStore.coordinatorIfExists(for: paneID)?.webView(for: tab),
+              webView.isLoading
+        else {
+            loadProgressVisible = false
+            loadProgress = 0
+            return
+        }
+        loadProgressVisible = true
+        loadProgress = max(webView.estimatedProgress, 0.05)
     }
 }
 

--- a/Nex/Features/WebPane/WebPaneView.swift
+++ b/Nex/Features/WebPane/WebPaneView.swift
@@ -3,22 +3,29 @@ import SwiftUI
 import WebKit
 
 /// SwiftUI wrapper for a `.web` pane. Composes the chrome strip
-/// (URL bar + nav buttons) over a `NSViewRepresentable` host that
-/// owns the WKWebView lifecycle: the WebView is fetched from
-/// `WebPaneStore` on first render and re-parented across SwiftUI
-/// rebuilds during layout transitions (sibling close, workspace
-/// switch).
+/// (URL bar + nav buttons + tab strip) over a `NSViewRepresentable`
+/// host that owns the WKWebView lifecycle. The host keeps all tab
+/// containers mounted side-by-side as siblings (only the active one
+/// visible via `isHidden = false`); the store retains them across
+/// SwiftUI rebuilds during layout transitions.
 struct WebPaneView: View {
     let paneID: UUID
-    let tab: WebTab?
+    /// All tabs in this web pane, in display order. Empty array =
+    /// blank pane (no tab yet).
+    let tabs: [WebTab]
+    /// Currently visible tab. nil falls back to `tabs.first`.
+    let activeTabID: UUID?
     let isFocused: Bool
-    /// Bumped by parent (PaneGridView) when ⌘L fires for this pane —
+    /// Bumped by parent (PaneGridView) when ⌘L fires for this pane,
     /// the chrome promotes the URL bar to first responder.
     let focusURLBarToken: UInt64
     let onNavigate: (String) -> Void
     let onBack: () -> Void
     let onForward: () -> Void
     let onReload: () -> Void
+    let onTabSelect: (UUID) -> Void
+    let onTabClose: (UUID) -> Void
+    let onTabNew: () -> Void
 
     @Environment(\.webPaneStore) private var webPaneStore
     @State private var displayedURL: String = ""
@@ -26,7 +33,16 @@ struct WebPaneView: View {
     @State private var canGoForward: Bool = false
     @State private var isLoading: Bool = false
 
+    /// Single source of truth for which tab is active. The host and
+    /// chrome both read this so they never disagree about the
+    /// fallback when `activeTabID` is stale.
+    private var activeTab: WebTab? {
+        if let id = activeTabID, let tab = tabs.first(where: { $0.id == id }) { return tab }
+        return tabs.first
+    }
+
     var body: some View {
+        let active = activeTab
         VStack(spacing: 0) {
             WebPaneChrome(
                 paneID: paneID,
@@ -34,35 +50,40 @@ struct WebPaneView: View {
                 canGoBack: canGoBack,
                 canGoForward: canGoForward,
                 isLoading: isLoading,
+                tabs: tabs,
+                activeTabID: active?.id,
                 onBack: onBack,
                 onForward: onForward,
                 onReload: onReload,
                 onNavigate: onNavigate,
                 onInspect: toggleInspector,
+                onTabSelect: onTabSelect,
+                onTabClose: onTabClose,
+                onTabNew: onTabNew,
                 focusRequestToken: focusURLBarToken
             )
 
-            if let tab {
+            if tabs.isEmpty {
+                emptyState
+            } else {
                 WebPaneHost(
                     paneID: paneID,
-                    tabID: tab.id,
-                    initialURL: tab.url,
+                    tabs: tabs,
+                    activeTab: active,
                     isFocused: isFocused
                 )
-            } else {
-                emptyState
             }
         }
         .background(Color(nsColor: .textBackgroundColor))
         .onAppear(perform: refreshState)
-        .onChange(of: tab?.id) { _, _ in refreshState() }
+        .onChange(of: active?.id) { _, _ in refreshState() }
         .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.stateDidChangeNotification)) { note in
             guard
                 let info = note.userInfo,
                 let firedPane = info["paneID"] as? UUID,
                 firedPane == paneID,
                 let firedTab = info["tabID"] as? UUID,
-                firedTab == tab?.id
+                firedTab == active?.id
             else { return }
             displayedURL = (info["url"] as? String) ?? displayedURL
             refreshNavState()
@@ -85,7 +106,7 @@ struct WebPaneView: View {
     }
 
     private func toggleInspector() {
-        guard let tab else { return }
+        guard let tab = activeTab else { return }
         let coord = webPaneStore.coordinator(for: paneID)
         let ok = coord.toggleInspector(tabID: tab.id)
         if !ok {
@@ -94,7 +115,7 @@ struct WebPaneView: View {
     }
 
     private func refreshState() {
-        guard let tab else {
+        guard let tab = activeTab else {
             displayedURL = ""
             canGoBack = false
             canGoForward = false
@@ -110,7 +131,7 @@ struct WebPaneView: View {
     }
 
     private func refreshNavState() {
-        guard let tab,
+        guard let tab = activeTab,
               let webView = webPaneStore.coordinatorIfExists(for: paneID)?.webView(for: tab) else {
             canGoBack = false
             canGoForward = false
@@ -123,17 +144,26 @@ struct WebPaneView: View {
     }
 }
 
-// MARK: - WKWebView host
+// MARK: - WKWebView host (multi-tab)
 
-/// Re-parents the active tab's WKWebView into a fresh container each
-/// time SwiftUI rebuilds the surrounding pane (layout transition,
-/// sibling close, workspace switch). The store retains the WebView so
-/// `dismantleNSView` only needs to detach it from the superview —
-/// destruction happens centrally via `WebPaneStore.destroyCoordinator`.
+/// Mounts every tab's `WebPaneTabContainer` as a sibling inside a
+/// single `PaneFocusView`, toggling `isHidden` to swap which one is
+/// visible. Non-active tabs keep loading / running JS in the
+/// background; their WKWebViews persist across tab switches and
+/// SwiftUI rebuilds (the store owns them).
+///
+/// Lifecycle:
+/// - `makeNSView` builds the focus container and mounts every tab.
+/// - `updateNSView` reconciles when tabs are added/removed/reordered
+///   and updates `isHidden`.
+/// - `dismantleNSView` only detaches from superview; the store
+///   keeps the WKWebViews alive.
 private struct WebPaneHost: NSViewRepresentable {
     let paneID: UUID
-    let tabID: UUID
-    let initialURL: String
+    let tabs: [WebTab]
+    /// Pre-resolved by `WebPaneView` so this host and the chrome
+    /// agree on which tab is visible (no double fallback).
+    let activeTab: WebTab?
     let isFocused: Bool
 
     @Environment(\.webPaneStore) private var webPaneStore
@@ -141,33 +171,51 @@ private struct WebPaneHost: NSViewRepresentable {
     func makeNSView(context _: Context) -> PaneFocusView {
         let focus = PaneFocusView(paneID: paneID)
         let coord = webPaneStore.coordinator(for: paneID)
-        // The tab the caller passed isn't necessarily registered with
-        // the coordinator yet, so synthesise a stub for the lookup —
-        // the coordinator's get-or-create logic will build the WebView
-        // and its host container on demand.
-        let tab = WebTab(id: tabID, url: initialURL)
-        let tabContainer = coord.container(for: tab)
-        focus.embed(tabContainer)
-        if isFocused {
-            Self.claimFirstResponder(for: tabContainer.webView, allowDuringTextEditing: true)
+        for tab in tabs {
+            let tabContainer = coord.container(for: tab)
+            focus.embed(tabContainer)
+            tabContainer.isHidden = tab.id != activeTab?.id
+        }
+        if let activeTab, isFocused {
+            Self.claimFirstResponder(
+                for: coord.container(for: activeTab).webView,
+                allowDuringTextEditing: true
+            )
         }
         return focus
     }
 
     func updateNSView(_ focus: PaneFocusView, context _: Context) {
         let coord = webPaneStore.coordinator(for: paneID)
-        let tab = WebTab(id: tabID, url: initialURL)
-        let tabContainer = coord.container(for: tab)
+        let liveContainers = tabs.map { coord.container(for: $0) }
+        let liveContainerSet = Set(liveContainers.map { ObjectIdentifier($0) })
 
-        for subview in focus.subviews where subview !== tabContainer {
-            subview.removeFromSuperview()
+        // Drop subviews that no longer correspond to a live tab
+        // (e.g. tab closed via `webPaneTabClose`).
+        for subview in focus.subviews {
+            if !liveContainerSet.contains(ObjectIdentifier(subview)) {
+                subview.removeFromSuperview()
+            }
         }
-        if tabContainer.superview !== focus {
-            tabContainer.removeFromSuperview()
-            focus.embed(tabContainer)
+
+        for container in liveContainers {
+            if container.superview !== focus {
+                container.removeFromSuperview()
+                focus.embed(container)
+            }
         }
-        if isFocused {
-            Self.claimFirstResponder(for: tabContainer.webView, allowDuringTextEditing: false)
+
+        // Active tab visible, others hidden but still mounted so
+        // their JS keeps running.
+        for (tab, container) in zip(tabs, liveContainers) {
+            container.isHidden = tab.id != activeTab?.id
+        }
+
+        if isFocused, let activeTab {
+            Self.claimFirstResponder(
+                for: coord.container(for: activeTab).webView,
+                allowDuringTextEditing: false
+            )
         }
     }
 
@@ -189,8 +237,8 @@ private struct WebPaneHost: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ container: PaneFocusView, coordinator _: ()) {
-        // Detach only — the WKWebView and its coordinator are owned by
-        // WebPaneStore. The store releases them on pane close.
+        // Detach only — WKWebViews and tab containers are owned by
+        // WebPaneStore and survive view teardown.
         for sub in container.subviews {
             sub.removeFromSuperview()
         }

--- a/Nex/Features/WebPane/WebPaneView.swift
+++ b/Nex/Features/WebPane/WebPaneView.swift
@@ -26,24 +26,22 @@ struct WebPaneView: View {
     let onTabSelect: (UUID) -> Void
     let onTabClose: (UUID) -> Void
     let onTabNew: () -> Void
-    /// Sibling panes in the same workspace, surfaced in the
-    /// element-pickup menu so the user can pick a destination for
-    /// the next click's payload. Empty array hides the per-target
-    /// menu items (the button still arms in queue-only mode).
+    /// Sibling panes in the same workspace, surfaced in the panel's
+    /// destination picker at send time.
     let availableInspectTargets: [InspectTargetOption]
-    /// True while the picker is armed on this pane.
     let inspectorArmed: Bool
-    let onArmInspectorPickup: (UUID?) -> Void
-    let onDisarmInspectorPickup: () -> Void
-    /// Active batch-annotate state. nil = no batch in progress.
+    /// Active batch state. nil = no batch in progress.
     let batchInspect: BatchInspectState?
-    /// Begin a batch with the named destination (nil = local queue).
-    let onStartBatchInspect: (UUID?) -> Void
+    /// Previous batch destination on this pane (in-session memory) —
+    /// seeds the panel's initial picker selection on a second batch.
+    let lastBatchTarget: BatchTargetMemory?
+    let onTogglePickup: () -> Void
     /// Edit / remove individual items, then finalise or cancel.
     let onBatchItemCommentChanged: (UUID, String) -> Void
     let onBatchItemRemoved: (UUID) -> Void
     let onBatchRowTapped: (UUID) -> Void
-    let onBatchSend: () -> Void
+    /// `sendTo` nil → queue locally; non-nil → paste into that pane.
+    let onBatchSend: (UUID?) -> Void
     let onBatchCancel: () -> Void
     let favourites: [Favourite]
     let onToggleFavourite: (String, String) -> Void
@@ -86,12 +84,9 @@ struct WebPaneView: View {
                 onTabSelect: onTabSelect,
                 onTabClose: onTabClose,
                 onTabNew: onTabNew,
-                availableInspectTargets: availableInspectTargets,
                 inspectorArmed: inspectorArmed,
-                onArmInspectorPickup: onArmInspectorPickup,
-                onDisarmInspectorPickup: onDisarmInspectorPickup,
-                batchInspectActive: batchInspect != nil,
-                onStartBatchInspect: onStartBatchInspect,
+                pendingItemCount: batchInspect?.items.count ?? 0,
+                onTogglePickup: onTogglePickup,
                 focusRequestToken: focusURLBarToken,
                 favourites: favourites,
                 onToggleStar: {
@@ -100,16 +95,17 @@ struct WebPaneView: View {
                 onOpenFavourite: onOpenFavourite
             )
 
-            if let batchInspect {
+            if let batchInspect, batchInspect.panelVisible {
                 WebBatchInspectPanel(
                     items: batchInspect.items,
-                    destinationLabel: destinationLabel(for: batchInspect.sendTo),
+                    availableTargets: availableInspectTargets,
                     focusedItemID: batchInspect.focusedItemID,
                     onCommentChanged: onBatchItemCommentChanged,
                     onRemoveItem: onBatchItemRemoved,
                     onRowTapped: onBatchRowTapped,
                     onSend: onBatchSend,
-                    onCancel: onBatchCancel
+                    onCancel: onBatchCancel,
+                    initialSelection: lastBatchTarget
                 )
             }
 
@@ -166,19 +162,6 @@ struct WebPaneView: View {
     private func toggleInspector() {
         guard let tab = activeTab else { return }
         webPaneStore.coordinator(for: paneID).toggleInspector(tabID: tab.id)
-    }
-
-    /// Resolve a batch destination pane id to a human-friendly label
-    /// using the same `availableInspectTargets` list that fills the
-    /// chrome menu. Falls back to the UUID prefix when the target
-    /// isn't (or no longer is) in the list, and the constant
-    /// "(local queue)" when no destination was set.
-    private func destinationLabel(for sendTo: UUID?) -> String {
-        guard let sendTo else { return "(local queue)" }
-        if let match = availableInspectTargets.first(where: { $0.id == sendTo }) {
-            return match.label
-        }
-        return String(sendTo.uuidString.prefix(8))
     }
 
     private func refreshState() {

--- a/Nex/Features/WebPane/WebPaneView.swift
+++ b/Nex/Features/WebPane/WebPaneView.swift
@@ -26,6 +26,25 @@ struct WebPaneView: View {
     let onTabSelect: (UUID) -> Void
     let onTabClose: (UUID) -> Void
     let onTabNew: () -> Void
+    /// Sibling panes in the same workspace, surfaced in the
+    /// element-pickup menu so the user can pick a destination for
+    /// the next click's payload. Empty array hides the per-target
+    /// menu items (the button still arms in queue-only mode).
+    let availableInspectTargets: [InspectTargetOption]
+    /// True while the picker is armed on this pane.
+    let inspectorArmed: Bool
+    let onArmInspectorPickup: (UUID?) -> Void
+    let onDisarmInspectorPickup: () -> Void
+    /// Active batch-annotate state. nil = no batch in progress.
+    let batchInspect: BatchInspectState?
+    /// Begin a batch with the named destination (nil = local queue).
+    let onStartBatchInspect: (UUID?) -> Void
+    /// Edit / remove individual items, then finalise or cancel.
+    let onBatchItemCommentChanged: (UUID, String) -> Void
+    let onBatchItemRemoved: (UUID) -> Void
+    let onBatchRowTapped: (UUID) -> Void
+    let onBatchSend: () -> Void
+    let onBatchCancel: () -> Void
 
     @Environment(\.webPaneStore) private var webPaneStore
     @State private var displayedURL: String = ""
@@ -60,8 +79,27 @@ struct WebPaneView: View {
                 onTabSelect: onTabSelect,
                 onTabClose: onTabClose,
                 onTabNew: onTabNew,
+                availableInspectTargets: availableInspectTargets,
+                inspectorArmed: inspectorArmed,
+                onArmInspectorPickup: onArmInspectorPickup,
+                onDisarmInspectorPickup: onDisarmInspectorPickup,
+                batchInspectActive: batchInspect != nil,
+                onStartBatchInspect: onStartBatchInspect,
                 focusRequestToken: focusURLBarToken
             )
+
+            if let batchInspect {
+                WebBatchInspectPanel(
+                    items: batchInspect.items,
+                    destinationLabel: destinationLabel(for: batchInspect.sendTo),
+                    focusedItemID: batchInspect.focusedItemID,
+                    onCommentChanged: onBatchItemCommentChanged,
+                    onRemoveItem: onBatchItemRemoved,
+                    onRowTapped: onBatchRowTapped,
+                    onSend: onBatchSend,
+                    onCancel: onBatchCancel
+                )
+            }
 
             if tabs.isEmpty {
                 emptyState
@@ -107,11 +145,20 @@ struct WebPaneView: View {
 
     private func toggleInspector() {
         guard let tab = activeTab else { return }
-        let coord = webPaneStore.coordinator(for: paneID)
-        let ok = coord.toggleInspector(tabID: tab.id)
-        if !ok {
-            NSLog("WebPaneView: Web Inspector SPI not available on this WebKit build")
+        webPaneStore.coordinator(for: paneID).toggleInspector(tabID: tab.id)
+    }
+
+    /// Resolve a batch destination pane id to a human-friendly label
+    /// using the same `availableInspectTargets` list that fills the
+    /// chrome menu. Falls back to the UUID prefix when the target
+    /// isn't (or no longer is) in the list, and the constant
+    /// "(local queue)" when no destination was set.
+    private func destinationLabel(for sendTo: UUID?) -> String {
+        guard let sendTo else { return "(local queue)" }
+        if let match = availableInspectTargets.first(where: { $0.id == sendTo }) {
+            return match.label
         }
+        return String(sendTo.uuidString.prefix(8))
     }
 
     private func refreshState() {

--- a/Nex/Features/WebPane/WebPaneView.swift
+++ b/Nex/Features/WebPane/WebPaneView.swift
@@ -45,9 +45,16 @@ struct WebPaneView: View {
     let onBatchRowTapped: (UUID) -> Void
     let onBatchSend: () -> Void
     let onBatchCancel: () -> Void
+    let favourites: [Favourite]
+    let onToggleFavourite: (String, String) -> Void
+    let onOpenFavourite: (String) -> Void
 
     @Environment(\.webPaneStore) private var webPaneStore
     @State private var displayedURL: String = ""
+    /// Title that pairs with `displayedURL`. Updated from the same
+    /// stateDidChange notification so the star toggle never saves a
+    /// stale title under a newly-navigated URL.
+    @State private var displayedTitle: String = ""
     @State private var canGoBack: Bool = false
     @State private var canGoForward: Bool = false
     @State private var isLoading: Bool = false
@@ -85,7 +92,12 @@ struct WebPaneView: View {
                 onDisarmInspectorPickup: onDisarmInspectorPickup,
                 batchInspectActive: batchInspect != nil,
                 onStartBatchInspect: onStartBatchInspect,
-                focusRequestToken: focusURLBarToken
+                focusRequestToken: focusURLBarToken,
+                favourites: favourites,
+                onToggleStar: {
+                    onToggleFavourite(displayedURL, displayedTitle)
+                },
+                onOpenFavourite: onOpenFavourite
             )
 
             if let batchInspect {
@@ -123,7 +135,15 @@ struct WebPaneView: View {
                 let firedTab = info["tabID"] as? UUID,
                 firedTab == active?.id
             else { return }
-            displayedURL = (info["url"] as? String) ?? displayedURL
+            // Ignore the empty/about:blank placeholders WebKit surfaces
+            // during a failed or in-progress load — otherwise a broken
+            // URL would persist as "about:blank" in the URL bar
+            // (mirrors the guard in WorkspaceFeature.webPaneStateChanged).
+            if let rawURL = info["url"] as? String,
+               !rawURL.isEmpty, rawURL != "about:blank" {
+                displayedURL = rawURL
+                displayedTitle = (info["title"] as? String) ?? ""
+            }
             refreshNavState()
         }
     }
@@ -164,6 +184,7 @@ struct WebPaneView: View {
     private func refreshState() {
         guard let tab = activeTab else {
             displayedURL = ""
+            displayedTitle = ""
             canGoBack = false
             canGoForward = false
             return
@@ -171,8 +192,10 @@ struct WebPaneView: View {
         let coord = webPaneStore.coordinatorIfExists(for: paneID)
         if let snapshot = coord?.currentURLAndTitle(tabID: tab.id), !snapshot.url.isEmpty {
             displayedURL = snapshot.url
+            displayedTitle = snapshot.title
         } else {
             displayedURL = tab.url
+            displayedTitle = tab.title
         }
         refreshNavState()
     }

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -292,6 +292,10 @@ struct WorkspaceFeature {
         /// chrome toggle so the user can dismiss the panel without
         /// losing their pending items.
         case webBatchPanelVisible(paneID: UUID, visible: Bool)
+        /// Flip / set the per-pane private flag. Pure state mutation —
+        /// the AppReducer destroys the coordinator alongside so the
+        /// host rebuilds tabs against the new data store.
+        case webPaneSetIsPrivate(paneID: UUID, enabled: Bool)
         /// Focus an item in the active batch — used by both the
         /// list-row tap (which then highlights on page) and the
         /// page-side marker click (which then highlights the row).
@@ -665,9 +669,10 @@ struct WorkspaceFeature {
                     state.webPanes[paneID] = ws
                 }
                 let store = webPaneStore
+                let isPrivate = state.webPanes[paneID]?.isPrivate ?? false
                 return .run { _ in
                     await MainActor.run {
-                        let coord = store.coordinator(for: paneID)
+                        let coord = store.coordinator(for: paneID, isPrivate: isPrivate)
                         _ = coord.navigate(tab: tab, to: normalized)
                     }
                 }
@@ -676,9 +681,10 @@ struct WorkspaceFeature {
                 guard let webState = state.webPanes[paneID],
                       let tab = webState.activeTab else { return .none }
                 let store = webPaneStore
+                let isPrivate = webState.isPrivate
                 return .run { _ in
                     await MainActor.run {
-                        _ = store.coordinator(for: paneID).goBack(tabID: tab.id)
+                        _ = store.coordinator(for: paneID, isPrivate: isPrivate).goBack(tabID: tab.id)
                     }
                 }
 
@@ -686,9 +692,10 @@ struct WorkspaceFeature {
                 guard let webState = state.webPanes[paneID],
                       let tab = webState.activeTab else { return .none }
                 let store = webPaneStore
+                let isPrivate = webState.isPrivate
                 return .run { _ in
                     await MainActor.run {
-                        _ = store.coordinator(for: paneID).goForward(tabID: tab.id)
+                        _ = store.coordinator(for: paneID, isPrivate: isPrivate).goForward(tabID: tab.id)
                     }
                 }
 
@@ -696,9 +703,10 @@ struct WorkspaceFeature {
                 guard let webState = state.webPanes[paneID],
                       let tab = webState.activeTab else { return .none }
                 let store = webPaneStore
+                let isPrivate = webState.isPrivate
                 return .run { _ in
                     await MainActor.run {
-                        _ = store.coordinator(for: paneID).reload(tabID: tab.id, hard: hard)
+                        _ = store.coordinator(for: paneID, isPrivate: isPrivate).reload(tabID: tab.id, hard: hard)
                     }
                 }
 
@@ -899,6 +907,13 @@ struct WorkspaceFeature {
                       let batch = webState.batchInspect,
                       batch.panelVisible != visible else { return .none }
                 webState.batchInspect?.panelVisible = visible
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webPaneSetIsPrivate(let paneID, let enabled):
+                guard var webState = state.webPanes[paneID],
+                      webState.isPrivate != enabled else { return .none }
+                webState.isPrivate = enabled
                 state.webPanes[paneID] = webState
                 return .none
 

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -279,13 +279,19 @@ struct WorkspaceFeature {
         /// Begin a batch-annotate session. Records the destination
         /// pane on `WebPaneState.batchInspect`; the AppReducer is
         /// responsible for arming the picker with `sticky: true`.
-        case webBatchInspectBegin(paneID: UUID, sendTo: UUID?)
+        case webBatchInspectBegin(paneID: UUID)
         case webBatchItemAdded(paneID: UUID, item: BatchInspectItem)
         case webBatchItemCommentChanged(paneID: UUID, itemID: UUID, comment: String)
         case webBatchItemRemoved(paneID: UUID, itemID: UUID)
         /// Tear down the batch session without sending. The
         /// AppReducer also disarms the sticky picker.
         case webBatchInspectCleared(paneID: UUID)
+        /// Set the panel-visible flag on an active batch. The
+        /// AppReducer pairs this with arming/disarming the picker and
+        /// posting marker show/hide to the page. Used by the scope
+        /// chrome toggle so the user can dismiss the panel without
+        /// losing their pending items.
+        case webBatchPanelVisible(paneID: UUID, visible: Bool)
         /// Focus an item in the active batch — used by both the
         /// list-row tap (which then highlights on page) and the
         /// page-side marker click (which then highlights the row).
@@ -852,9 +858,9 @@ struct WorkspaceFeature {
                 state.webPanes[paneID] = webState
                 return .none
 
-            case .webBatchInspectBegin(let paneID, let sendTo):
+            case .webBatchInspectBegin(let paneID):
                 guard var webState = state.webPanes[paneID] else { return .none }
-                webState.batchInspect = BatchInspectState(sendTo: sendTo, items: [])
+                webState.batchInspect = BatchInspectState(items: [])
                 state.webPanes[paneID] = webState
                 return .none
 
@@ -885,6 +891,14 @@ struct WorkspaceFeature {
             case .webBatchInspectCleared(let paneID):
                 guard var webState = state.webPanes[paneID] else { return .none }
                 webState.batchInspect = nil
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webBatchPanelVisible(let paneID, let visible):
+                guard var webState = state.webPanes[paneID],
+                      let batch = webState.batchInspect,
+                      batch.panelVisible != visible else { return .none }
+                webState.batchInspect?.panelVisible = visible
                 state.webPanes[paneID] = webState
                 return .none
 

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -130,6 +130,18 @@ struct WorkspaceFeature {
             }
         }
 
+        /// Sync the pane header to reflect the currently-active web
+        /// tab. Call after any change to `activeTabID` (open / close /
+        /// select / cycle) so the header doesn't lag behind until the
+        /// next KVO tick from the WebView. No-op when the title is
+        /// already correct.
+        mutating func syncWebPaneHeader(paneID: UUID) {
+            guard let webState = webPanes[paneID] else { return }
+            let newTitle = webState.activeTab?.displayLabel ?? "Web"
+            guard panes[id: paneID]?.title != newTitle else { return }
+            mutatePane(id: paneID) { $0.title = newTitle }
+        }
+
         /// Update focused pane and push the previous focus onto
         /// `focusHistory` (deduped, capped). Use for every focus
         /// change EXCEPT pane-close: the closing pane is destroyed,
@@ -220,6 +232,21 @@ struct WorkspaceFeature {
         /// persistence keeps a fresh URL even when the user navigates
         /// without typing in the URL bar.
         case webPaneStateChanged(paneID: UUID, tabID: UUID, url: String, title: String)
+        /// Append a new tab to a web pane. `tabID` is supplied by the
+        /// caller so request/response CLI replies can echo a concrete
+        /// id before the effect runs.
+        case webPaneTabOpen(paneID: UUID, tabID: UUID, url: String, makeActive: Bool = true)
+        /// Close a tab inside a web pane. If `tabID == activeTabID`,
+        /// the active selection falls back to the previous sibling
+        /// (or the new first tab). Closing the last tab is rejected
+        /// here — callers compose with `.closePane(paneID)` instead,
+        /// matching how the priority ⌘W layer handles single-tab
+        /// panes.
+        case webPaneTabClose(paneID: UUID, tabID: UUID)
+        case webPaneTabSelect(paneID: UUID, tabID: UUID)
+        /// Cycle by signed offset. `+1` next, `-1` prev. Wraps around.
+        case webPaneTabCycle(paneID: UUID, offset: Int)
+        case webPaneTabReorder(paneID: UUID, orderedTabIDs: [UUID])
         case toggleMarkdownEdit(UUID)
         case increaseMarkdownFontSize(UUID)
         case decreaseMarkdownFontSize(UUID)
@@ -627,7 +654,7 @@ struct WorkspaceFeature {
 
             case .webPaneStateChanged(let paneID, let tabID, let url, let title):
                 guard var webState = state.webPanes[paneID] else { return .none }
-                guard let idx = webState.tabs.firstIndex(where: { $0.id == tabID }) else { return .none }
+                guard let idx = webState.index(of: tabID) else { return .none }
                 // Only overwrite the URL when the coordinator reports
                 // something non-empty (about:blank arrives as "" early
                 // in load and would otherwise wipe the persisted URL).
@@ -638,9 +665,91 @@ struct WorkspaceFeature {
                 webState.tabs[idx].url = newURL
                 webState.tabs[idx].title = title
                 state.webPanes[paneID] = webState
-                if !title.isEmpty {
+                // Only echo to the pane header when this tab is the
+                // resolved active one. webState.activeTab falls back to
+                // tabs.first when activeTabID is stale, so this
+                // matches what the UI is actually showing.
+                if !title.isEmpty,
+                   tabID == webState.activeTab?.id,
+                   state.panes[id: paneID]?.title != title {
                     state.mutatePane(id: paneID) { $0.title = title }
                 }
+                return .none
+
+            case .webPaneTabOpen(let paneID, let tabID, let url, let makeActive):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                // Caller is responsible for allocating fresh UUIDs.
+                guard !webState.contains(tabID: tabID) else { return .none }
+                let normalized = WebPaneCoordinator.normalizeURLInput(url)
+                webState.tabs.append(WebTab(id: tabID, url: normalized))
+                if makeActive {
+                    webState.activeTabID = tabID
+                }
+                state.webPanes[paneID] = webState
+                if makeActive {
+                    state.syncWebPaneHeader(paneID: paneID)
+                }
+                return .none
+
+            case .webPaneTabClose(let paneID, let tabID):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                guard webState.tabs.count > 1 else {
+                    // Single-tab close = pane close. Use the proper
+                    // closePane flow so the workspace cleanup (focus
+                    // history, layout removal, coordinator teardown)
+                    // happens. Callers that want different behaviour
+                    // should compose explicitly.
+                    return .send(.closePane(paneID))
+                }
+                guard let idx = webState.index(of: tabID) else { return .none }
+                let wasActive = webState.activeTabID == tabID
+                webState.tabs.remove(at: idx)
+                if wasActive {
+                    // Prefer the left neighbour of the closed tab;
+                    // fall back to the new first when idx was 0.
+                    let fallbackIdx = max(idx - 1, 0)
+                    webState.activeTabID = webState.tabs[fallbackIdx].id
+                }
+                state.webPanes[paneID] = webState
+                if wasActive {
+                    state.syncWebPaneHeader(paneID: paneID)
+                }
+                let store = webPaneStore
+                return .run { _ in
+                    await store.destroyTab(paneID: paneID, tabID: tabID)
+                }
+
+            case .webPaneTabSelect(let paneID, let tabID):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                guard webState.contains(tabID: tabID) else { return .none }
+                guard webState.activeTabID != tabID else { return .none }
+                webState.activeTabID = tabID
+                state.webPanes[paneID] = webState
+                state.syncWebPaneHeader(paneID: paneID)
+                return .none
+
+            case .webPaneTabCycle(let paneID, let offset):
+                guard var webState = state.webPanes[paneID], webState.tabs.count > 1 else { return .none }
+                let activeID = webState.activeTabID ?? webState.tabs.first?.id
+                guard let activeID, let currentIdx = webState.index(of: activeID) else { return .none }
+                let count = webState.tabs.count
+                let nextIdx = ((currentIdx + offset) % count + count) % count
+                webState.activeTabID = webState.tabs[nextIdx].id
+                state.webPanes[paneID] = webState
+                state.syncWebPaneHeader(paneID: paneID)
+                return .none
+
+            case .webPaneTabReorder(let paneID, let orderedTabIDs):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                let currentOrder = webState.tabs.map(\.id)
+                guard orderedTabIDs != currentOrder else { return .none }
+                // Only reorder if the new sequence is a permutation
+                // of the existing tab ids. Drop the action otherwise
+                // rather than silently truncating / dropping tabs.
+                guard Set(orderedTabIDs) == Set(currentOrder),
+                      orderedTabIDs.count == webState.tabs.count else { return .none }
+                webState.tabs = orderedTabIDs.compactMap { id in webState.tabs.first(where: { $0.id == id }) }
+                state.webPanes[paneID] = webState
                 return .none
 
             case .createScratchpad:

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -247,6 +247,50 @@ struct WorkspaceFeature {
         /// Cycle by signed offset. `+1` next, `-1` prev. Wraps around.
         case webPaneTabCycle(paneID: UUID, offset: Int)
         case webPaneTabReorder(paneID: UUID, orderedTabIDs: [UUID])
+        /// Append a captured console line to the pane's ring buffer.
+        /// Dispatched from `ContentView` when the coordinator posts a
+        /// `consoleLineNotification`.
+        case webConsoleLineReceived(paneID: UUID, line: ConsoleLine)
+        /// Drop everything from the pane's console buffer (the
+        /// `--clear` flag on `nex web console`). `seq` keeps counting.
+        case webConsoleClear(paneID: UUID)
+        /// Reset the pane's `droppedSinceLastDrain` counter to 0.
+        /// Dispatched by `handleWebConsole` right after the reply
+        /// goes out — without this, every subsequent
+        /// `nex web console` call would re-report the same stale
+        /// drop count.
+        case webConsoleAcknowledgeDrops(paneID: UUID)
+        /// Arm the picker for `paneID`, recording the destination
+        /// pane id (if `--send-to` was supplied) plus the nonce the
+        /// coordinator handed back. The coordinator has already
+        /// asked the in-page JS to listen; this action just records
+        /// the bookkeeping side so a delivered inspect-result can be
+        /// routed.
+        case webInspectArmedFor(paneID: UUID, sendTo: UUID?, nonce: String)
+        /// Symmetric tear-down. Called when the coordinator reports a
+        /// delivered click (auto-disarm) or when an explicit disarm
+        /// is dispatched (tab close, target gone).
+        case webInspectDisarm(paneID: UUID)
+        /// A picker-captured payload arrived. Pushed onto the per-
+        /// pane queue so `nex web inspect-result` can drain it.
+        case webInspectResultReceived(paneID: UUID, result: InspectResult)
+        /// Drop everything from the pane's inspect-result queue.
+        case webInspectResultClear(paneID: UUID)
+        /// Begin a batch-annotate session. Records the destination
+        /// pane on `WebPaneState.batchInspect`; the AppReducer is
+        /// responsible for arming the picker with `sticky: true`.
+        case webBatchInspectBegin(paneID: UUID, sendTo: UUID?)
+        case webBatchItemAdded(paneID: UUID, item: BatchInspectItem)
+        case webBatchItemCommentChanged(paneID: UUID, itemID: UUID, comment: String)
+        case webBatchItemRemoved(paneID: UUID, itemID: UUID)
+        /// Tear down the batch session without sending. The
+        /// AppReducer also disarms the sticky picker.
+        case webBatchInspectCleared(paneID: UUID)
+        /// Focus an item in the active batch — used by both the
+        /// list-row tap (which then highlights on page) and the
+        /// page-side marker click (which then highlights the row).
+        /// Pass nil to clear the focus highlight.
+        case webBatchItemFocused(paneID: UUID, itemID: UUID?)
         case toggleMarkdownEdit(UUID)
         case increaseMarkdownFontSize(UUID)
         case decreaseMarkdownFontSize(UUID)
@@ -656,9 +700,11 @@ struct WorkspaceFeature {
                 guard var webState = state.webPanes[paneID] else { return .none }
                 guard let idx = webState.index(of: tabID) else { return .none }
                 // Only overwrite the URL when the coordinator reports
-                // something non-empty (about:blank arrives as "" early
-                // in load and would otherwise wipe the persisted URL).
-                let newURL = url.isEmpty ? webState.tabs[idx].url : url
+                // something meaningful. about:blank shows up early in
+                // a load and again on WKWebView's revert after a
+                // failed navigation; both would wipe the URL bar.
+                let isPlaceholder = url.isEmpty || url == "about:blank"
+                let newURL = isPlaceholder ? webState.tabs[idx].url : url
                 guard webState.tabs[idx].url != newURL || webState.tabs[idx].title != title else {
                     return .none
                 }
@@ -749,6 +795,103 @@ struct WorkspaceFeature {
                 guard Set(orderedTabIDs) == Set(currentOrder),
                       orderedTabIDs.count == webState.tabs.count else { return .none }
                 webState.tabs = orderedTabIDs.compactMap { id in webState.tabs.first(where: { $0.id == id }) }
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webConsoleLineReceived(let paneID, let line):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                webState.consoleBuffer.append(line)
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webConsoleClear(let paneID):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                webState.consoleBuffer.clear()
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webConsoleAcknowledgeDrops(let paneID):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                _ = webState.consoleBuffer.acknowledgeDrops()
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webInspectArmedFor(let paneID, let sendTo, let nonce):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                webState.inspectorArmed = true
+                webState.pendingInspectSendTo = sendTo
+                webState.pendingInspectNonce = nonce
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webInspectDisarm(let paneID):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                webState.inspectorArmed = false
+                webState.pendingInspectSendTo = nil
+                webState.pendingInspectNonce = nil
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webInspectResultReceived(let paneID, let result):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                webState.inspectResultQueue.append(result)
+                // Cap the queue. 32 entries is generous for the
+                // interactive workflow — agents that don't drain
+                // quickly should use `--clear` on `nex web inspect-result`.
+                if webState.inspectResultQueue.count > 32 {
+                    webState.inspectResultQueue.removeFirst(
+                        webState.inspectResultQueue.count - 32
+                    )
+                }
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webInspectResultClear(let paneID):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                webState.inspectResultQueue.removeAll()
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webBatchInspectBegin(let paneID, let sendTo):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                webState.batchInspect = BatchInspectState(sendTo: sendTo, items: [])
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webBatchItemAdded(let paneID, let item):
+                guard var webState = state.webPanes[paneID],
+                      webState.batchInspect != nil else { return .none }
+                webState.batchInspect?.items.append(item)
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webBatchItemCommentChanged(let paneID, let itemID, let comment):
+                guard var webState = state.webPanes[paneID],
+                      var batch = webState.batchInspect,
+                      let idx = batch.items.firstIndex(where: { $0.id == itemID })
+                else { return .none }
+                batch.items[idx].comment = comment
+                webState.batchInspect = batch
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webBatchItemRemoved(let paneID, let itemID):
+                guard var webState = state.webPanes[paneID],
+                      webState.batchInspect != nil else { return .none }
+                webState.batchInspect?.items.removeAll { $0.id == itemID }
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webBatchInspectCleared(let paneID):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                webState.batchInspect = nil
+                state.webPanes[paneID] = webState
+                return .none
+
+            case .webBatchItemFocused(let paneID, let itemID):
+                guard var webState = state.webPanes[paneID],
+                      webState.batchInspect != nil else { return .none }
+                webState.batchInspect?.focusedItemID = itemID
                 state.webPanes[paneID] = webState
                 return .none
 

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -9,6 +9,11 @@ struct ClosedPaneSnapshot: Equatable {
     var scratchpadContent: String?
     var claudeSessionID: String?
     var markdownFontSize: Double = 14
+    /// Captured web-pane sidecar at the moment of close, so
+    /// `reopenClosedPane` can restore the same URL/tab set. Nil for
+    /// non-web panes and for closed private panes (which intentionally
+    /// drop their tabs at quit/close time).
+    var webState: WebPaneState?
 }
 
 @Reducer
@@ -35,6 +40,11 @@ struct WorkspaceFeature {
         /// restarts. A `Pane` lives in exactly one of `panes` or
         /// `parkedPanes` at any time.
         var parkedPanes: IdentifiedArrayOf<Pane> = []
+        /// Sidecar state for `.web` panes — tab list, active tab,
+        /// private flag. Kept off `Pane` itself so non-web consumers
+        /// don't need to learn the type. Mirrors `parkedPanes`'s
+        /// "lives alongside `panes`" model.
+        var webPanes: [UUID: WebPaneState] = [:]
         var zoomedPaneID: UUID?
         var savedLayout: PaneLayout?
         var searchingPaneID: UUID?
@@ -82,7 +92,8 @@ struct WorkspaceFeature {
             repoAssociations: IdentifiedArrayOf<RepoAssociation> = [],
             createdAt: Date,
             lastAccessedAt: Date,
-            labels: [String] = []
+            labels: [String] = [],
+            webPanes: [UUID: WebPaneState] = [:]
         ) {
             self.id = id
             self.name = name
@@ -95,6 +106,7 @@ struct WorkspaceFeature {
             self.createdAt = createdAt
             self.lastAccessedAt = lastAccessedAt
             self.labels = labels
+            self.webPanes = webPanes
         }
 
         /// Read a pane wherever it lives — visible layout or the
@@ -183,6 +195,31 @@ struct WorkspaceFeature {
         case paneBranchChanged(paneID: UUID, branch: String?)
         case openMarkdownFile(filePath: String, reusePaneID: UUID? = nil)
         case openDiffPane(repoPath: String, targetPath: String?, reusePaneID: UUID? = nil)
+        /// Open a web pane. Splits off the focused pane like
+        /// `openDiffPane`, or replaces the focused pane (`reusePaneID`)
+        /// when invoked via `nex open --here`-style flows. `isPrivate`
+        /// is wired through Phase 5; Phase 1 always passes `false`.
+        /// `paneID`/`tabID` are pre-allocated by the caller so the
+        /// CLI reply (`nex web open`) can echo a concrete pane id
+        /// before the workspace effect runs.
+        case openWebPane(
+            paneID: UUID,
+            tabID: UUID,
+            url: String,
+            reusePaneID: UUID? = nil,
+            isPrivate: Bool = false
+        )
+        /// Tell the coordinator to navigate the active tab. The
+        /// coordinator updates the WebView; the URL bar follows via
+        /// the `stateDidChangeNotification` published from KVO.
+        case webPaneNavigate(paneID: UUID, url: String)
+        case webPaneBack(paneID: UUID)
+        case webPaneForward(paneID: UUID)
+        case webPaneReload(paneID: UUID, hard: Bool = false)
+        /// Mirror coordinator-reported URL/title changes into state so
+        /// persistence keeps a fresh URL even when the user navigates
+        /// without typing in the URL bar.
+        case webPaneStateChanged(paneID: UUID, tabID: UUID, url: String, title: String)
         case toggleMarkdownEdit(UUID)
         case increaseMarkdownFontSize(UUID)
         case decreaseMarkdownFontSize(UUID)
@@ -227,6 +264,7 @@ struct WorkspaceFeature {
     @Dependency(\.ghosttyConfig) var ghosttyConfig
     @Dependency(\.gitService) var gitService
     @Dependency(\.editorService) var editorService
+    @Dependency(\.webPaneStore) var webPaneStore
     @Dependency(\.date.now) var now
     @Dependency(\.uuid) var uuid
 
@@ -475,6 +513,136 @@ struct WorkspaceFeature {
                 state.currentLayoutIndex = nil
                 return branchEffect
 
+            case .openWebPane(let newPaneID, let tabID, let url, let reusePaneID, let isPrivate):
+                let normalized = WebPaneCoordinator.normalizeURLInput(url)
+                let tab = WebTab(id: tabID, url: normalized)
+                let newPane = Pane(
+                    id: newPaneID,
+                    type: .web,
+                    title: "Web",
+                    workingDirectory: NSHomeDirectory(),
+                    createdAt: now,
+                    lastActivityAt: now
+                )
+
+                state.webPanes[newPaneID] = WebPaneState(
+                    tabs: [tab],
+                    activeTabID: tab.id,
+                    isPrivate: isPrivate
+                )
+
+                if let reusePaneID, let oldPane = state.panes[id: reusePaneID] {
+                    if state.searchingPaneID == reusePaneID {
+                        state.searchingPaneID = nil
+                        state.searchNeedle = ""
+                        state.searchTotal = nil
+                        state.searchSelected = nil
+                    }
+                    if let saved = state.savedLayout {
+                        state.layout = saved
+                        state.zoomedPaneID = nil
+                        state.savedLayout = nil
+                    }
+                    var linkedPane = newPane
+                    linkedPane.parkedSourcePaneID = reusePaneID
+                    state.layout = state.layout.replacing(paneID: reusePaneID, with: .leaf(newPaneID))
+                    state.panes.remove(id: reusePaneID)
+                    state.parkedPanes.append(oldPane)
+                    state.panes.append(linkedPane)
+                    state.setFocus(newPaneID)
+                    state.currentLayoutIndex = nil
+                    return .none
+                }
+
+                if let sourceID = state.focusedPaneID {
+                    if let saved = state.savedLayout {
+                        state.layout = saved
+                        state.zoomedPaneID = nil
+                        state.savedLayout = nil
+                    }
+                    let (newLayout, _) = state.layout.splitting(
+                        paneID: sourceID,
+                        direction: .horizontal,
+                        newPaneID: newPaneID
+                    )
+                    state.layout = newLayout
+                } else {
+                    state.layout = .leaf(newPaneID)
+                }
+                state.panes.append(newPane)
+                state.setFocus(newPaneID)
+                state.currentLayoutIndex = nil
+                return .none
+
+            case .webPaneNavigate(let paneID, let url):
+                guard let webState = state.webPanes[paneID],
+                      let tab = webState.activeTab else { return .none }
+                let normalized = WebPaneCoordinator.normalizeURLInput(url)
+                // Mirror into state so a save right now persists the
+                // intended URL even before the coordinator's KVO
+                // notification round-trips.
+                if var ws = state.webPanes[paneID] {
+                    if let idx = ws.tabs.firstIndex(where: { $0.id == tab.id }) {
+                        ws.tabs[idx].url = normalized
+                    }
+                    state.webPanes[paneID] = ws
+                }
+                let store = webPaneStore
+                return .run { _ in
+                    await MainActor.run {
+                        let coord = store.coordinator(for: paneID)
+                        _ = coord.navigate(tab: tab, to: normalized)
+                    }
+                }
+
+            case .webPaneBack(let paneID):
+                guard let webState = state.webPanes[paneID],
+                      let tab = webState.activeTab else { return .none }
+                let store = webPaneStore
+                return .run { _ in
+                    await MainActor.run {
+                        _ = store.coordinator(for: paneID).goBack(tabID: tab.id)
+                    }
+                }
+
+            case .webPaneForward(let paneID):
+                guard let webState = state.webPanes[paneID],
+                      let tab = webState.activeTab else { return .none }
+                let store = webPaneStore
+                return .run { _ in
+                    await MainActor.run {
+                        _ = store.coordinator(for: paneID).goForward(tabID: tab.id)
+                    }
+                }
+
+            case .webPaneReload(let paneID, let hard):
+                guard let webState = state.webPanes[paneID],
+                      let tab = webState.activeTab else { return .none }
+                let store = webPaneStore
+                return .run { _ in
+                    await MainActor.run {
+                        _ = store.coordinator(for: paneID).reload(tabID: tab.id, hard: hard)
+                    }
+                }
+
+            case .webPaneStateChanged(let paneID, let tabID, let url, let title):
+                guard var webState = state.webPanes[paneID] else { return .none }
+                guard let idx = webState.tabs.firstIndex(where: { $0.id == tabID }) else { return .none }
+                // Only overwrite the URL when the coordinator reports
+                // something non-empty (about:blank arrives as "" early
+                // in load and would otherwise wipe the persisted URL).
+                let newURL = url.isEmpty ? webState.tabs[idx].url : url
+                guard webState.tabs[idx].url != newURL || webState.tabs[idx].title != title else {
+                    return .none
+                }
+                webState.tabs[idx].url = newURL
+                webState.tabs[idx].title = title
+                state.webPanes[paneID] = webState
+                if !title.isEmpty {
+                    state.mutatePane(id: paneID) { $0.title = title }
+                }
+                return .none
+
             case .createScratchpad:
                 let newPaneID = uuid()
                 let newPane = Pane(
@@ -563,7 +731,19 @@ struct WorkspaceFeature {
                 // scenes, alongside stale SurfaceManager bookkeeping.
                 let hasBackingSurface = paneType == .shell
                     || (state.panes[id: paneID]?.isUsingExternalEditor ?? false)
+                let isWebPane = paneType == .web
                 if let pane = state.panes[id: paneID] {
+                    // For web panes the sidecar holds the URL — capture
+                    // it into the snapshot so `reopenClosedPane` can
+                    // rebuild the same tab list. Private panes get a
+                    // nil webState so reopen restores a blank tab.
+                    let snapshotWebState: WebPaneState? = {
+                        guard pane.type == .web,
+                              let ws = state.webPanes[paneID],
+                              !ws.isPrivate
+                        else { return nil }
+                        return ws
+                    }()
                     state.recentlyClosedPanes.append(
                         ClosedPaneSnapshot(
                             workingDirectory: pane.workingDirectory,
@@ -572,12 +752,16 @@ struct WorkspaceFeature {
                             filePath: pane.filePath,
                             scratchpadContent: pane.scratchpadContent,
                             claudeSessionID: pane.claudeSessionID,
-                            markdownFontSize: pane.markdownFontSize
+                            markdownFontSize: pane.markdownFontSize,
+                            webState: snapshotWebState
                         )
                     )
                     if state.recentlyClosedPanes.count > 10 {
                         state.recentlyClosedPanes.removeFirst()
                     }
+                }
+                if isWebPane {
+                    state.webPanes.removeValue(forKey: paneID)
                 }
                 state.panes.remove(id: paneID)
                 let newLayout = state.layout.removing(paneID: paneID)
@@ -600,8 +784,24 @@ struct WorkspaceFeature {
                 }
 
                 if hasBackingSurface {
+                    let store = webPaneStore
+                    if isWebPane {
+                        // Defensive — web panes never set hasBackingSurface
+                        // today, but if that ever changes the destroy
+                        // still has to run on the main actor.
+                        return .run { _ in
+                            await surfaceManager.destroySurface(paneID: paneID)
+                            await store.destroyCoordinator(paneID: paneID)
+                        }
+                    }
                     return .run { _ in
                         await surfaceManager.destroySurface(paneID: paneID)
+                    }
+                }
+                if isWebPane {
+                    let store = webPaneStore
+                    return .run { _ in
+                        await store.destroyCoordinator(paneID: paneID)
                     }
                 }
                 return .none
@@ -1045,11 +1245,15 @@ struct WorkspaceFeature {
                 )
                 state.layout = newLayout
                 state.panes.append(newPane)
+                if snapshot.type == .web, let webState = snapshot.webState {
+                    state.webPanes[newPaneID] = webState
+                }
                 state.setFocus(newPaneID)
                 state.currentLayoutIndex = nil
 
-                // Markdown, scratchpad, and diff panes don't need a surface
-                if snapshot.type == .markdown || snapshot.type == .scratchpad || snapshot.type == .diff {
+                // Non-shell pane types don't need a ghostty surface
+                if snapshot.type == .markdown || snapshot.type == .scratchpad
+                    || snapshot.type == .diff || snapshot.type == .web {
                     return .none
                 }
 

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -247,6 +247,17 @@ enum NexAction: String, CaseIterable {
     case commandPalette = "command_palette"
     case newGroup = "new_group"
     case openDiff = "open_diff"
+
+    // Web pane actions (Phase 1). All ship unbound — the priority
+    // layer in `PaneShortcutMonitor` dispatches them directly when
+    // the focused pane is a web pane, so the global ⌘L / ⌘R / ⌘[ / ⌘]
+    // defaults are preserved for every other pane type.
+    case openWebPane = "open_web_pane"
+    case webFocusURLBar = "web_focus_url_bar"
+    case webBack = "web_back"
+    case webForward = "web_forward"
+    case webReload = "web_reload"
+
     case unbind
 
     /// Actions handled by SwiftUI Commands (menu bar items).
@@ -305,6 +316,11 @@ enum NexAction: String, CaseIterable {
         case .commandPalette: "Command Palette"
         case .newGroup: "New Group"
         case .openDiff: "Open Diff"
+        case .openWebPane: "Open Web Pane"
+        case .webFocusURLBar: "Web: Focus URL Bar"
+        case .webBack: "Web: Back"
+        case .webForward: "Web: Forward"
+        case .webReload: "Web: Reload"
         case .unbind: "Unbind"
         }
     }
@@ -327,6 +343,8 @@ enum NexAction: String, CaseIterable {
         case .openFile, .toggleMarkdownEdit, .increaseMarkdownFontSize, .decreaseMarkdownFontSize,
              .resetMarkdownFontSize, .openDiff:
             "Files"
+        case .openWebPane, .webFocusURLBar, .webBack, .webForward, .webReload:
+            "Web Pane (active when web pane focused)"
         case .toggleSearch, .closeSearch:
             "Search"
         case .unbind:

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -248,15 +248,19 @@ enum NexAction: String, CaseIterable {
     case newGroup = "new_group"
     case openDiff = "open_diff"
 
-    // Web pane actions (Phase 1). All ship unbound — the priority
-    // layer in `PaneShortcutMonitor` dispatches them directly when
-    // the focused pane is a web pane, so the global ⌘L / ⌘R / ⌘[ / ⌘]
-    // defaults are preserved for every other pane type.
+    // Web pane actions. All ship unbound; the priority layer in
+    // `PaneShortcutMonitor` dispatches them directly when the focused
+    // pane is a web pane, so the global ⌘L / ⌘R / ⌘[ / ⌘] / ⌘T /
+    // ⌘W / ⌘⇧[ / ⌘⇧] defaults are preserved for every other pane type.
     case openWebPane = "open_web_pane"
     case webFocusURLBar = "web_focus_url_bar"
     case webBack = "web_back"
     case webForward = "web_forward"
     case webReload = "web_reload"
+    case webTabNew = "web_tab_new"
+    case webTabClose = "web_tab_close"
+    case webTabPrev = "web_tab_prev"
+    case webTabNext = "web_tab_next"
 
     case unbind
 
@@ -321,6 +325,10 @@ enum NexAction: String, CaseIterable {
         case .webBack: "Web: Back"
         case .webForward: "Web: Forward"
         case .webReload: "Web: Reload"
+        case .webTabNew: "Web: New Tab"
+        case .webTabClose: "Web: Close Tab"
+        case .webTabPrev: "Web: Previous Tab"
+        case .webTabNext: "Web: Next Tab"
         case .unbind: "Unbind"
         }
     }
@@ -343,7 +351,8 @@ enum NexAction: String, CaseIterable {
         case .openFile, .toggleMarkdownEdit, .increaseMarkdownFontSize, .decreaseMarkdownFontSize,
              .resetMarkdownFontSize, .openDiff:
             "Files"
-        case .openWebPane, .webFocusURLBar, .webBack, .webForward, .webReload:
+        case .openWebPane, .webFocusURLBar, .webBack, .webForward, .webReload,
+             .webTabNew, .webTabClose, .webTabPrev, .webTabNext:
             "Web Pane (active when web pane focused)"
         case .toggleSearch, .closeSearch:
             "Search"

--- a/Nex/Models/PaneType.swift
+++ b/Nex/Models/PaneType.swift
@@ -3,4 +3,5 @@ enum PaneType: String, Codable {
     case markdown
     case scratchpad
     case diff
+    case web
 }

--- a/Nex/Nex.entitlements
+++ b/Nex/Nex.entitlements
@@ -4,6 +4,8 @@
 <dict>
     <key>com.apple.security.app-sandbox</key>
     <false/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -30,6 +30,7 @@ struct NexApp: App {
                 .environment(\.surfaceManager, SurfaceManager.liveValue)
                 .environment(\.socketServer, SocketServer.liveValue)
                 .environment(\.ghosttyConfig, .liveValue)
+                .environment(\.webPaneStore, WebPaneStore.liveValue)
                 .background(SpacesBindingAttacher())
                 .frame(minWidth: 600, minHeight: 400)
                 .onAppear {

--- a/Nex/Services/DatabaseService.swift
+++ b/Nex/Services/DatabaseService.swift
@@ -180,6 +180,15 @@ final class DatabaseService: Sendable {
             }
         }
 
+        migrator.registerMigration("v12_web_pane_url") { db in
+            let columns = try db.columns(in: "pane").map(\.name)
+            if !columns.contains("webURL") {
+                try db.alter(table: "pane") { t in
+                    t.add(column: "webURL", .text)
+                }
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }
@@ -215,6 +224,10 @@ struct PaneRecord: Codable, FetchableRecord, PersistableRecord {
     var status: String
     var createdAt: Double
     var lastActivityAt: Double
+    /// Last-known URL for a `.web` pane (Phase 1: single-tab v1).
+    /// Always nil for other pane types and for private web panes
+    /// (whose contents intentionally do not survive restart).
+    var webURL: String?
 }
 
 struct AppStateRecord: Codable, FetchableRecord, PersistableRecord {

--- a/Nex/Services/DatabaseService.swift
+++ b/Nex/Services/DatabaseService.swift
@@ -203,6 +203,21 @@ final class DatabaseService: Sendable {
             }
         }
 
+        // Phase 5: per-pane private mode. Private panes survive
+        // restart as the pane (still .web, still flagged private) but
+        // their tabs/URLs and on-disk cookies do not — `webURL` and
+        // `webTabsJSON` are written nil for private panes; only the
+        // flag persists so the coordinator rebuilds with a
+        // nonPersistent data store on restore.
+        migrator.registerMigration("v14_web_pane_private") { db in
+            let columns = try db.columns(in: "pane").map(\.name)
+            if !columns.contains("webIsPrivate") {
+                try db.alter(table: "pane") { t in
+                    t.add(column: "webIsPrivate", .boolean)
+                }
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }
@@ -247,6 +262,11 @@ struct PaneRecord: Codable, FetchableRecord, PersistableRecord {
     var webTabsJSON: String?
     /// Id of the active tab; nil falls back to `tabs.first`.
     var webActiveTabID: String?
+    /// Per-pane private mode (Phase 5). When true the pane uses a
+    /// `WKWebsiteDataStore.nonPersistent()` store and saves with no
+    /// URL or tabs, so reopen restores a blank pane that still
+    /// remembers it is private.
+    var webIsPrivate: Bool?
 }
 
 struct AppStateRecord: Codable, FetchableRecord, PersistableRecord {

--- a/Nex/Services/DatabaseService.swift
+++ b/Nex/Services/DatabaseService.swift
@@ -189,6 +189,20 @@ final class DatabaseService: Sendable {
             }
         }
 
+        migrator.registerMigration("v13_web_pane_tabs") { db in
+            let columns = try db.columns(in: "pane").map(\.name)
+            if !columns.contains("webTabsJSON") {
+                try db.alter(table: "pane") { t in
+                    t.add(column: "webTabsJSON", .text)
+                }
+            }
+            if !columns.contains("webActiveTabID") {
+                try db.alter(table: "pane") { t in
+                    t.add(column: "webActiveTabID", .text)
+                }
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }
@@ -224,10 +238,15 @@ struct PaneRecord: Codable, FetchableRecord, PersistableRecord {
     var status: String
     var createdAt: Double
     var lastActivityAt: Double
-    /// Last-known URL for a `.web` pane (Phase 1: single-tab v1).
-    /// Always nil for other pane types and for private web panes
-    /// (whose contents intentionally do not survive restart).
+    /// Legacy single-tab URL for a `.web` pane. `webTabsJSON` is
+    /// authoritative on read; this is kept around for loaders that
+    /// pre-date the v13 migration. Always nil for non-web panes and
+    /// for private web panes (whose contents do not survive restart).
     var webURL: String?
+    /// Full tab list as JSON-encoded `[WebTab]`.
+    var webTabsJSON: String?
+    /// Id of the active tab; nil falls back to `tabs.first`.
+    var webActiveTabID: String?
 }
 
 struct AppStateRecord: Codable, FetchableRecord, PersistableRecord {

--- a/Nex/Services/PersistenceService.swift
+++ b/Nex/Services/PersistenceService.swift
@@ -159,7 +159,8 @@ actor PersistenceService {
                                 ?? tabs.first?.id
                             webPanes[paneID] = WebPaneState(
                                 tabs: tabs,
-                                activeTabID: activeID
+                                activeTabID: activeID,
+                                isPrivate: pr.webIsPrivate ?? false
                             )
                         }
                     }
@@ -328,21 +329,27 @@ struct PersistenceSnapshot {
                 // Write the full tab list as JSON and the active tab
                 // id. `webURL` is also written as a legacy fallback
                 // for any loader that pre-dates the v13 migration.
-                // Private panes intentionally drop everything so
-                // restart restores them blank.
+                // Private panes intentionally drop tab contents so
+                // restart restores them blank, but the
+                // `webIsPrivate` flag itself is always persisted so
+                // the coordinator rebuilds with a nonPersistent
+                // store on the next load.
                 var webURL: String?
                 var webTabsJSON: String?
                 var webActiveTabID: String?
+                var webIsPrivate: Bool?
                 if pane.type == .web,
-                   let webState = workspace.webPanes[pane.id],
-                   !webState.isPrivate {
-                    webURL = webState.activeTab?.url
-                    if !webState.tabs.isEmpty,
-                       let data = try? webTabsEncoder.encode(webState.tabs),
-                       let json = String(data: data, encoding: .utf8) {
-                        webTabsJSON = json
+                   let webState = workspace.webPanes[pane.id] {
+                    webIsPrivate = webState.isPrivate
+                    if !webState.isPrivate {
+                        webURL = webState.activeTab?.url
+                        if !webState.tabs.isEmpty,
+                           let data = try? webTabsEncoder.encode(webState.tabs),
+                           let json = String(data: data, encoding: .utf8) {
+                            webTabsJSON = json
+                        }
+                        webActiveTabID = webState.activeTabID?.uuidString
                     }
-                    webActiveTabID = webState.activeTabID?.uuidString
                 }
                 return PaneRecord(
                     id: pane.id.uuidString,
@@ -358,7 +365,8 @@ struct PersistenceSnapshot {
                     lastActivityAt: pane.lastActivityAt.timeIntervalSince1970,
                     webURL: webURL,
                     webTabsJSON: webTabsJSON,
-                    webActiveTabID: webActiveTabID
+                    webActiveTabID: webActiveTabID,
+                    webIsPrivate: webIsPrivate
                 )
             }
         }

--- a/Nex/Services/PersistenceService.swift
+++ b/Nex/Services/PersistenceService.swift
@@ -2,6 +2,12 @@ import ComposableArchitecture
 import Foundation
 import GRDB
 
+/// Shared coders for the web-tabs JSON column. JSONEncoder/Decoder are
+/// stateless and reusable; instantiating fresh per pane on every
+/// debounced save adds noticeable churn when many web panes are open.
+private let webTabsEncoder = JSONEncoder()
+private let webTabsDecoder = JSONDecoder()
+
 /// Debounced state persistence to SQLite via GRDB.
 /// Coalesces rapid state changes into a single write.
 actor PersistenceService {
@@ -134,19 +140,27 @@ actor PersistenceService {
                         )
                         panes.append(pane)
                         if paneType == .web {
-                            // Phase 1: hydrate a single-tab web state
-                            // from the persisted URL. Empty/nil URL =
-                            // blank pane (e.g. private pane on restore).
-                            let url = pr.webURL ?? ""
-                            if !url.isEmpty {
-                                let tab = WebTab(url: url)
-                                webPanes[paneID] = WebPaneState(
-                                    tabs: [tab],
-                                    activeTabID: tab.id
-                                )
-                            } else {
-                                webPanes[paneID] = WebPaneState()
+                            // Prefer the full tabs JSON; fall back to
+                            // the legacy single-tab `webURL` for rows
+                            // written before the v13 migration.
+                            // Empty/nil = blank pane (private pane on
+                            // restore).
+                            var tabs: [WebTab] = []
+                            if let json = pr.webTabsJSON,
+                               !json.isEmpty,
+                               let data = json.data(using: .utf8),
+                               let decoded = try? webTabsDecoder.decode([WebTab].self, from: data) {
+                                tabs = decoded
+                            } else if let url = pr.webURL, !url.isEmpty {
+                                tabs = [WebTab(url: url)]
                             }
+                            let activeID = pr.webActiveTabID
+                                .flatMap { UUID(uuidString: $0) }
+                                ?? tabs.first?.id
+                            webPanes[paneID] = WebPaneState(
+                                tabs: tabs,
+                                activeTabID: activeID
+                            )
                         }
                     }
 
@@ -311,15 +325,24 @@ struct PersistenceSnapshot {
 
         pnRecords = state.workspaces.flatMap { workspace in
             workspace.panes.map { pane in
-                // Phase 1 web persistence: store only the active tab's
-                // URL. Private panes intentionally drop their URL so
+                // Write the full tab list as JSON and the active tab
+                // id. `webURL` is also written as a legacy fallback
+                // for any loader that pre-dates the v13 migration.
+                // Private panes intentionally drop everything so
                 // restart restores them blank.
-                let webURL: String? = if pane.type == .web,
-                                         let webState = workspace.webPanes[pane.id],
-                                         !webState.isPrivate {
-                    webState.activeTab?.url
-                } else {
-                    nil
+                var webURL: String?
+                var webTabsJSON: String?
+                var webActiveTabID: String?
+                if pane.type == .web,
+                   let webState = workspace.webPanes[pane.id],
+                   !webState.isPrivate {
+                    webURL = webState.activeTab?.url
+                    if !webState.tabs.isEmpty,
+                       let data = try? webTabsEncoder.encode(webState.tabs),
+                       let json = String(data: data, encoding: .utf8) {
+                        webTabsJSON = json
+                    }
+                    webActiveTabID = webState.activeTabID?.uuidString
                 }
                 return PaneRecord(
                     id: pane.id.uuidString,
@@ -333,7 +356,9 @@ struct PersistenceSnapshot {
                     status: pane.status.rawValue,
                     createdAt: pane.createdAt.timeIntervalSince1970,
                     lastActivityAt: pane.lastActivityAt.timeIntervalSince1970,
-                    webURL: webURL
+                    webURL: webURL,
+                    webTabsJSON: webTabsJSON,
+                    webActiveTabID: webActiveTabID
                 )
             }
         }

--- a/Nex/Services/PersistenceService.swift
+++ b/Nex/Services/PersistenceService.swift
@@ -115,6 +115,7 @@ actor PersistenceService {
                         .fetchAll(db)
 
                     var panes = IdentifiedArrayOf<Pane>()
+                    var webPanes: [UUID: WebPaneState] = [:]
                     for pr in paneRecords {
                         guard let paneID = UUID(uuidString: pr.id) else { continue }
                         let paneType = PaneType(rawValue: pr.type) ?? .shell
@@ -132,6 +133,21 @@ actor PersistenceService {
                             lastActivityAt: Date(timeIntervalSince1970: pr.lastActivityAt)
                         )
                         panes.append(pane)
+                        if paneType == .web {
+                            // Phase 1: hydrate a single-tab web state
+                            // from the persisted URL. Empty/nil URL =
+                            // blank pane (e.g. private pane on restore).
+                            let url = pr.webURL ?? ""
+                            if !url.isEmpty {
+                                let tab = WebTab(url: url)
+                                webPanes[paneID] = WebPaneState(
+                                    tabs: [tab],
+                                    activeTabID: tab.id
+                                )
+                            } else {
+                                webPanes[paneID] = WebPaneState()
+                            }
+                        }
                     }
 
                     // Load repo associations for this workspace
@@ -182,7 +198,8 @@ actor PersistenceService {
                         repoAssociations: repoAssociations,
                         createdAt: Date(timeIntervalSince1970: record.createdAt),
                         lastAccessedAt: Date(timeIntervalSince1970: record.lastAccessedAt),
-                        labels: labels
+                        labels: labels,
+                        webPanes: webPanes
                     )
                     workspaces.append(workspace)
                 }
@@ -294,7 +311,17 @@ struct PersistenceSnapshot {
 
         pnRecords = state.workspaces.flatMap { workspace in
             workspace.panes.map { pane in
-                PaneRecord(
+                // Phase 1 web persistence: store only the active tab's
+                // URL. Private panes intentionally drop their URL so
+                // restart restores them blank.
+                let webURL: String? = if pane.type == .web,
+                                         let webState = workspace.webPanes[pane.id],
+                                         !webState.isPrivate {
+                    webState.activeTab?.url
+                } else {
+                    nil
+                }
+                return PaneRecord(
                     id: pane.id.uuidString,
                     workspaceID: workspace.id.uuidString,
                     label: pane.label,
@@ -305,7 +332,8 @@ struct PersistenceSnapshot {
                     claudeSessionID: pane.claudeSessionID,
                     status: pane.status.rawValue,
                     createdAt: pane.createdAt.timeIntervalSince1970,
-                    lastActivityAt: pane.lastActivityAt.timeIntervalSince1970
+                    lastActivityAt: pane.lastActivityAt.timeIntervalSince1970,
+                    webURL: webURL
                 )
             }
         }

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -92,7 +92,7 @@ enum SocketMessage: Equatable {
     /// Open a new `.web` pane with the given URL. `paneID` (from
     /// `NEX_PANE_ID`) is informational; opening always creates a new
     /// pane in the active workspace, mirroring `nex diff`.
-    case webOpen(paneID: UUID?, url: String)
+    case webOpen(paneID: UUID?, url: String, isPrivate: Bool)
     /// Read the active tab's current URL + title for the resolved pane.
     case webURL(paneID: UUID?, target: String?, workspace: String?)
     case webBack(paneID: UUID?, target: String?, workspace: String?)
@@ -141,6 +141,31 @@ enum SocketMessage: Equatable {
     case webInspectResult(
         paneID: UUID?, target: String?, workspace: String?, clear: Bool
     )
+
+    // Phase 5 — private mode + cookies
+
+    /// Set the resolved web pane's private mode flag. The reducer
+    /// destroys the coordinator so the host rebuilds tabs against
+    /// the new data store. Idempotent.
+    case webPrivate(
+        paneID: UUID?, target: String?, workspace: String?, enabled: Bool
+    )
+    /// List cookies for the resolved web pane's data store, grouped
+    /// by domain. Read-only.
+    case webCookiesList(paneID: UUID?, target: String?, workspace: String?)
+    /// Drop cookies (and other site data when `--all`) for the
+    /// resolved web pane's data store. `domain` scopes deletion to
+    /// cookies whose domain matches; omitting it clears everything.
+    case webCookiesClear(
+        paneID: UUID?, target: String?, workspace: String?,
+        domain: String?, all: Bool
+    )
+    /// Delete cookies matching `name` (and optional `domain` scope)
+    /// from the resolved web pane's data store.
+    case webCookiesDelete(
+        paneID: UUID?, target: String?, workspace: String?,
+        name: String, domain: String?
+    )
 }
 
 /// Commands that expect a single-line JSON reply followed by EOF. For any
@@ -153,7 +178,8 @@ private let replyCommandAllowlist: Set<String> = [
     "web-open", "web-url", "web-back",
     "web-forward", "web-reload", "web-capture",
     "web-tabs", "web-tab-new", "web-tab-close", "web-tab-select",
-    "web-console", "web-inspect", "web-inspect-result"
+    "web-console", "web-inspect", "web-inspect-result",
+    "web-private", "web-cookies-list", "web-cookies-clear", "web-cookies-delete"
 ]
 
 /// Unix domain socket server that listens for structured JSON messages
@@ -590,6 +616,16 @@ final class SocketServer: Sendable {
         var submit: Bool?
         /// `web-inspect --disarm`.
         var disarm: Bool?
+        /// `web-open --private`, `web-private on|off`. Treated as a
+        /// tri-state on `web-open` (nil = no flag → default false);
+        /// `web-private` requires it.
+        var isPrivate: Bool?
+        /// `web-cookies-*` — RFC 6265 domain. Optional on clear,
+        /// optional on delete (scopes to a single host when present).
+        var domain: String?
+        /// `web-cookies-clear --all` extends deletion to caches +
+        /// local storage + indexed db.
+        var all: Bool?
 
         enum CodingKeys: String, CodingKey {
             case command
@@ -611,6 +647,8 @@ final class SocketServer: Sendable {
             case since, level, clear
             case sendTo = "send_to"
             case submit, disarm
+            case isPrivate = "private"
+            case domain, all
         }
     }
 
@@ -746,7 +784,7 @@ final class SocketServer: Sendable {
         if wire.command == "web-open" {
             guard let url = wire.url, !url.isEmpty else { return nil }
             let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
-            return (.webOpen(paneID: paneID, url: url), wire)
+            return (.webOpen(paneID: paneID, url: url, isPrivate: wire.isPrivate ?? false), wire)
         }
 
         if wire.command == "web-url" {
@@ -843,6 +881,49 @@ final class SocketServer: Sendable {
                 target: scope.target,
                 workspace: scope.workspace,
                 clear: wire.clear ?? false
+            ), wire)
+        }
+
+        if wire.command == "web-private" {
+            guard let scope = parseWebTarget(wire),
+                  let enabled = wire.isPrivate else { return nil }
+            return (.webPrivate(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace,
+                enabled: enabled
+            ), wire)
+        }
+
+        if wire.command == "web-cookies-list" {
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webCookiesList(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace
+            ), wire)
+        }
+
+        if wire.command == "web-cookies-clear" {
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webCookiesClear(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace,
+                domain: (wire.domain?.isEmpty == true) ? nil : wire.domain,
+                all: wire.all ?? false
+            ), wire)
+        }
+
+        if wire.command == "web-cookies-delete" {
+            guard let scope = parseWebTarget(wire),
+                  let name = wire.name, !name.isEmpty else { return nil }
+            return (.webCookiesDelete(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace,
+                name: name,
+                domain: (wire.domain?.isEmpty == true) ? nil : wire.domain
             ), wire)
         }
 

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -84,6 +84,25 @@ enum SocketMessage: Equatable {
     case graftStop(workspace: String?, repo: String?, paneID: UUID?)
     /// `nex graft status` — list active sessions across all workspaces.
     case graftStatus
+
+    // Web pane commands (Phase 1). `web` is a first-class top-level
+    // CLI verb (not a `pane` subcommand), so the wire names follow
+    // suit: `web-open` / `web-url` / etc.
+
+    /// Open a new `.web` pane with the given URL. `paneID` (from
+    /// `NEX_PANE_ID`) is informational; opening always creates a new
+    /// pane in the active workspace, mirroring `nex diff`.
+    case webOpen(paneID: UUID?, url: String)
+    /// Read the active tab's current URL + title for the resolved pane.
+    case webURL(paneID: UUID?, target: String?, workspace: String?)
+    case webBack(paneID: UUID?, target: String?, workspace: String?)
+    case webForward(paneID: UUID?, target: String?, workspace: String?)
+    case webReload(paneID: UUID?, target: String?, workspace: String?, hard: Bool)
+    /// `mode` is one of `meta`, `text`, `screenshot`. `meta` is the
+    /// cheap default — URL + title + byte counts; `text` returns the
+    /// visible page text; `screenshot` returns a PNG (inline base64
+    /// under 1 MB, else a `/tmp` path).
+    case webCapture(paneID: UUID?, target: String?, workspace: String?, mode: String)
 }
 
 /// Commands that expect a single-line JSON reply followed by EOF. For any
@@ -92,7 +111,9 @@ enum SocketMessage: Equatable {
 /// pre-request/response protocol.
 private let replyCommandAllowlist: Set<String> = [
     "pane-list", "pane-close", "pane-capture", "pane-send", "pane-send-key",
-    "graft-start", "graft-stop", "graft-status"
+    "graft-start", "graft-stop", "graft-status",
+    "web-open", "web-url", "web-back",
+    "web-forward", "web-reload", "web-capture"
 ]
 
 /// Unix domain socket server that listens for structured JSON messages
@@ -491,6 +512,12 @@ final class SocketServer: Sendable {
         var scrollback: Bool?
         /// `graft-start` / `graft-stop` — repo name or path scope.
         var repo: String?
+        /// `web-open` / `web-url` etc. — destination URL or
+        /// (for capture) the visible-text/screenshot/meta mode.
+        var url: String?
+        var mode: String?
+        /// `web-reload --hard`.
+        var hard: Bool?
 
         enum CodingKeys: String, CodingKey {
             case command
@@ -506,6 +533,7 @@ final class SocketServer: Sendable {
             case targetPath = "target_path"
             case lines, scrollback
             case repo
+            case url, mode, hard
         }
     }
 
@@ -622,6 +650,58 @@ final class SocketServer: Sendable {
 
         if wire.command == "graft-status" {
             return (.graftStatus, wire)
+        }
+
+        if wire.command == "web-open" {
+            guard let url = wire.url, !url.isEmpty else { return nil }
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            return (.webOpen(paneID: paneID, url: url), wire)
+        }
+
+        if wire.command == "web-url" {
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            let target = (wire.target?.isEmpty == true) ? nil : wire.target
+            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+            guard paneID != nil || target != nil else { return nil }
+            return (.webURL(paneID: paneID, target: target, workspace: workspace), wire)
+        }
+
+        if wire.command == "web-back" {
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            let target = (wire.target?.isEmpty == true) ? nil : wire.target
+            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+            guard paneID != nil || target != nil else { return nil }
+            return (.webBack(paneID: paneID, target: target, workspace: workspace), wire)
+        }
+
+        if wire.command == "web-forward" {
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            let target = (wire.target?.isEmpty == true) ? nil : wire.target
+            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+            guard paneID != nil || target != nil else { return nil }
+            return (.webForward(paneID: paneID, target: target, workspace: workspace), wire)
+        }
+
+        if wire.command == "web-reload" {
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            let target = (wire.target?.isEmpty == true) ? nil : wire.target
+            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+            guard paneID != nil || target != nil else { return nil }
+            return (.webReload(
+                paneID: paneID, target: target, workspace: workspace,
+                hard: wire.hard ?? false
+            ), wire)
+        }
+
+        if wire.command == "web-capture" {
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            let target = (wire.target?.isEmpty == true) ? nil : wire.target
+            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+            let mode = (wire.mode?.isEmpty == true) ? "meta" : (wire.mode ?? "meta")
+            guard paneID != nil || target != nil else { return nil }
+            return (.webCapture(
+                paneID: paneID, target: target, workspace: workspace, mode: mode
+            ), wire)
         }
 
         if wire.command == "pane-send-key" {

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -117,6 +117,30 @@ enum SocketMessage: Equatable {
     /// `pane close` for that.
     case webTabClose(paneID: UUID?, target: String?, workspace: String?, tabRef: String)
     case webTabSelect(paneID: UUID?, target: String?, workspace: String?, tabRef: String)
+
+    // Phase 3 — console + inspector
+
+    /// Drain the console ring buffer of the resolved web pane.
+    /// `since` is the last seq the caller has already seen (0 = full
+    /// buffer). `level` filters to a single severity. `clear` empties
+    /// the buffer after the read so the next call starts fresh.
+    case webConsole(
+        paneID: UUID?, target: String?, workspace: String?,
+        since: UInt64, level: String?, clear: Bool
+    )
+    /// Arm the picker for the resolved pane's active tab. `sendTo`
+    /// is an optional pane target (label or UUID) into which the
+    /// next click's payload gets pasted. `submit` controls whether
+    /// the paste ends with an Enter keystroke (default: false).
+    /// `disarm` disarms an existing arm without picking.
+    case webInspect(
+        paneID: UUID?, target: String?, workspace: String?,
+        sendTo: String?, submit: Bool, disarm: Bool
+    )
+    /// Drain the per-pane inspect-result queue without arming.
+    case webInspectResult(
+        paneID: UUID?, target: String?, workspace: String?, clear: Bool
+    )
 }
 
 /// Commands that expect a single-line JSON reply followed by EOF. For any
@@ -128,7 +152,8 @@ private let replyCommandAllowlist: Set<String> = [
     "graft-start", "graft-stop", "graft-status",
     "web-open", "web-url", "web-back",
     "web-forward", "web-reload", "web-capture",
-    "web-tabs", "web-tab-new", "web-tab-close", "web-tab-select"
+    "web-tabs", "web-tab-new", "web-tab-close", "web-tab-select",
+    "web-console", "web-inspect", "web-inspect-result"
 ]
 
 /// Unix domain socket server that listens for structured JSON messages
@@ -553,6 +578,18 @@ final class SocketServer: Sendable {
         var tab: String?
         /// `web-tab-new --no-focus` → false.
         var makeActive: Bool?
+        /// `web-console --since`. Default 0 = full buffer.
+        var since: UInt64?
+        /// `web-console --level`. Optional severity filter.
+        var level: String?
+        /// `web-console --clear`, `web-inspect-result --clear`.
+        var clear: Bool?
+        /// `web-inspect --send-to <pane-target>`.
+        var sendTo: String?
+        /// `web-inspect --submit`. Default false (paste only).
+        var submit: Bool?
+        /// `web-inspect --disarm`.
+        var disarm: Bool?
 
         enum CodingKeys: String, CodingKey {
             case command
@@ -571,6 +608,9 @@ final class SocketServer: Sendable {
             case url, mode, hard
             case tab
             case makeActive = "make_active"
+            case since, level, clear
+            case sendTo = "send_to"
+            case submit, disarm
         }
     }
 
@@ -769,6 +809,40 @@ final class SocketServer: Sendable {
                   let tabRef = wire.tab, !tabRef.isEmpty else { return nil }
             return (.webTabSelect(
                 paneID: scope.paneID, target: scope.target, workspace: scope.workspace, tabRef: tabRef
+            ), wire)
+        }
+
+        if wire.command == "web-console" {
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webConsole(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace,
+                since: wire.since ?? 0,
+                level: (wire.level?.isEmpty == true) ? nil : wire.level,
+                clear: wire.clear ?? false
+            ), wire)
+        }
+
+        if wire.command == "web-inspect" {
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webInspect(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace,
+                sendTo: (wire.sendTo?.isEmpty == true) ? nil : wire.sendTo,
+                submit: wire.submit ?? false,
+                disarm: wire.disarm ?? false
+            ), wire)
+        }
+
+        if wire.command == "web-inspect-result" {
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webInspectResult(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace,
+                clear: wire.clear ?? false
             ), wire)
         }
 

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -103,6 +103,20 @@ enum SocketMessage: Equatable {
     /// visible page text; `screenshot` returns a PNG (inline base64
     /// under 1 MB, else a `/tmp` path).
     case webCapture(paneID: UUID?, target: String?, workspace: String?, mode: String)
+
+    // Tab commands
+
+    /// List the open tabs of the resolved web pane.
+    case webTabs(paneID: UUID?, target: String?, workspace: String?)
+    /// Open a new tab in the resolved web pane. `url` may be empty
+    /// (blank tab). `makeActive` defaults to true.
+    case webTabNew(paneID: UUID?, target: String?, workspace: String?, url: String, makeActive: Bool)
+    /// Close a tab. `tabRef` is either a tab UUID or a numeric index.
+    /// Resolving to the only tab in the pane returns `{ok:false}`
+    /// rather than implicitly closing the pane — callers can use
+    /// `pane close` for that.
+    case webTabClose(paneID: UUID?, target: String?, workspace: String?, tabRef: String)
+    case webTabSelect(paneID: UUID?, target: String?, workspace: String?, tabRef: String)
 }
 
 /// Commands that expect a single-line JSON reply followed by EOF. For any
@@ -113,7 +127,8 @@ private let replyCommandAllowlist: Set<String> = [
     "pane-list", "pane-close", "pane-capture", "pane-send", "pane-send-key",
     "graft-start", "graft-stop", "graft-status",
     "web-open", "web-url", "web-back",
-    "web-forward", "web-reload", "web-capture"
+    "web-forward", "web-reload", "web-capture",
+    "web-tabs", "web-tab-new", "web-tab-close", "web-tab-select"
 ]
 
 /// Unix domain socket server that listens for structured JSON messages
@@ -180,7 +195,20 @@ final class SocketServer: Sendable {
             closeImpl()
         }
 
-        /// Identity compare on id only — the closures aren't comparable
+        /// Convenience for the common reply path: send then close.
+        func sendAndClose(_ json: [String: Any]) {
+            sendImpl(json)
+            closeImpl()
+        }
+
+        /// Convenience for the common error path: send `{ok:false,error:...}`
+        /// then close.
+        func error(_ message: String) {
+            sendImpl(["ok": false, "error": message])
+            closeImpl()
+        }
+
+        /// Identity compare on id only - the closures aren't comparable
         /// but two handles from the same server slot always share an id.
         /// Keeps the enclosing TCA Action Equatable-synthesized.
         static func == (lhs: ReplyHandle, rhs: ReplyHandle) -> Bool {
@@ -518,6 +546,13 @@ final class SocketServer: Sendable {
         var mode: String?
         /// `web-reload --hard`.
         var hard: Bool?
+        /// `web-tab-close` / `web-tab-select` — tab UUID or numeric
+        /// index. Parser keeps it as a raw string; the reducer
+        /// resolves to a concrete UUID by trying UUID(uuidString:)
+        /// first, then Int parsing for index.
+        var tab: String?
+        /// `web-tab-new --no-focus` → false.
+        var makeActive: Bool?
 
         enum CodingKeys: String, CodingKey {
             case command
@@ -534,7 +569,23 @@ final class SocketServer: Sendable {
             case lines, scrollback
             case repo
             case url, mode, hard
+            case tab
+            case makeActive = "make_active"
         }
+    }
+
+    /// Shared scope extraction for the `web-*` commands. All of them
+    /// follow the same shape on the wire (paneID from NEX_PANE_ID
+    /// and/or --target with optional --workspace) and reject when
+    /// neither paneID nor target is present.
+    private static func parseWebTarget(
+        _ wire: WireMessage
+    ) -> (paneID: UUID?, target: String?, workspace: String?)? {
+        let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+        let target = (wire.target?.isEmpty == true) ? nil : wire.target
+        let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+        guard paneID != nil || target != nil else { return nil }
+        return (paneID, target, workspace)
     }
 
     /// Parse a single JSON message into a (SocketMessage, WireMessage) tuple.
@@ -659,48 +710,65 @@ final class SocketServer: Sendable {
         }
 
         if wire.command == "web-url" {
-            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
-            let target = (wire.target?.isEmpty == true) ? nil : wire.target
-            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
-            guard paneID != nil || target != nil else { return nil }
-            return (.webURL(paneID: paneID, target: target, workspace: workspace), wire)
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webURL(paneID: scope.paneID, target: scope.target, workspace: scope.workspace), wire)
         }
 
         if wire.command == "web-back" {
-            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
-            let target = (wire.target?.isEmpty == true) ? nil : wire.target
-            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
-            guard paneID != nil || target != nil else { return nil }
-            return (.webBack(paneID: paneID, target: target, workspace: workspace), wire)
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webBack(paneID: scope.paneID, target: scope.target, workspace: scope.workspace), wire)
         }
 
         if wire.command == "web-forward" {
-            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
-            let target = (wire.target?.isEmpty == true) ? nil : wire.target
-            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
-            guard paneID != nil || target != nil else { return nil }
-            return (.webForward(paneID: paneID, target: target, workspace: workspace), wire)
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webForward(paneID: scope.paneID, target: scope.target, workspace: scope.workspace), wire)
         }
 
         if wire.command == "web-reload" {
-            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
-            let target = (wire.target?.isEmpty == true) ? nil : wire.target
-            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
-            guard paneID != nil || target != nil else { return nil }
+            guard let scope = parseWebTarget(wire) else { return nil }
             return (.webReload(
-                paneID: paneID, target: target, workspace: workspace,
+                paneID: scope.paneID, target: scope.target, workspace: scope.workspace,
                 hard: wire.hard ?? false
             ), wire)
         }
 
         if wire.command == "web-capture" {
-            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
-            let target = (wire.target?.isEmpty == true) ? nil : wire.target
-            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+            guard let scope = parseWebTarget(wire) else { return nil }
             let mode = (wire.mode?.isEmpty == true) ? "meta" : (wire.mode ?? "meta")
-            guard paneID != nil || target != nil else { return nil }
             return (.webCapture(
-                paneID: paneID, target: target, workspace: workspace, mode: mode
+                paneID: scope.paneID, target: scope.target, workspace: scope.workspace, mode: mode
+            ), wire)
+        }
+
+        if wire.command == "web-tabs" {
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webTabs(paneID: scope.paneID, target: scope.target, workspace: scope.workspace), wire)
+        }
+
+        if wire.command == "web-tab-new" {
+            guard let scope = parseWebTarget(wire) else { return nil }
+            return (.webTabNew(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace,
+                url: wire.url ?? "",
+                makeActive: wire.makeActive ?? true
+            ), wire)
+        }
+
+        if wire.command == "web-tab-close" {
+            guard let scope = parseWebTarget(wire),
+                  let tabRef = wire.tab, !tabRef.isEmpty else { return nil }
+            return (.webTabClose(
+                paneID: scope.paneID, target: scope.target, workspace: scope.workspace, tabRef: tabRef
+            ), wire)
+        }
+
+        if wire.command == "web-tab-select" {
+            guard let scope = parseWebTarget(wire),
+                  let tabRef = wire.tab, !tabRef.isEmpty else { return nil }
+            return (.webTabSelect(
+                paneID: scope.paneID, target: scope.target, workspace: scope.workspace, tabRef: tabRef
             ), wire)
         }
 

--- a/NexTests/InspectPayloadSanitiserTests.swift
+++ b/NexTests/InspectPayloadSanitiserTests.swift
@@ -1,0 +1,217 @@
+import CoreGraphics
+import Foundation
+@testable import Nex
+import Testing
+
+struct InspectPayloadSanitiserTests {
+    private static let tabID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+
+    // MARK: - stripUnsafeControlCharacters
+
+    @Test func stripsCSIEscapeSequence() {
+        // ESC [ 31 m (red) text ESC [ 0 m
+        let input = "\u{1B}[31mhello\u{1B}[0m"
+        let stripped = InspectPayloadSanitiser.stripUnsafeControlCharacters(input)
+        #expect(stripped == "hello")
+    }
+
+    @Test func stripsOSCEscapeSequenceWithBEL() {
+        // ESC ] 52;c;... BEL — clipboard write the receiver shouldn't honour.
+        let input = "before\u{1B}]52;c;abc\u{07}after"
+        let stripped = InspectPayloadSanitiser.stripUnsafeControlCharacters(input)
+        #expect(stripped == "beforeafter")
+    }
+
+    @Test func stripsOSCEscapeSequenceWithST() {
+        // ESC ] 0;title ESC \ — terminal title set (ST = ESC + backslash).
+        let input = "x\u{1B}]0;evil\u{1B}\\y"
+        let stripped = InspectPayloadSanitiser.stripUnsafeControlCharacters(input)
+        #expect(stripped == "xy")
+    }
+
+    @Test func stripsTwoCharEscape() {
+        // ESC c (full reset)
+        let input = "x\u{1B}cy"
+        let stripped = InspectPayloadSanitiser.stripUnsafeControlCharacters(input)
+        #expect(stripped == "xy")
+    }
+
+    @Test func keepsNewlineAndTab() {
+        let input = "line1\nline2\tcol"
+        let stripped = InspectPayloadSanitiser.stripUnsafeControlCharacters(input)
+        #expect(stripped == "line1\nline2\tcol")
+    }
+
+    @Test func stripsOtherC0() {
+        // BEL alone, vertical tab, etc.
+        let input = "a\u{07}b\u{0B}c\u{00}d"
+        let stripped = InspectPayloadSanitiser.stripUnsafeControlCharacters(input)
+        #expect(stripped == "abcd")
+    }
+
+    @Test func stripsDEL() {
+        let input = "a\u{7F}b"
+        let stripped = InspectPayloadSanitiser.stripUnsafeControlCharacters(input)
+        #expect(stripped == "ab")
+    }
+
+    @Test func emptyInputReturnsEmpty() {
+        #expect(InspectPayloadSanitiser.stripUnsafeControlCharacters("") == "")
+    }
+
+    // MARK: - clampField
+
+    @Test func clampUnderLimitReturnsUnchanged() {
+        let input = "short"
+        #expect(InspectPayloadSanitiser.clampField(input, limit: 100) == "short")
+    }
+
+    @Test func clampAtLimitReturnsUnchanged() {
+        let input = String(repeating: "a", count: 16)
+        #expect(InspectPayloadSanitiser.clampField(input, limit: 16) == input)
+    }
+
+    @Test func clampOverLimitAppendsMarker() {
+        let input = String(repeating: "a", count: 200)
+        let clamped = InspectPayloadSanitiser.clampField(input, limit: 64)
+        #expect(clamped.utf8.count == 64)
+        #expect(clamped.hasSuffix(InspectPayloadSanitiser.truncationMarker))
+    }
+
+    @Test func clampStripsBeforeMeasuring() {
+        // Stripped length fits the budget so no truncation should happen.
+        let input = "\u{1B}[31mhello\u{1B}[0m"
+        #expect(InspectPayloadSanitiser.clampField(input, limit: 16) == "hello")
+    }
+
+    @Test func clampMultiByteStaysOnUTF8Boundary() {
+        // Each emoji is 4 UTF-8 bytes. Limit forces truncation
+        // partway through; clamped output must still decode.
+        let input = String(repeating: "🚀", count: 10) // 40 bytes
+        let clamped = InspectPayloadSanitiser.clampField(input, limit: 32)
+        #expect(clamped.utf8.count <= 32)
+        // Should decode round-trip to a valid string ending in the marker.
+        #expect(clamped.hasSuffix(InspectPayloadSanitiser.truncationMarker))
+        let strippedPrefix = clamped.dropLast(InspectPayloadSanitiser.truncationMarker.count)
+        // All remaining graphemes should be the rocket emoji (no broken
+        // partial code unit).
+        #expect(strippedPrefix.allSatisfy { $0 == "🚀" })
+    }
+
+    @Test func clampLimitSmallerThanMarkerStillBounded() {
+        // When the budget can't fit the marker, the helper still
+        // shouldn't crash — it should return at most a marker-sized
+        // output without exceeding any growth.
+        let input = String(repeating: "a", count: 100)
+        let clamped = InspectPayloadSanitiser.clampField(input, limit: 4)
+        // No precondition: just that it returns something and didn't trap.
+        #expect(clamped.hasSuffix(InspectPayloadSanitiser.truncationMarker))
+    }
+
+    // MARK: - decode
+
+    @Test func decodeReturnsNilForEmptyPayload() {
+        // No selector, no tag, no url → nothing useful to surface.
+        let payload: [String: Any] = ["outer_html": ""]
+        #expect(InspectPayloadSanitiser.decode(payload, tabID: Self.tabID) == nil)
+    }
+
+    @Test func decodeAcceptsMinimalPayload() {
+        let payload: [String: Any] = ["tag": "div", "selector": "#foo"]
+        let result = InspectPayloadSanitiser.decode(payload, tabID: Self.tabID)
+        #expect(result?.tag == "div")
+        #expect(result?.selector == "#foo")
+        #expect(result?.tabID == Self.tabID)
+    }
+
+    @Test func decodeClampsOversizedOuterHTML() {
+        let huge = String(repeating: "x", count: 32 * 1024)
+        let payload: [String: Any] = ["tag": "div", "selector": "#foo", "outer_html": huge]
+        let result = InspectPayloadSanitiser.decode(payload, tabID: Self.tabID)
+        #expect(result?.outerHTML.utf8.count == InspectPayloadSanitiser.outerHTMLBudget)
+        #expect(result?.outerHTML.hasSuffix(InspectPayloadSanitiser.truncationMarker) == true)
+    }
+
+    @Test func decodeStripsAnsiFromAttributes() {
+        let payload: [String: Any] = [
+            "tag": "div",
+            "selector": "#foo",
+            "attributes": ["data-x": "\u{1B}[31mred\u{1B}[0m"]
+        ]
+        let result = InspectPayloadSanitiser.decode(payload, tabID: Self.tabID)
+        #expect(result?.attributes["data-x"] == "red")
+    }
+
+    @Test func decodeParsesRect() {
+        let payload: [String: Any] = [
+            "tag": "button",
+            "selector": "button",
+            "rect": ["x": 1.5, "y": 2.5, "w": 100.0, "h": 30.0]
+        ]
+        let result = InspectPayloadSanitiser.decode(payload, tabID: Self.tabID)
+        #expect(result?.rect == CGRect(x: 1.5, y: 2.5, width: 100.0, height: 30.0))
+    }
+
+    // MARK: - formatForPaste
+
+    @Test func formatForPasteIncludesFencedJSON() {
+        let result = InspectResult(
+            tabID: Self.tabID,
+            selector: "#foo",
+            xpath: "/html/body/div[1]",
+            tag: "div",
+            elementID: "foo",
+            outerHTML: "<div id=\"foo\">hi</div>",
+            attributes: ["class": "bar"],
+            rect: CGRect(x: 0, y: 0, width: 10, height: 10),
+            text: "hi",
+            contextHTML: "<body><div id=\"foo\">hi</div></body>",
+            url: "https://example.com",
+            capturedAt: Date(timeIntervalSince1970: 0)
+        )
+        let formatted = InspectPayloadSanitiser.formatForPaste(result)
+        #expect(formatted.contains("# nex inspect"))
+        #expect(formatted.contains("```json"))
+        #expect(formatted.contains("\"selector\""))
+        #expect(formatted.contains("\"#foo\""))
+    }
+
+    @Test func formatBatchForPasteIncludesEachComment() {
+        let r = InspectResult(
+            tabID: Self.tabID, selector: "#a", xpath: "/", tag: "div",
+            elementID: "", outerHTML: "", attributes: [:],
+            rect: .zero, text: "", contextHTML: "", url: "",
+            capturedAt: Date(timeIntervalSince1970: 0)
+        )
+        let items = [
+            BatchInspectItem(result: r, comment: "first comment"),
+            BatchInspectItem(result: r, comment: "second comment")
+        ]
+        let formatted = InspectPayloadSanitiser.formatBatchForPaste(items)
+        #expect(formatted.contains("(2 items)"))
+        #expect(formatted.contains("first comment"))
+        #expect(formatted.contains("second comment"))
+    }
+
+    @Test func inspectResultDefaultCommentIsEmpty() {
+        // Single-shot picker captures should never carry a comment;
+        // the field is purely a batch-mode annotation slot.
+        let payload: [String: Any] = ["tag": "div", "selector": "#x"]
+        let result = InspectPayloadSanitiser.decode(payload, tabID: Self.tabID)
+        #expect(result?.comment == "")
+    }
+
+    @Test func formatBatchSingularItemHeader() {
+        let r = InspectResult(
+            tabID: Self.tabID, selector: "#a", xpath: "/", tag: "div",
+            elementID: "", outerHTML: "", attributes: [:],
+            rect: .zero, text: "", contextHTML: "", url: "",
+            capturedAt: Date(timeIntervalSince1970: 0)
+        )
+        let formatted = InspectPayloadSanitiser.formatBatchForPaste([
+            BatchInspectItem(result: r, comment: "")
+        ])
+        #expect(formatted.contains("(1 item)"))
+        #expect(!formatted.contains("(1 items)"))
+    }
+}

--- a/NexTests/PersistenceTests.swift
+++ b/NexTests/PersistenceTests.swift
@@ -207,6 +207,109 @@ struct PersistenceTests {
         #expect(result.repoRegistry.first?.remoteURL == "https://github.com/user/my-repo.git")
     }
 
+    @Test func webPanePublicRoundTrip() async throws {
+        let db = try DatabaseService(inMemory: true)
+        let persistence = PersistenceService(db: db)
+
+        let paneID = UUID()
+        let pane = Pane(
+            id: paneID,
+            type: .web,
+            workingDirectory: NSHomeDirectory(),
+            createdAt: Date(timeIntervalSince1970: 1000),
+            lastActivityAt: Date(timeIntervalSince1970: 2000)
+        )
+        let tabID = UUID()
+        let webState = WebPaneState(
+            tabs: [WebTab(id: tabID, url: "https://example.com", title: "Example")],
+            activeTabID: tabID,
+            isPrivate: false
+        )
+
+        let wsID = UUID()
+        let workspace = WorkspaceFeature.State(
+            id: wsID,
+            name: "Web Test",
+            slug: "web-test-\(wsID.uuidString.prefix(8).lowercased())",
+            color: .blue,
+            panes: [pane],
+            layout: .leaf(paneID),
+            focusedPaneID: paneID,
+            createdAt: Date(timeIntervalSince1970: 1000),
+            lastAccessedAt: Date(timeIntervalSince1970: 2000),
+            webPanes: [paneID: webState]
+        )
+
+        var workspaces = IdentifiedArrayOf<WorkspaceFeature.State>()
+        workspaces.append(workspace)
+        let state = AppReducer.State(workspaces: workspaces, activeWorkspaceID: wsID)
+        await persistence.save(snapshot: PersistenceSnapshot(state: state))
+        try await Task.sleep(for: .seconds(1))
+
+        let result = await persistence.load()
+        let loadedWS = result.workspaces.first!
+        let loadedWeb = loadedWS.webPanes[paneID]
+        #expect(loadedWeb != nil)
+        #expect(loadedWeb?.isPrivate == false)
+        #expect(loadedWeb?.tabs.count == 1)
+        #expect(loadedWeb?.tabs.first?.url == "https://example.com")
+        #expect(loadedWeb?.activeTabID == tabID)
+    }
+
+    @Test func webPanePrivateBlanksOnReload() async throws {
+        let db = try DatabaseService(inMemory: true)
+        let persistence = PersistenceService(db: db)
+
+        let paneID = UUID()
+        let pane = Pane(
+            id: paneID,
+            type: .web,
+            workingDirectory: NSHomeDirectory(),
+            createdAt: Date(timeIntervalSince1970: 1000),
+            lastActivityAt: Date(timeIntervalSince1970: 2000)
+        )
+        let tabID = UUID()
+        // Private pane with a tab in memory — save must drop the
+        // tab from disk but preserve the private flag itself so the
+        // restore keeps the pane configured for a nonPersistent
+        // data store.
+        let webState = WebPaneState(
+            tabs: [WebTab(id: tabID, url: "https://secret.example.com")],
+            activeTabID: tabID,
+            isPrivate: true
+        )
+
+        let wsID = UUID()
+        let workspace = WorkspaceFeature.State(
+            id: wsID,
+            name: "Private Test",
+            slug: "private-test-\(wsID.uuidString.prefix(8).lowercased())",
+            color: .blue,
+            panes: [pane],
+            layout: .leaf(paneID),
+            focusedPaneID: paneID,
+            createdAt: Date(timeIntervalSince1970: 1000),
+            lastAccessedAt: Date(timeIntervalSince1970: 2000),
+            webPanes: [paneID: webState]
+        )
+
+        var workspaces = IdentifiedArrayOf<WorkspaceFeature.State>()
+        workspaces.append(workspace)
+        let state = AppReducer.State(workspaces: workspaces, activeWorkspaceID: wsID)
+        await persistence.save(snapshot: PersistenceSnapshot(state: state))
+        try await Task.sleep(for: .seconds(1))
+
+        let result = await persistence.load()
+        let loadedWS = result.workspaces.first!
+        let loadedPane = loadedWS.panes.first!
+        let loadedWeb = loadedWS.webPanes[paneID]
+        #expect(loadedPane.type == .web)
+        #expect(loadedWeb != nil)
+        #expect(loadedWeb?.isPrivate == true)
+        #expect(loadedWeb?.tabs.isEmpty == true)
+        #expect(loadedWeb?.activeTabID == nil)
+    }
+
     @Test func repoAssociationRoundTrip() async throws {
         let db = try DatabaseService(inMemory: true)
         let persistence = PersistenceService(db: db)

--- a/NexTests/RingBufferTests.swift
+++ b/NexTests/RingBufferTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+@testable import Nex
+import Testing
+
+struct RingBufferTests {
+    @Test func emptyOnInit() {
+        let buf = RingBuffer<Int>(capacity: 4)
+        #expect(buf.isEmpty)
+        #expect(buf.count == 0)
+        #expect(buf.nextSeq == 0)
+        #expect(buf.droppedSinceLastDrain == 0)
+    }
+
+    @Test func appendUnderCapacityKeepsEverything() {
+        var buf = RingBuffer<Int>(capacity: 4)
+        buf.append(10)
+        buf.append(20)
+        buf.append(30)
+        #expect(buf.count == 3)
+        #expect(buf.entries.map(\.value) == [10, 20, 30])
+        #expect(buf.entries.map(\.seq) == [0, 1, 2])
+        #expect(buf.nextSeq == 3)
+        #expect(buf.droppedSinceLastDrain == 0)
+    }
+
+    @Test func appendOverCapacityEvictsOldestAndCountsDrops() {
+        var buf = RingBuffer<Int>(capacity: 3)
+        for n in 1 ... 5 {
+            buf.append(n)
+        }
+        #expect(buf.count == 3)
+        #expect(buf.entries.map(\.value) == [3, 4, 5])
+        // seqs keep counting; the evicted entries had seq 0 and 1.
+        #expect(buf.entries.map(\.seq) == [2, 3, 4])
+        #expect(buf.nextSeq == 5)
+        #expect(buf.droppedSinceLastDrain == 2)
+    }
+
+    @Test func sinceZeroReturnsEverything() {
+        var buf = RingBuffer<Int>(capacity: 4)
+        for n in 0 ..< 3 {
+            buf.append(n)
+        }
+        let all = buf.entries(since: 0)
+        #expect(all.map(\.value) == [0, 1, 2])
+    }
+
+    @Test func sinceMidwayReturnsTail() {
+        var buf = RingBuffer<Int>(capacity: 10)
+        for n in 0 ..< 6 {
+            buf.append(n * 10)
+        }
+        // seq 3 → values 30, 40, 50 (entries[3...])
+        let tail = buf.entries(since: 3)
+        #expect(tail.map(\.value) == [30, 40, 50])
+        #expect(tail.map(\.seq) == [3, 4, 5])
+    }
+
+    @Test func sinceBeyondNextSeqReturnsEmpty() {
+        var buf = RingBuffer<Int>(capacity: 4)
+        buf.append(1)
+        buf.append(2)
+        #expect(buf.entries(since: 99).isEmpty)
+    }
+
+    @Test func sinceAcrossEvictionReturnsOnlyLiveTail() {
+        var buf = RingBuffer<Int>(capacity: 3)
+        for n in 0 ..< 5 {
+            buf.append(n)
+        } // live: seq 2,3,4 → values 2,3,4
+        // Caller asks since=1 — that seq has been evicted, so they
+        // should get every live entry (the binary search lands at lo=0).
+        let result = buf.entries(since: 1)
+        #expect(result.map(\.seq) == [2, 3, 4])
+        #expect(result.map(\.value) == [2, 3, 4])
+    }
+
+    @Test func acknowledgeDropsResetsCounter() {
+        var buf = RingBuffer<Int>(capacity: 2)
+        for n in 0 ..< 5 {
+            buf.append(n)
+        }
+        #expect(buf.droppedSinceLastDrain == 3)
+        let drained = buf.acknowledgeDrops()
+        #expect(drained == 3)
+        #expect(buf.droppedSinceLastDrain == 0)
+        // Drains are additive across calls — append more and check.
+        buf.append(99)
+        buf.append(100)
+        #expect(buf.droppedSinceLastDrain == 2)
+    }
+
+    @Test func clearEmptiesButPreservesSeqNamespace() {
+        var buf = RingBuffer<Int>(capacity: 4)
+        for n in 0 ..< 3 {
+            buf.append(n)
+        }
+        buf.clear()
+        #expect(buf.isEmpty)
+        #expect(buf.nextSeq == 3) // unchanged
+        buf.append(99)
+        #expect(buf.entries.map(\.seq) == [3])
+    }
+}

--- a/NexTests/SocketParsingTests.swift
+++ b/NexTests/SocketParsingTests.swift
@@ -990,4 +990,100 @@ struct SocketParsingTests {
         """)
         #expect(SocketServer.parseWireMessage(data) == nil)
     }
+
+    // MARK: - Phase 5 — private mode + cookies
+
+    @Test func parseWebOpenDefaultsToPublic() {
+        let data = jsonData("""
+        {"command":"web-open","url":"https://example.com"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webOpen(
+            paneID: nil, url: "https://example.com", isPrivate: false
+        ))
+    }
+
+    @Test func parseWebOpenWithPrivateFlag() {
+        let data = jsonData("""
+        {"command":"web-open","url":"https://example.com","private":true}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webOpen(
+            paneID: nil, url: "https://example.com", isPrivate: true
+        ))
+    }
+
+    @Test func parseWebPrivateOn() {
+        let data = jsonData("""
+        {"command":"web-private","pane_id":"\(Self.paneIDString)","private":true}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webPrivate(
+            paneID: Self.paneUUID, target: nil, workspace: nil, enabled: true
+        ))
+    }
+
+    @Test func parseWebPrivateOff() {
+        let data = jsonData("""
+        {"command":"web-private","target":"web","workspace":"Dev","private":false}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webPrivate(
+            paneID: nil, target: "web", workspace: "Dev", enabled: false
+        ))
+    }
+
+    @Test func parseWebPrivateRequiresFlag() {
+        let data = jsonData("""
+        {"command":"web-private","pane_id":"\(Self.paneIDString)"}
+        """)
+        #expect(SocketServer.parseWireMessage(data) == nil)
+    }
+
+    @Test func parseWebCookiesList() {
+        let data = jsonData("""
+        {"command":"web-cookies-list","pane_id":"\(Self.paneIDString)"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webCookiesList(
+            paneID: Self.paneUUID, target: nil, workspace: nil
+        ))
+    }
+
+    @Test func parseWebCookiesClearAllSiteData() {
+        let data = jsonData("""
+        {"command":"web-cookies-clear","pane_id":"\(Self.paneIDString)","all":true}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webCookiesClear(
+            paneID: Self.paneUUID, target: nil, workspace: nil, domain: nil, all: true
+        ))
+    }
+
+    @Test func parseWebCookiesClearScopedToDomain() {
+        let data = jsonData("""
+        {"command":"web-cookies-clear","pane_id":"\(Self.paneIDString)","domain":"example.com"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webCookiesClear(
+            paneID: Self.paneUUID, target: nil, workspace: nil, domain: "example.com", all: false
+        ))
+    }
+
+    @Test func parseWebCookiesDelete() {
+        let data = jsonData("""
+        {"command":"web-cookies-delete","pane_id":"\(Self.paneIDString)","name":"sessionid","domain":"example.com"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webCookiesDelete(
+            paneID: Self.paneUUID, target: nil, workspace: nil, name: "sessionid", domain: "example.com"
+        ))
+    }
+
+    @Test func parseWebCookiesDeleteRequiresName() {
+        let data = jsonData("""
+        {"command":"web-cookies-delete","pane_id":"\(Self.paneIDString)"}
+        """)
+        #expect(SocketServer.parseWireMessage(data) == nil)
+    }
 }

--- a/NexTests/SocketParsingTests.swift
+++ b/NexTests/SocketParsingTests.swift
@@ -833,4 +833,161 @@ struct SocketParsingTests {
         let result = SocketServer.parseWireMessage(data)
         #expect(result?.0 == .graftStatus)
     }
+
+    // MARK: - parseWireMessage — Phase 3 web console/inspector
+
+    @Test func parseWebConsoleDefaults() {
+        let data = jsonData("""
+        {"command":"web-console","pane_id":"\(Self.paneIDString)"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webConsole(
+            paneID: Self.paneUUID,
+            target: nil,
+            workspace: nil,
+            since: 0,
+            level: nil,
+            clear: false
+        ))
+    }
+
+    @Test func parseWebConsoleWithFilters() {
+        let data = jsonData("""
+        {"command":"web-console","pane_id":"\(Self.paneIDString)",
+         "since":42,"level":"error","clear":true}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webConsole(
+            paneID: Self.paneUUID,
+            target: nil,
+            workspace: nil,
+            since: 42,
+            level: "error",
+            clear: true
+        ))
+    }
+
+    @Test func parseWebConsoleEmptyLevelNormalisedToNil() {
+        let data = jsonData("""
+        {"command":"web-console","pane_id":"\(Self.paneIDString)","level":""}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webConsole(
+            paneID: Self.paneUUID,
+            target: nil,
+            workspace: nil,
+            since: 0,
+            level: nil,
+            clear: false
+        ))
+    }
+
+    @Test func parseWebConsoleRequiresScope() {
+        // No pane_id and no target — `parseWebTarget` rejects.
+        let data = jsonData("""
+        {"command":"web-console"}
+        """)
+        #expect(SocketServer.parseWireMessage(data) == nil)
+    }
+
+    @Test func parseWebConsoleByTargetWithWorkspace() {
+        let data = jsonData("""
+        {"command":"web-console","target":"main","workspace":"Dev"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webConsole(
+            paneID: nil,
+            target: "main",
+            workspace: "Dev",
+            since: 0,
+            level: nil,
+            clear: false
+        ))
+    }
+
+    @Test func parseWebInspectArm() {
+        let data = jsonData("""
+        {"command":"web-inspect","pane_id":"\(Self.paneIDString)",
+         "send_to":"agent","submit":true}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webInspect(
+            paneID: Self.paneUUID,
+            target: nil,
+            workspace: nil,
+            sendTo: "agent",
+            submit: true,
+            disarm: false
+        ))
+    }
+
+    @Test func parseWebInspectDisarm() {
+        let data = jsonData("""
+        {"command":"web-inspect","pane_id":"\(Self.paneIDString)","disarm":true}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webInspect(
+            paneID: Self.paneUUID,
+            target: nil,
+            workspace: nil,
+            sendTo: nil,
+            submit: false,
+            disarm: true
+        ))
+    }
+
+    @Test func parseWebInspectEmptySendToNormalisedToNil() {
+        let data = jsonData("""
+        {"command":"web-inspect","pane_id":"\(Self.paneIDString)","send_to":""}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webInspect(
+            paneID: Self.paneUUID,
+            target: nil,
+            workspace: nil,
+            sendTo: nil,
+            submit: false,
+            disarm: false
+        ))
+    }
+
+    @Test func parseWebInspectRequiresScope() {
+        let data = jsonData("""
+        {"command":"web-inspect"}
+        """)
+        #expect(SocketServer.parseWireMessage(data) == nil)
+    }
+
+    @Test func parseWebInspectResultBare() {
+        let data = jsonData("""
+        {"command":"web-inspect-result","pane_id":"\(Self.paneIDString)"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webInspectResult(
+            paneID: Self.paneUUID,
+            target: nil,
+            workspace: nil,
+            clear: false
+        ))
+    }
+
+    @Test func parseWebInspectResultClear() {
+        let data = jsonData("""
+        {"command":"web-inspect-result","pane_id":"\(Self.paneIDString)","clear":true}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webInspectResult(
+            paneID: Self.paneUUID,
+            target: nil,
+            workspace: nil,
+            clear: true
+        ))
+    }
+
+    @Test func parseWebInspectResultRequiresScope() {
+        let data = jsonData("""
+        {"command":"web-inspect-result"}
+        """)
+        #expect(SocketServer.parseWireMessage(data) == nil)
+    }
 }

--- a/NexTests/WebPaneURLNormalisationTests.swift
+++ b/NexTests/WebPaneURLNormalisationTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+@testable import Nex
+import Testing
+
+struct WebPaneURLNormalisationTests {
+    @Test func emptyInputReturnsEmpty() {
+        #expect(WebPaneCoordinator.normalizeURLInput("") == "")
+        #expect(WebPaneCoordinator.normalizeURLInput("   ") == "")
+    }
+
+    @Test func passesThroughExplicitHTTPSchemes() {
+        #expect(WebPaneCoordinator.normalizeURLInput("https://example.com") == "https://example.com")
+        #expect(WebPaneCoordinator.normalizeURLInput("http://example.com/path?q=1") == "http://example.com/path?q=1")
+    }
+
+    @Test func passesThroughOpaqueSchemes() {
+        // Without the scheme-detection rule, these would get an
+        // erroneous `https://` prefix and never load.
+        #expect(
+            WebPaneCoordinator.normalizeURLInput("data:text/html,<h1>x</h1>")
+                == "data:text/html,<h1>x</h1>"
+        )
+        #expect(
+            WebPaneCoordinator.normalizeURLInput("javascript:void(0)")
+                == "javascript:void(0)"
+        )
+        #expect(
+            WebPaneCoordinator.normalizeURLInput("mailto:foo@bar.com")
+                == "mailto:foo@bar.com"
+        )
+        #expect(
+            WebPaneCoordinator.normalizeURLInput("tel:+61400000000")
+                == "tel:+61400000000"
+        )
+        #expect(
+            WebPaneCoordinator.normalizeURLInput("about:blank")
+                == "about:blank"
+        )
+        #expect(
+            WebPaneCoordinator.normalizeURLInput("file:///tmp/page.html")
+                == "file:///tmp/page.html"
+        )
+    }
+
+    @Test func bareHostnameGetsHTTPSPrefix() {
+        #expect(WebPaneCoordinator.normalizeURLInput("example.com") == "https://example.com")
+        #expect(WebPaneCoordinator.normalizeURLInput("www.example.com/path") == "https://www.example.com/path")
+    }
+
+    @Test func localHostnameGetsHTTPPrefix() {
+        // Local + private addresses fall back to http://. Single-label
+        // host (no dot) is also treated as internal.
+        #expect(WebPaneCoordinator.normalizeURLInput("localhost") == "http://localhost")
+        #expect(WebPaneCoordinator.normalizeURLInput("localhost:3000") == "http://localhost:3000")
+        #expect(WebPaneCoordinator.normalizeURLInput("127.0.0.1:8080") == "http://127.0.0.1:8080")
+        #expect(WebPaneCoordinator.normalizeURLInput("router.local") == "http://router.local")
+        #expect(WebPaneCoordinator.normalizeURLInput("dev-box") == "http://dev-box")
+    }
+
+    @Test func hostPortPairIsNotMistakenForAScheme() {
+        // `host:port` (digits after colon) should NOT be treated as a
+        // scheme — must still get the http/https prefix.
+        #expect(WebPaneCoordinator.normalizeURLInput("example.com:8080") == "https://example.com:8080")
+        #expect(WebPaneCoordinator.normalizeURLInput("localhost:3000") == "http://localhost:3000")
+    }
+
+    @Test func privateRangesGetHTTPPrefix() {
+        #expect(WebPaneCoordinator.normalizeURLInput("10.0.0.1") == "http://10.0.0.1")
+        #expect(WebPaneCoordinator.normalizeURLInput("192.168.1.1") == "http://192.168.1.1")
+        #expect(WebPaneCoordinator.normalizeURLInput("172.16.0.1") == "http://172.16.0.1")
+        #expect(WebPaneCoordinator.normalizeURLInput("169.254.1.1") == "http://169.254.1.1")
+    }
+}

--- a/Resources/skills/nex-agentic/SKILL.md
+++ b/Resources/skills/nex-agentic/SKILL.md
@@ -3,11 +3,16 @@ name: nex-agentic
 description: >
   Use the Nex terminal multiplexer and its CLI to orchestrate multi-agent
   development workflows. Enables spawning named child panes, starting Claude
-  agents in them, farming out parallel work, and coordinating results via
-  markdown files and direct pane messaging. Trigger when: the user asks to
-  "spawn agents", "fan out work", "create worker panes", "orchestrate panes",
-  "use nex to coordinate", "multi-agent", "farm out tasks", or any variation
-  of parallelizing work across Nex panes.
+  agents in them, farming out parallel work, coordinating results via markdown
+  files and direct pane messaging, AND driving / observing a web app from an
+  agent via the `nex web` pane (open URL, capture page text or screenshot,
+  drain console buffer, arm element picker to paste structured payloads into
+  an agent pane). Trigger when: the user asks to "spawn agents", "fan out
+  work", "create worker panes", "orchestrate panes", "use nex to coordinate",
+  "multi-agent", "farm out tasks", or any variation of parallelizing work
+  across Nex panes. Also trigger when an agent needs to "drive the browser",
+  "watch the page console", "capture a screenshot of the app", "pick an
+  element from the page", or coordinate with the web pane in any way.
 ---
 
 # Nex Agentic Development Skill
@@ -100,7 +105,10 @@ nex pane name <label>
 # Label resolution is scoped to the sender's own workspace by default
 # (issue #92). Pass --workspace <name-or-id> to target another workspace
 # or to disambiguate a label collision; UUID targets are always global.
-nex pane send --target <label-or-uuid> [--workspace <name-or-uuid>] <command...>
+# `--bare` writes the text without appending Enter — pair with
+# `pane send-key` for compositional flows (autocomplete with `tab`,
+# escape sequences, partial input, paste-safe structured content).
+nex pane send [--bare] --target <label-or-uuid> [--workspace <name-or-uuid>] <command...>
 
 # List panes (only command that returns data — use for reconciliation)
 nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]
@@ -132,8 +140,8 @@ nex pane list --current
 nex pane list --workspace nex
 ```
 
-Each JSON entry includes: `id`, `label`, `type` (`shell`/`markdown`/
-`scratchpad`), `title`, `workspace_id`, `workspace_name`,
+Each JSON entry includes: `id`, `label`, `type` (`shell` / `markdown` /
+`scratchpad` / `diff` / `web`), `title`, `workspace_id`, `workspace_name`,
 `working_directory`, `git_branch`, `status` (`idle`/`running`/
 `waitingForInput`), `claude_session_id`, `is_focused`,
 `is_active_workspace`, `created_at`, `last_activity_at`.
@@ -177,6 +185,70 @@ nex event notification --title "..." --body "..."  # Desktop notification
 ```bash
 nex workspace create [--name "..."] [--path /dir] [--color blue|green|red|yellow|purple|orange|pink|gray]
 ```
+
+### Web Pane Commands
+
+A `web` pane is a full in-pane browser with URL bar, multi-tab
+strip, console capture, an element picker that pastes structured
+payloads into a chosen pane, private mode, and a cookies editor.
+The CLI surface is the orchestration angle: an agent in pane A can
+drive or observe a web app in pane B.
+
+```bash
+# Create a new web pane in the active workspace
+nex web open [--private] <url>
+
+# Read the active tab's URL + title
+nex web url --target <name-or-uuid> [--workspace <name-or-uuid>]
+
+# Navigate
+nex web back    --target <name-or-uuid>
+nex web forward --target <name-or-uuid>
+nex web reload  --target <name-or-uuid> [--hard]
+
+# Capture page state into a JSON reply
+nex web capture --target <name-or-uuid> --mode meta|text|screenshot
+
+# Multi-tab
+nex web tabs       --target <name-or-uuid> [--json] [--no-header]
+nex web tab-new    --target <name-or-uuid> [<url>] [--no-focus]
+nex web tab-close  --target <name-or-uuid> <ref>   # UUID or numeric index
+nex web tab-select --target <name-or-uuid> <ref>
+
+# Drain the per-pane console ring buffer (since-cursor, level filter, clear)
+nex web console --target <name-or-uuid> [--since N] [--level error|warn|info|log|debug] [--clear] [--json]
+
+# Arm the element picker. With --send-to, the next click pastes a
+# sanitised payload (selector, xpath, tag, outer_html, attributes,
+# rect, surrounding text, url) into the named pane via `pane send`.
+# Default is paste-only — pass --submit if the receiving pane should
+# auto-execute (rarely what you want for an agent prompt).
+nex web inspect --target <name-or-uuid> [--send-to <pane>] [--submit] [--disarm]
+
+# Drain the per-pane inspect-result queue without arming
+nex web inspect-result --target <name-or-uuid> [--clear] [--json]
+
+# Toggle private mode (rebuilds the coordinator with a nonPersistent
+# data store; live JS state is lost on transition)
+nex web private on|off --target <name-or-uuid>
+
+# Cookies (per-pane data store)
+nex web cookies list   --target <name-or-uuid> [--json]
+nex web cookies clear  --target <name-or-uuid> [--domain X] [--all]
+nex web cookies delete <name> --target <name-or-uuid> [--domain X]
+```
+
+All `web` verbs follow the same `--target` / `--workspace`
+scoping as `pane send` (issue #92): label targets need an origin
+pane or `--workspace`; UUID targets resolve globally. All are
+reply-allowlisted — they return JSON and the CLI exits non-zero on
+failure.
+
+**Known limitation.** `WKUserContentController` user-script injection
+is unreliable on `data:` URLs (opaque origin). Console capture +
+element picker rely on injected scripts, so reach for a real
+`http(s)://` URL when validating those paths. Smoke tests can still
+use `data:` URLs for navigation / capture --mode text / tabs.
 
 ### Key Behaviors
 
@@ -344,6 +416,76 @@ nex pane send --target coder claude
 sleep 2
 nex pane send --target coder "You are a coder. Write code for the task in .nex-tasks/feature.md and save it to .nex-results/code.md"
 ```
+
+### Pattern 4: Agent driving / observing a web app via web pane
+
+The web pane closes the loop where an agent in one pane drives or
+observes a web app in another. Common shapes:
+
+**(a) Capture-then-fix loop** — agent runs the app in a web pane,
+polls its console for errors, fixes the code, reloads, repeats.
+
+```bash
+# Coordinator opens the dev server's URL in a web pane and an agent
+# pane that watches it.
+nex web open http://localhost:3000              # → prints `open ok: <web-uuid>`
+nex pane create --name dev-agent
+sleep 2
+nex pane send --target dev-agent claude --permission-mode acceptEdits
+
+# Agent prompt (typed into dev-agent):
+#   "Watch the console buffer of web pane <web-uuid>. Every 10s run
+#    `nex web console --target <web-uuid> --json --since $cursor`
+#    (track the cursor between polls). When you see a JS error,
+#    open the relevant source file and propose a fix. Reload the web
+#    pane after each edit via `nex web reload --target <web-uuid>`."
+```
+
+**(b) Click-to-locate-source** — the human clicks an element on the
+page, an agent gets the selector + outerHTML and finds the code that
+rendered it. The picker is single-shot by default (one click → one
+delivery), or sticky via the chrome's batch-annotate panel.
+
+```bash
+# Arm the picker on the web pane, route the next click into the agent
+nex web inspect --target <web-uuid> --send-to dev-agent
+# → next click on the web page pastes a fenced JSON block into
+#   dev-agent's PTY (paste-only; agent reads it as input but does NOT
+#   auto-submit unless --submit was passed)
+```
+
+The pasted payload includes `selector`, `xpath`, `tag`, `id`,
+`outer_html` (clipped 16KB), `attributes`, `rect`, surrounding `text`,
+`context_html` (clipped 4KB), and `url`. ANSI / C0 control bytes are
+stripped before paste so the agent's prompt can't be smuggled into.
+
+**(c) Headless visual diff** — capture screenshots before/after a
+change to gate a deploy.
+
+```bash
+nex web capture --target <web-uuid> --mode screenshot
+# → JSON reply contains either `png_base64` (small) or `path` to a
+#   PNG in the system temp dir (larger). The CLI prints the path.
+```
+
+**(d) Sandbox a flaky integration** — open the integration target in a
+private web pane so the agent's exploration doesn't pollute the
+user's real session.
+
+```bash
+nex web open --private https://staging.example.com
+# Cookies + caches discarded on quit; tabs blank on restart.
+```
+
+**Picker behaviour to design around:**
+- Arming is single-shot by default — exactly one click delivers, then
+  the picker disarms. Sticky mode (multiple clicks per arm) is only
+  reachable through the batch-annotate panel in the chrome.
+- Delivery defaults to paste-no-submit — the receiving agent reads
+  the JSON as input but does not execute it. Pass `--submit` only
+  when the receiver is at a prompt that should auto-fire on Enter.
+- The picker auto-disarms on tab switch, tab close, and Escape.
+- Page JS cannot spoof inbound payloads on the inspect channel.
 
 ## Task File Format
 

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -101,9 +101,11 @@ func printUsage() {
       nex graft start [--workspace <name-or-uuid>] [--repo <name-or-path>]
       nex graft stop [--workspace <name-or-uuid>] [--repo <name-or-path>]
       nex graft status [--json]
-      nex web open <url>
+      nex web open [--private] <url>
       nex web url|back|forward|reload [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--hard]
       nex web capture [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot]
+      nex web private on|off [--target <name-or-uuid>] [--workspace <name-or-uuid>]
+      nex web cookies list|clear|delete [...]
     \n
     """, stderr)
 }
@@ -756,7 +758,7 @@ func handlePane(_ args: inout ArraySlice<String>) {
 func printWebUsage(stream: UnsafeMutablePointer<FILE>) {
     fputs("""
     Usage:
-      nex web open <url>
+      nex web open [--private] <url>
       nex web url      [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web back     [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web forward  [--target <name-or-uuid>] [--workspace <name-or-uuid>]
@@ -769,6 +771,8 @@ func printWebUsage(stream: UnsafeMutablePointer<FILE>) {
       nex web console     [--target ...] [--workspace ...] [--since N] [--level log|debug|info|warn|error] [--clear] [--json]
       nex web inspect     [--target ...] [--workspace ...] [--send-to <pane>] [--submit] [--disarm]
       nex web inspect-result [--target ...] [--workspace ...] [--clear] [--json]
+      nex web private    on|off [--target ...] [--workspace ...]
+      nex web cookies    list|clear|delete [...]
 
     When invoked from outside a Nex pane, --target must be a UUID
     or --workspace <name-or-id> must be passed (label resolution
@@ -827,14 +831,18 @@ func handleWeb(_ args: inout ArraySlice<String>) {
 
     switch action {
     case "open":
+        let isPrivate = popSwitch("--private", from: &args)
         guard let url = args.popFirst(), !url.isEmpty else {
-            fputs("Usage: nex web open <url>\n", stderr)
+            fputs("Usage: nex web open [--private] <url>\n", stderr)
             exit(1)
         }
         var payload: [String: Any] = [
             "command": "web-open",
             "url": url
         ]
+        if isPrivate {
+            payload["private"] = true
+        }
         if let originPaneID = ProcessInfo.processInfo.environment["NEX_PANE_ID"],
            !originPaneID.isEmpty {
             payload["pane_id"] = originPaneID
@@ -985,6 +993,33 @@ func handleWeb(_ args: inout ArraySlice<String>) {
         if clear { payload["clear"] = true }
         attachWebTargetScope(&payload, target: target, workspace: workspace, command: "inspect-result")
         sendWebReplyAndPrintInspectResult(payload, asJSON: asJSON)
+
+    case "private":
+        guard let mode = args.popFirst(), !mode.isEmpty else {
+            fputs("Usage: nex web private on|off [--target X] [--workspace Y]\n", stderr)
+            exit(1)
+        }
+        let enabled: Bool
+        switch mode.lowercased() {
+        case "on", "true", "1", "yes":
+            enabled = true
+        case "off", "false", "0", "no":
+            enabled = false
+        default:
+            fputs("nex web private: expected 'on' or 'off' (got '\(mode)')\n", stderr)
+            exit(1)
+        }
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        var payload: [String: Any] = [
+            "command": "web-private",
+            "private": enabled
+        ]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "private")
+        sendWebReplyAndPrintPrivate(payload)
+
+    case "cookies":
+        handleWebCookies(&args)
 
     default:
         fputs("Unknown web action: \(action)\n", stderr)
@@ -1235,6 +1270,176 @@ private func sendWebReplyAndPrintInspectResult(_ payload: [String: Any], asJSON:
         let tag = (result["tag"] as? String) ?? ""
         print("\(tag)  \(selector)  (\(url))")
     }
+}
+
+// MARK: - web private + cookies
+
+func handleWebCookies(_ args: inout ArraySlice<String>) {
+    guard let action = args.popFirst() else {
+        printWebCookiesUsage(stream: stderr)
+        exit(1)
+    }
+    if action == "-h" || action == "--help" || action == "help" {
+        printWebCookiesUsage(stream: stdout)
+        exit(0)
+    }
+
+    switch action {
+    case "list":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let asJSON = popSwitch("--json", from: &args)
+        var payload: [String: Any] = ["command": "web-cookies-list"]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "cookies list")
+        sendWebReplyAndPrintCookies(payload, asJSON: asJSON)
+
+    case "clear":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let domain = parseFlag("--domain", from: &args)
+        let all = popSwitch("--all", from: &args)
+        if all, domain != nil {
+            fputs("nex web cookies clear: --all and --domain are mutually exclusive\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = ["command": "web-cookies-clear"]
+        if let domain { payload["domain"] = domain }
+        if all { payload["all"] = true }
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "cookies clear")
+        sendWebReplyAndPrintCookiesClear(payload, all: all)
+
+    case "delete":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let domain = parseFlag("--domain", from: &args)
+        guard let name = parseFlag("--name", from: &args) ?? args.popFirst(),
+              !name.isEmpty else {
+            fputs("Usage: nex web cookies delete <name> [--domain <d>] [--target X] [--workspace Y]\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = [
+            "command": "web-cookies-delete",
+            "name": name
+        ]
+        if let domain { payload["domain"] = domain }
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "cookies delete")
+        sendWebReplyAndPrintCookiesDelete(payload)
+
+    default:
+        fputs("Unknown cookies action: \(action)\n", stderr)
+        printWebCookiesUsage(stream: stderr)
+        exit(1)
+    }
+}
+
+private func printWebCookiesUsage(stream: UnsafeMutablePointer<FILE>) {
+    fputs("""
+    Usage:
+      nex web cookies list   [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--json]
+      nex web cookies clear  [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--domain <d>] [--all]
+      nex web cookies delete <name> [--domain <d>] [--target <name-or-uuid>] [--workspace <name-or-uuid>]
+
+    --all on `clear` removes cookies AND caches/local storage/indexed db for
+    this pane's data store. Without --domain, `clear` removes every cookie.
+    \n
+    """, stream)
+}
+
+/// Send `payload` to Nex and decode the reply for a `nex web ...` command.
+/// Exits non-zero with a structured stderr message on transport failure,
+/// empty reply, invalid JSON, or `ok=false`. `command` is the label used in
+/// error messages (e.g. "private", "cookies list").
+private func readWebReplyOrExit(_ payload: [String: Any], command: String) -> [String: Any] {
+    guard let data = sendJSONAndReadReply(payload) else {
+        fputs("nex web \(command): transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    guard !data.isEmpty else {
+        fputs("nex web \(command): no response from Nex (upgrade required?)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        fputs("nex web \(command): invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex web \(command): \(msg)\n", stderr)
+        exit(1)
+    }
+    return json
+}
+
+private func sendWebReplyAndPrintPrivate(_ payload: [String: Any]) {
+    let json = readWebReplyOrExit(payload, command: "private")
+    let isPrivate = (json["private"] as? Bool) ?? false
+    let changed = (json["changed"] as? Bool) ?? false
+    let paneID = (json["pane_id"] as? String) ?? "?"
+    let suffix = changed ? "" : " (no change)"
+    print("private \(isPrivate ? "on" : "off"): \(paneID)\(suffix)")
+}
+
+private func sendWebReplyAndPrintCookies(_ payload: [String: Any], asJSON: Bool) {
+    let json = readWebReplyOrExit(payload, command: "cookies list")
+    let cookies = (json["cookies"] as? [[String: Any]]) ?? []
+    if asJSON {
+        if let out = try? JSONSerialization.data(withJSONObject: cookies, options: [.sortedKeys]),
+           let s = String(data: out, encoding: .utf8) {
+            print(s)
+        }
+        return
+    }
+    if cookies.isEmpty {
+        print("(no cookies)")
+        return
+    }
+    print("DOMAIN                     NAME                 VALUE")
+    let sorted = cookies.sorted {
+        let a = ($0["domain"] as? String) ?? ""
+        let b = ($1["domain"] as? String) ?? ""
+        if a != b { return a < b }
+        return (($0["name"] as? String) ?? "") < (($1["name"] as? String) ?? "")
+    }
+    for cookie in sorted {
+        let domain = (cookie["domain"] as? String) ?? ""
+        let name = (cookie["name"] as? String) ?? ""
+        let value = (cookie["value"] as? String) ?? ""
+        let domainClipped = domain.count > 24 ? String(domain.prefix(23)) + "…" : domain
+        let nameClipped = name.count > 20 ? String(name.prefix(19)) + "…" : name
+        let valueClipped = value.count > 40 ? String(value.prefix(39)) + "…" : value
+        print(String(
+            format: "%-26@  %-20@  %@",
+            domainClipped as NSString,
+            nameClipped as NSString,
+            valueClipped
+        ))
+    }
+}
+
+private func sendWebReplyAndPrintCookiesClear(_ payload: [String: Any], all: Bool) {
+    let json = readWebReplyOrExit(payload, command: "cookies clear")
+    if all || (json["cleared_site_data"] as? Bool) == true {
+        print("cleared all site data")
+        return
+    }
+    let deleted = (json["deleted"] as? Int) ?? 0
+    let domain = (json["domain"] as? String) ?? ""
+    if domain.isEmpty {
+        print("deleted \(deleted) cookie\(deleted == 1 ? "" : "s")")
+    } else {
+        print("deleted \(deleted) cookie\(deleted == 1 ? "" : "s") for \(domain)")
+    }
+}
+
+private func sendWebReplyAndPrintCookiesDelete(_ payload: [String: Any]) {
+    let json = readWebReplyOrExit(payload, command: "cookies delete")
+    let deleted = (json["deleted"] as? Int) ?? 0
+    let name = (json["name"] as? String) ?? "?"
+    if deleted == 0 {
+        print("no cookie matched name '\(name)'")
+        exit(1)
+    }
+    print("deleted \(deleted) cookie\(deleted == 1 ? "" : "s") named '\(name)'")
 }
 
 // MARK: - pane list

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -101,6 +101,9 @@ func printUsage() {
       nex graft start [--workspace <name-or-uuid>] [--repo <name-or-path>]
       nex graft stop [--workspace <name-or-uuid>] [--repo <name-or-path>]
       nex graft status [--json]
+      nex web open <url>
+      nex web url|back|forward|reload [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--hard]
+      nex web capture [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot]
     \n
     """, stderr)
 }
@@ -748,6 +751,235 @@ func handlePane(_ args: inout ArraySlice<String>) {
     }
 }
 
+// MARK: - web (top-level subcommand)
+
+func printWebUsage(stream: UnsafeMutablePointer<FILE>) {
+    fputs("""
+    Usage:
+      nex web open <url>
+      nex web url      [--target <name-or-uuid>] [--workspace <name-or-uuid>]
+      nex web back     [--target <name-or-uuid>] [--workspace <name-or-uuid>]
+      nex web forward  [--target <name-or-uuid>] [--workspace <name-or-uuid>]
+      nex web reload   [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--hard]
+      nex web capture  [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot]
+
+    When invoked from outside a Nex pane, --target must be a UUID
+    or --workspace <name-or-id> must be passed (label resolution
+    needs an explicit workspace scope).
+    \n
+    """, stream)
+}
+
+/// Apply the `--target` / `--workspace` / `NEX_PANE_ID` rule (issue
+/// #92): label targets need either an origin pane or an explicit
+/// workspace; UUID targets always resolve globally. Returns the
+/// payload extension; exits non-zero on rule violation.
+private func attachWebTargetScope(
+    _ payload: inout [String: Any],
+    target: String?,
+    workspace: String?,
+    command: String
+) {
+    if let target {
+        payload["target"] = target
+    }
+    if let workspace {
+        payload["workspace"] = workspace
+    }
+    if let originPaneID = ProcessInfo.processInfo.environment["NEX_PANE_ID"],
+       !originPaneID.isEmpty {
+        payload["pane_id"] = originPaneID
+    }
+
+    // Enforce the external-caller workspace rule before sending so
+    // failures surface as a clear CLI message rather than a server
+    // error round-trip.
+    let isUUIDTarget = target.flatMap { UUID(uuidString: $0) } != nil
+    let hasOrigin = ProcessInfo.processInfo.environment["NEX_PANE_ID"]?.isEmpty == false
+    if let target, !isUUIDTarget, workspace == nil, !hasOrigin {
+        fputs("nex web \(command): --target by label requires --workspace <name-or-id> when called outside a Nex pane\n", stderr)
+        exit(1)
+    }
+    // No target and no origin pane = no resolvable pane.
+    if target == nil, !hasOrigin {
+        fputs("nex web \(command): no --target supplied and NEX_PANE_ID is not set\n", stderr)
+        exit(1)
+    }
+}
+
+func handleWeb(_ args: inout ArraySlice<String>) {
+    guard let action = args.popFirst() else {
+        printWebUsage(stream: stderr)
+        exit(1)
+    }
+
+    if action == "-h" || action == "--help" || action == "help" {
+        printWebUsage(stream: stdout)
+        exit(0)
+    }
+
+    switch action {
+    case "open":
+        guard let url = args.popFirst(), !url.isEmpty else {
+            fputs("Usage: nex web open <url>\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = [
+            "command": "web-open",
+            "url": url
+        ]
+        if let originPaneID = ProcessInfo.processInfo.environment["NEX_PANE_ID"],
+           !originPaneID.isEmpty {
+            payload["pane_id"] = originPaneID
+        }
+        sendWebReplyAndPrintBasic(payload, command: "open")
+
+    case "url":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        var payload: [String: Any] = ["command": "web-url"]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "url")
+        sendWebReplyAndPrintURL(payload)
+
+    case "back":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        var payload: [String: Any] = ["command": "web-back"]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "back")
+        sendWebReplyAndPrintBasic(payload, command: "back")
+
+    case "forward":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        var payload: [String: Any] = ["command": "web-forward"]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "forward")
+        sendWebReplyAndPrintBasic(payload, command: "forward")
+
+    case "reload":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let hard = popSwitch("--hard", from: &args)
+        var payload: [String: Any] = ["command": "web-reload"]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "reload")
+        if hard { payload["hard"] = true }
+        sendWebReplyAndPrintBasic(payload, command: "reload")
+
+    case "capture":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let mode = parseFlag("--mode", from: &args) ?? "meta"
+        let allowed: Set = ["meta", "text", "screenshot"]
+        guard allowed.contains(mode) else {
+            fputs("nex web capture: unknown --mode '\(mode)' (allowed: meta, text, screenshot)\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = [
+            "command": "web-capture",
+            "mode": mode
+        ]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "capture")
+        sendWebReplyAndPrintCapture(payload)
+
+    default:
+        fputs("Unknown web action: \(action)\n", stderr)
+        printWebUsage(stream: stderr)
+        exit(1)
+    }
+}
+
+private func sendWebReplyAndPrintBasic(_ payload: [String: Any], command: String) {
+    guard let data = sendJSONAndReadReply(payload) else {
+        fputs("nex web \(command): transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    guard !data.isEmpty else {
+        fputs("nex web \(command): no response from Nex (upgrade required?)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        fputs("nex web \(command): invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex web \(command): \(msg)\n", stderr)
+        exit(1)
+    }
+    let paneID = (json["pane_id"] as? String) ?? "?"
+    let extra = if let url = json["url"] as? String { " (\(url))" } else { "" }
+    print("\(command) ok: \(paneID)\(extra)")
+}
+
+private func sendWebReplyAndPrintURL(_ payload: [String: Any]) {
+    guard let data = sendJSONAndReadReply(payload) else {
+        fputs("nex web url: transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    guard !data.isEmpty else {
+        fputs("nex web url: no response from Nex (upgrade required?)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        fputs("nex web url: invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex web url: \(msg)\n", stderr)
+        exit(1)
+    }
+    let url = (json["url"] as? String) ?? ""
+    let title = (json["title"] as? String) ?? ""
+    if !title.isEmpty {
+        print("\(url)\t\(title)")
+    } else {
+        print(url)
+    }
+}
+
+private func sendWebReplyAndPrintCapture(_ payload: [String: Any]) {
+    guard let data = sendJSONAndReadReply(payload) else {
+        fputs("nex web capture: transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    guard !data.isEmpty else {
+        fputs("nex web capture: no response from Nex (upgrade required?)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        fputs("nex web capture: invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex web capture: \(msg)\n", stderr)
+        exit(1)
+    }
+    let mode = (json["mode"] as? String) ?? "meta"
+    switch mode {
+    case "text":
+        if let text = json["text"] as? String { print(text) }
+    case "screenshot":
+        if let path = json["path"] as? String {
+            print(path)
+        } else if let b64 = json["png_base64"] as? String {
+            // Inline: print to stdout — the caller can pipe to `base64 -D > out.png`.
+            print(b64)
+        }
+    default:
+        // meta — print URL + title + byte_count
+        let url = (json["url"] as? String) ?? ""
+        let title = (json["title"] as? String) ?? ""
+        print("url:    \(url)")
+        if !title.isEmpty {
+            print("title:  \(title)")
+        }
+        if let bytes = json["byte_count"] as? Int {
+            print("bytes:  \(bytes)")
+        }
+    }
+}
+
 // MARK: - pane list
 
 func handlePaneList(_ args: inout ArraySlice<String>) {
@@ -1313,6 +1545,8 @@ case "diff":
     handleDiff(&args)
 case "graft":
     handleGraft(&args)
+case "web":
+    handleWeb(&args)
 default:
     fputs("Unknown command: \(subcommand)\n", stderr)
     printUsage()

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -762,6 +762,10 @@ func printWebUsage(stream: UnsafeMutablePointer<FILE>) {
       nex web forward  [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web reload   [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--hard]
       nex web capture  [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot]
+      nex web tabs        [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--json] [--no-header]
+      nex web tab-new     [<url>] [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--no-focus]
+      nex web tab-close   <ref> [--target <name-or-uuid>] [--workspace <name-or-uuid>]
+      nex web tab-select  <ref> [--target <name-or-uuid>] [--workspace <name-or-uuid>]
 
     When invoked from outside a Nex pane, --target must be a UUID
     or --workspace <name-or-id> must be passed (label resolution
@@ -880,10 +884,100 @@ func handleWeb(_ args: inout ArraySlice<String>) {
         attachWebTargetScope(&payload, target: target, workspace: workspace, command: "capture")
         sendWebReplyAndPrintCapture(payload)
 
+    case "tabs":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let asJSON = popSwitch("--json", from: &args)
+        let noHeader = popSwitch("--no-header", from: &args)
+        var payload: [String: Any] = ["command": "web-tabs"]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "tabs")
+        sendWebReplyAndPrintTabs(payload, asJSON: asJSON, noHeader: noHeader)
+
+    case "tab-new":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let noFocus = popSwitch("--no-focus", from: &args)
+        let url = args.popFirst() ?? ""
+        var payload: [String: Any] = [
+            "command": "web-tab-new",
+            "url": url,
+            "make_active": !noFocus
+        ]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "tab-new")
+        sendWebReplyAndPrintBasic(payload, command: "tab-new")
+
+    case "tab-close":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        guard let ref = args.popFirst(), !ref.isEmpty else {
+            fputs("Usage: nex web tab-close <ref> [--target X] [--workspace Y]\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = [
+            "command": "web-tab-close",
+            "tab": ref
+        ]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "tab-close")
+        sendWebReplyAndPrintBasic(payload, command: "tab-close")
+
+    case "tab-select":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        guard let ref = args.popFirst(), !ref.isEmpty else {
+            fputs("Usage: nex web tab-select <ref> [--target X] [--workspace Y]\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = [
+            "command": "web-tab-select",
+            "tab": ref
+        ]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "tab-select")
+        sendWebReplyAndPrintBasic(payload, command: "tab-select")
+
     default:
         fputs("Unknown web action: \(action)\n", stderr)
         printWebUsage(stream: stderr)
         exit(1)
+    }
+}
+
+private func sendWebReplyAndPrintTabs(_ payload: [String: Any], asJSON: Bool, noHeader: Bool) {
+    guard let data = sendJSONAndReadReply(payload) else {
+        fputs("nex web tabs: transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    guard !data.isEmpty else {
+        fputs("nex web tabs: no response from Nex (upgrade required?)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        fputs("nex web tabs: invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex web tabs: \(msg)\n", stderr)
+        exit(1)
+    }
+    let tabs = (json["tabs"] as? [[String: Any]]) ?? []
+    if asJSON {
+        if let out = try? JSONSerialization.data(withJSONObject: tabs, options: [.sortedKeys]),
+           let s = String(data: out, encoding: .utf8) {
+            print(s)
+        }
+        return
+    }
+    // Plain text: INDEX  ACTIVE  TITLE  URL  ID
+    if !noHeader {
+        print("IDX  A  TITLE                    URL")
+    }
+    for tab in tabs {
+        let idx = (tab["index"] as? Int) ?? 0
+        let active = (tab["active"] as? Bool) ?? false
+        let title = (tab["title"] as? String) ?? ""
+        let url = (tab["url"] as? String) ?? ""
+        let titleClipped = title.count > 24 ? String(title.prefix(23)) + "…" : title
+        print(String(format: "%-3d  %@  %-24@  %@", idx, active ? "*" : " ", titleClipped as NSString, url))
     }
 }
 

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -766,6 +766,9 @@ func printWebUsage(stream: UnsafeMutablePointer<FILE>) {
       nex web tab-new     [<url>] [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--no-focus]
       nex web tab-close   <ref> [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web tab-select  <ref> [--target <name-or-uuid>] [--workspace <name-or-uuid>]
+      nex web console     [--target ...] [--workspace ...] [--since N] [--level log|debug|info|warn|error] [--clear] [--json]
+      nex web inspect     [--target ...] [--workspace ...] [--send-to <pane>] [--submit] [--disarm]
+      nex web inspect-result [--target ...] [--workspace ...] [--clear] [--json]
 
     When invoked from outside a Nex pane, --target must be a UUID
     or --workspace <name-or-id> must be passed (label resolution
@@ -934,6 +937,55 @@ func handleWeb(_ args: inout ArraySlice<String>) {
         attachWebTargetScope(&payload, target: target, workspace: workspace, command: "tab-select")
         sendWebReplyAndPrintBasic(payload, command: "tab-select")
 
+    case "console":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let sinceArg = parseFlag("--since", from: &args)
+        let level = parseFlag("--level", from: &args)
+        let clear = popSwitch("--clear", from: &args)
+        let asJSON = popSwitch("--json", from: &args)
+        var payload: [String: Any] = ["command": "web-console"]
+        if let sinceArg, let parsed = UInt64(sinceArg) {
+            payload["since"] = parsed
+        } else if let sinceArg {
+            fputs("nex web console: --since must be an unsigned integer (got '\(sinceArg)')\n", stderr)
+            exit(1)
+        }
+        if let level {
+            let allowed: Set = ["log", "debug", "info", "warn", "error"]
+            guard allowed.contains(level) else {
+                fputs("nex web console: --level must be one of log|debug|info|warn|error\n", stderr)
+                exit(1)
+            }
+            payload["level"] = level
+        }
+        if clear { payload["clear"] = true }
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "console")
+        sendWebReplyAndPrintConsole(payload, asJSON: asJSON)
+
+    case "inspect":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let sendTo = parseFlag("--send-to", from: &args)
+        let submit = popSwitch("--submit", from: &args)
+        let disarm = popSwitch("--disarm", from: &args)
+        var payload: [String: Any] = ["command": "web-inspect"]
+        if let sendTo { payload["send_to"] = sendTo }
+        if submit { payload["submit"] = true }
+        if disarm { payload["disarm"] = true }
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "inspect")
+        sendWebReplyAndPrintInspect(payload)
+
+    case "inspect-result":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let clear = popSwitch("--clear", from: &args)
+        let asJSON = popSwitch("--json", from: &args)
+        var payload: [String: Any] = ["command": "web-inspect-result"]
+        if clear { payload["clear"] = true }
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "inspect-result")
+        sendWebReplyAndPrintInspectResult(payload, asJSON: asJSON)
+
     default:
         fputs("Unknown web action: \(action)\n", stderr)
         printWebUsage(stream: stderr)
@@ -1071,6 +1123,117 @@ private func sendWebReplyAndPrintCapture(_ payload: [String: Any]) {
         if let bytes = json["byte_count"] as? Int {
             print("bytes:  \(bytes)")
         }
+    }
+}
+
+private func sendWebReplyAndPrintConsole(_ payload: [String: Any], asJSON: Bool) {
+    guard let data = sendJSONAndReadReply(payload) else {
+        fputs("nex web console: transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    guard !data.isEmpty else {
+        fputs("nex web console: no response from Nex (upgrade required?)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        fputs("nex web console: invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex web console: \(msg)\n", stderr)
+        exit(1)
+    }
+    let lines = (json["lines"] as? [[String: Any]]) ?? []
+    if asJSON {
+        if let out = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]),
+           let s = String(data: out, encoding: .utf8) {
+            print(s)
+        }
+        return
+    }
+    if let dropped = json["dropped"] as? Int, dropped > 0 {
+        fputs("(dropped \(dropped) lines before this batch — buffer was full)\n", stderr)
+    }
+    for line in lines {
+        let seq = (line["seq"] as? UInt64) ?? 0
+        let level = (line["level"] as? String) ?? "log"
+        let message = (line["message"] as? String) ?? ""
+        print("[\(seq)] \(level): \(message)")
+    }
+    if let next = json["next_since"] as? UInt64 {
+        fputs("(next_since=\(next))\n", stderr)
+    }
+}
+
+private func sendWebReplyAndPrintInspect(_ payload: [String: Any]) {
+    guard let data = sendJSONAndReadReply(payload) else {
+        fputs("nex web inspect: transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    guard !data.isEmpty else {
+        fputs("nex web inspect: no response from Nex (upgrade required?)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        fputs("nex web inspect: invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex web inspect: \(msg)\n", stderr)
+        exit(1)
+    }
+    let paneID = (json["pane_id"] as? String) ?? "?"
+    let armed = (json["armed"] as? Bool) ?? false
+    if !armed {
+        print("inspect disarmed: \(paneID)")
+        return
+    }
+    let sendTo = (json["send_to"] as? String) ?? ""
+    if sendTo.isEmpty {
+        print("inspect armed: \(paneID) — click an element in the web pane to capture")
+    } else {
+        let submit = (json["submit"] as? Bool) ?? false
+        print("inspect armed: \(paneID) → will paste to \(sendTo)\(submit ? " (+submit)" : "")")
+    }
+}
+
+private func sendWebReplyAndPrintInspectResult(_ payload: [String: Any], asJSON: Bool) {
+    guard let data = sendJSONAndReadReply(payload) else {
+        fputs("nex web inspect-result: transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    guard !data.isEmpty else {
+        fputs("nex web inspect-result: no response from Nex (upgrade required?)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        fputs("nex web inspect-result: invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex web inspect-result: \(msg)\n", stderr)
+        exit(1)
+    }
+    let results = (json["results"] as? [[String: Any]]) ?? []
+    if asJSON {
+        if let out = try? JSONSerialization.data(withJSONObject: results, options: [.sortedKeys]),
+           let s = String(data: out, encoding: .utf8) {
+            print(s)
+        }
+        return
+    }
+    if results.isEmpty {
+        print("(no pending inspect results)")
+        return
+    }
+    for result in results {
+        let selector = (result["selector"] as? String) ?? ""
+        let url = (result["url"] as? String) ?? ""
+        let tag = (result["tag"] as? String) ?? ""
+        print("\(tag)  \(selector)  (\(url))")
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `.web` as a fifth pane type — a full in-pane browser with URL bar, multi-tab strip, favourites, private mode + cookies UI, console log capture, and an element picker that streams structured payloads into a chosen agent pane.
- Ships across 5 phases (1 PR) so the feature can land as one coherent change. Phase 6 (polish grab-bag) is tracked in #146 and Phase 7 (streaming console / full capture matrix) in #145, both as separate follow-ups.
- 34 files, +9544/-185. New module `Nex/Features/WebPane/` with 12 files; one `nex web …` CLI verb with 18 subcommands; three schema migrations (v12–v14).

## Phase breakdown

Commits, in order:

1. `830d515` — **Phase 1**: single-tab in-app browser with agent CLI (`open` / `url` / `back` / `forward` / `reload` / `capture`). WebView lifetime owned by a new `WebPaneStore` singleton mirroring `SurfaceManager`. Schema v12 (`webURL`).
2. `71ec3af` — **Phase 2**: multi-tab support, tab strip, persistence. Schema v13 (`webTabsJSON`, `webActiveTabID`).
3. `dca8281` — **Phase 3**: console capture (1000-line ring buffer, drop-oldest, capture phase listeners catch what page handlers `preventDefault`); element picker with nonce-validated payloads, paste-safe single-shot delivery, and batch-annotate mode with on-page numbered badges + comment popovers.
4. `ac38ea1` — **Phase 4**: favourites (star toggle + bookmarks dropdown + Settings editor) and the element-pickup chrome simplification (no schema impact).
5. `5f3b792` — **Phase 4 follow-up**: unify element-pickup flow and fix the reload-after-restore bug (`lastAttemptedURL` seeded for restore-time loads, not just URL-bar typed loads).
6. `cda93e0` — **Phase 5**: per-pane private mode (coordinator destroyed + rebuilt against `nonPersistent()` data store on toggle), accordion-grouped cookies UI with inline create + edit forms, and `nex web private` / `nex web cookies` CLI. Schema v14 (`webIsPrivate`).
7. `377e769` — **Phase 6 trickle**: Safari-style load progress strip driven by KVO on `estimatedProgress` + `isLoading`.

## CLI surface (all reply-allowlisted)

| Verb | What |
|---|---|
| `nex web open [--private] <url>` | Create a new web pane in the active workspace |
| `nex web url` / `back` / `forward` / `reload` | Navigation on the resolved pane |
| `nex web capture --mode meta\|text\|screenshot` | Capture page state (`dom` / `all` deferred to #145) |
| `nex web tabs` / `tab-new` / `tab-close` / `tab-select` | Multi-tab control |
| `nex web console [--since N] [--level X] [--clear]` | Drain the console ring buffer |
| `nex web inspect [--send-to <pane>] [--submit] [--disarm]` | Arm the element picker, paste the next click into another pane |
| `nex web inspect-result [--clear]` | Drain the inspect-result queue without arming |
| `nex web private on\|off` | Per-pane private mode toggle |
| `nex web cookies list\|clear\|delete` | Cookie inspection + edit + bulk delete |

`--target` + `--workspace` follow the existing issue #92 scoping rule: label targets need either `NEX_PANE_ID` or `--workspace`; UUIDs resolve globally.

## Architecture highlights

- **`WebPaneStore`** mirrors `SurfaceManager` — process-wide registry of `WebPaneCoordinator` instances keyed by paneID. WebViews survive SwiftUI rebuilds; coordinator destroyed only on pane close.
- **State sidecar** (`webPanes: [UUID: WebPaneState]` on `WorkspaceFeature.State`) keeps web-specific fields out of the `Pane` struct so non-web consumers don't have to learn the type.
- **Paste-safe inspect delivery** — `paneSendText(paneID, text, bare: true)` factored out of `handlePaneSend` so a clicked-element payload pastes into a target pane without auto-submitting (default; `--submit` opts in).
- **Nonce-validated inspect channel** — each picker arm generates a 128-bit nonce baked into the injected JS; the Swift handler rejects messages without a matching nonce, so page JS can't spoof the channel.
- **Private mode coordinator rebuild** — `WKWebView.configuration.websiteDataStore` is sealed at construction, so toggling private destroys + recreates the coordinator. The view layer's `updateNSView` has a defensive mismatch check (`existing.dataStore.isPersistent == isPrivate`) that catches the TCA effect's async ordering.
- **Confirmation dialogs** before flipping private mode (warns about loss of live JS state) and before "Clear all site data" (caches + IndexedDB + local storage, not just cookies).

## Test plan

- [x] `xcodegen generate --spec project.yml`
- [x] `xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation build`
- [x] `xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation test` — 877 tests pass
- [x] `swiftlint lint` — clean (7 pre-existing param-count warnings unrelated)
- [x] `swiftformat --lint .` — clean
- [x] Manual: `nex web open https://example.com` creates a web pane; URL bar + ⏎ navigates; back/forward/reload work; resize/split surrounding panes — WebView survives layout transition without reloading.
- [x] Manual: ⌘T opens a new tab; close button works; ⌘W closes the tab; with one tab remaining ⌘W closes the pane. Restart Nex — tab list and active tab restored.
- [x] Manual: open a page with `console.log` / trigger a JS error; `nex web console --target X` returns lines with monotonic `seq`. Try to fire the inspect handler from page JS — rejected (no nonce match).
- [x] Manual: `nex web inspect --send-to <agent>` arms picker; clicking an element pastes payload into the agent pane's terminal **without** auto-submit. With `--submit`, submits.
- [x] Manual: star a page → see it in the bookmarks dropdown → click → navigates active tab. Quit + relaunch — favourites persist.
- [x] Manual: enable private mode via the lock button → confirmation dialog → tabs reload against the nonPersistent store. Cookies panel shows empty.
- [x] Manual: in a normal pane, log into a site → open the storage panel → accordion shows cookies grouped by domain. Click `+` → inline create form at top of accordion → save → cookie appears. Click a cookie row → inline edit form → change value → save.
- [x] Manual: quit + relaunch — private pane reopens **blank** (still `.web`, still private, no tabs); the normal pane reopens at its last URL.

## Follow-ups

- #146 — Phase 6 polish grab-bag (zoom keys, cross-pane URL drag-drop, right-click menu, shared-store indicator, soft tab cap, tab strip state restore)
- #145 — Phase 7 (full capture matrix + streaming console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)