### PR TITLE
Web pane: nex web exec for agent-driven page interaction

### DIFF
--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -2298,6 +2298,62 @@ struct AppReducer {
         }
     }
 
+    func handleWebExec(
+        state: State,
+        paneID: UUID?,
+        target: String?,
+        workspaceFilter: String?,
+        script: String,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(
+            state: state, paneID: paneID, target: target,
+            workspaceFilter: workspaceFilter, reply: reply
+        ) else { return .none }
+        guard let tab = resolved.webState.activeTab else {
+            reply?.error("web pane has no active tab")
+            return .none
+        }
+        let store = webPaneStore
+        let resolvedPaneID = resolved.paneID
+        let workspaceID = resolved.workspace.id
+        let tabID = tab.id
+        return .run { _ in
+            let result = await MainActor.run {
+                store.coordinatorIfExists(for: resolvedPaneID)
+            }
+            guard let coord = result else {
+                reply?.error("web pane coordinator not mounted")
+                return
+            }
+            let outcome = await coord.executeJavaScript(tabID: tabID, source: script)
+            var payload: [String: Any] = [
+                "pane_id": resolvedPaneID.uuidString,
+                "workspace_id": workspaceID.uuidString,
+                "tab_id": tabID.uuidString
+            ]
+            switch outcome {
+            case .value(let data):
+                // Unwrap the `{"v": <result>}` envelope produced by the
+                // coordinator. JSONSerialization needs the wrapper to
+                // round-trip JS primitives (numbers, strings, null).
+                let wrapper = try? JSONSerialization.jsonObject(
+                    with: data, options: [.fragmentsAllowed]
+                ) as? [String: Any]
+                payload["ok"] = true
+                payload["result"] = wrapper?["v"] ?? NSNull()
+            case .error(let name, let message, let line, let col):
+                payload["ok"] = false
+                payload["error"] = message
+                var err: [String: Any] = ["name": name, "message": message]
+                if let line { err["line"] = line }
+                if let col { err["column"] = col }
+                payload["js_error"] = err
+            }
+            reply?.sendAndClose(payload)
+        }
+    }
+
     private static func cookieJSON(_ cookie: HTTPCookie) -> [String: Any] {
         var dict: [String: Any] = [
             "name": cookie.name,
@@ -4724,6 +4780,16 @@ struct AppReducer {
                         workspaceFilter: workspaceFilter,
                         name: name,
                         domain: domain,
+                        reply: reply
+                    )
+
+                case .webExec(let paneID, let target, let workspaceFilter, let script):
+                    return handleWebExec(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        script: script,
                         reply: reply
                     )
                 }

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -525,6 +525,75 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         return truncated + "\n[truncated]"
     }
 
+    /// Result of an agent-driven `web exec`. Successful evaluations
+    /// carry the JSON-encoded result (wrapped in a single-key object
+    /// so primitives like `42` or `"hello"` can round-trip through
+    /// `JSONSerialization`, which requires a top-level
+    /// array/object). Errors carry the structured WebKit exception.
+    /// Sendable so it can cross `@MainActor` back to the caller.
+    enum ExecResult {
+        case value(Data)
+        case error(name: String, message: String, lineNumber: Int?, columnNumber: Int?)
+    }
+
+    /// Evaluate arbitrary JavaScript in the given tab and return the
+    /// result. The script runs in the page's main frame at page
+    /// origin — same powers as DevTools' Console tab, scoped to the
+    /// loaded document. The returned `Data` is the JSON encoding of
+    /// `{"v": <result>}` so primitives round-trip cleanly.
+    func executeJavaScript(tabID: UUID, source: String) async -> ExecResult {
+        guard let webView = webViews[tabID] else {
+            return .error(
+                name: "PaneError",
+                message: "no WKWebView mounted for tab \(tabID.uuidString)",
+                lineNumber: nil,
+                columnNumber: nil
+            )
+        }
+        do {
+            let raw = try await webView.evaluateJavaScript(source)
+            let sanitised = Self.sanitiseExecResult(raw ?? NSNull())
+            let data = try JSONSerialization.data(
+                withJSONObject: ["v": sanitised],
+                options: [.fragmentsAllowed]
+            )
+            return .value(data)
+        } catch let error as NSError {
+            let info = error.userInfo
+            let name = (info["WKJavaScriptExceptionName"] as? String)
+                ?? error.domain
+            let message = (info["WKJavaScriptExceptionMessage"] as? String)
+                ?? error.localizedDescription
+            let line = info["WKJavaScriptExceptionLineNumber"] as? Int
+            let col = info["WKJavaScriptExceptionColumnNumber"] as? Int
+            return .error(name: name, message: message, lineNumber: line, columnNumber: col)
+        }
+    }
+
+    /// Coerce `WKWebView.evaluateJavaScript` return values to
+    /// JSON-serialisable types. WebKit hands back `String` /
+    /// `NSNumber` / `NSNull` / `[Any]` / `[String: Any]` for valid
+    /// JSON, but nested dicts can hold values keyed by non-string
+    /// keys when the JS side returns a `Map` or numeric-key object —
+    /// coerce those keys to strings here so the JSON encoder doesn't
+    /// reject the whole payload.
+    private static func sanitiseExecResult(_ value: Any) -> Any {
+        if let dict = value as? [String: Any] {
+            return dict.mapValues(sanitiseExecResult)
+        }
+        if let dict = value as? [AnyHashable: Any] {
+            var out: [String: Any] = [:]
+            for (k, v) in dict {
+                out["\(k)"] = sanitiseExecResult(v)
+            }
+            return out
+        }
+        if let array = value as? [Any] {
+            return array.map(sanitiseExecResult)
+        }
+        return value
+    }
+
     /// Capture the visible viewport as a PNG. Returns the raw bytes;
     /// callers decide whether to inline as base64 or spill to a file.
     func captureScreenshot(tabID: UUID) async -> Data? {

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -166,6 +166,13 @@ enum SocketMessage: Equatable {
         paneID: UUID?, target: String?, workspace: String?,
         name: String, domain: String?
     )
+    /// Evaluate arbitrary JavaScript in the resolved web pane's
+    /// active tab. Returns the JSON-serialised result so an agent in
+    /// another pane can click, type, scroll, or read DOM state.
+    case webExec(
+        paneID: UUID?, target: String?, workspace: String?,
+        script: String
+    )
 }
 
 /// Commands that expect a single-line JSON reply followed by EOF. For any
@@ -179,7 +186,8 @@ private let replyCommandAllowlist: Set<String> = [
     "web-forward", "web-reload", "web-capture",
     "web-tabs", "web-tab-new", "web-tab-close", "web-tab-select",
     "web-console", "web-inspect", "web-inspect-result",
-    "web-private", "web-cookies-list", "web-cookies-clear", "web-cookies-delete"
+    "web-private", "web-cookies-list", "web-cookies-clear", "web-cookies-delete",
+    "web-exec"
 ]
 
 /// Unix domain socket server that listens for structured JSON messages
@@ -626,6 +634,9 @@ final class SocketServer: Sendable {
         /// `web-cookies-clear --all` extends deletion to caches +
         /// local storage + indexed db.
         var all: Bool?
+        /// `web-exec` — JavaScript source to evaluate in the
+        /// resolved web pane's active tab.
+        var script: String?
 
         enum CodingKeys: String, CodingKey {
             case command
@@ -649,6 +660,7 @@ final class SocketServer: Sendable {
             case submit, disarm
             case isPrivate = "private"
             case domain, all
+            case script
         }
     }
 
@@ -924,6 +936,17 @@ final class SocketServer: Sendable {
                 workspace: scope.workspace,
                 name: name,
                 domain: (wire.domain?.isEmpty == true) ? nil : wire.domain
+            ), wire)
+        }
+
+        if wire.command == "web-exec" {
+            guard let scope = parseWebTarget(wire),
+                  let script = wire.script, !script.isEmpty else { return nil }
+            return (.webExec(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace,
+                script: script
             ), wire)
         }
 

--- a/NexTests/SocketParsingTests.swift
+++ b/NexTests/SocketParsingTests.swift
@@ -1086,4 +1086,38 @@ struct SocketParsingTests {
         """)
         #expect(SocketServer.parseWireMessage(data) == nil)
     }
+
+    @Test func parseWebExec() {
+        let data = jsonData("""
+        {"command":"web-exec","pane_id":"\(Self.paneIDString)","script":"document.title"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webExec(
+            paneID: Self.paneUUID, target: nil, workspace: nil, script: "document.title"
+        ))
+    }
+
+    @Test func parseWebExecByTargetWithWorkspace() {
+        let data = jsonData("""
+        {"command":"web-exec","target":"web","workspace":"Dev","script":"1 + 1"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webExec(
+            paneID: nil, target: "web", workspace: "Dev", script: "1 + 1"
+        ))
+    }
+
+    @Test func parseWebExecRequiresScript() {
+        let data = jsonData("""
+        {"command":"web-exec","pane_id":"\(Self.paneIDString)"}
+        """)
+        #expect(SocketServer.parseWireMessage(data) == nil)
+    }
+
+    @Test func parseWebExecRejectsEmptyScript() {
+        let data = jsonData("""
+        {"command":"web-exec","pane_id":"\(Self.paneIDString)","script":""}
+        """)
+        #expect(SocketServer.parseWireMessage(data) == nil)
+    }
 }

--- a/Resources/skills/nex-agentic/SKILL.md
+++ b/Resources/skills/nex-agentic/SKILL.md
@@ -236,6 +236,15 @@ nex web private on|off --target <name-or-uuid>
 nex web cookies list   --target <name-or-uuid> [--json]
 nex web cookies clear  --target <name-or-uuid> [--domain X] [--all]
 nex web cookies delete <name> --target <name-or-uuid> [--domain X]
+
+# Evaluate JavaScript in the active tab and return the JSON-serialised
+# result. Same powers as DevTools' Console tab — click selectors, fill
+# inputs, scroll, read DOM state, wait for elements, etc. Pass --file
+# instead of a positional argument for multi-line scripts. With --json,
+# the full reply (including js_error for thrown exceptions) is printed;
+# otherwise just the `result` value is printed (strings unwrapped,
+# everything else JSON-encoded). Exit non-zero on JS exception.
+nex web exec [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--file path | <js>] [--json]
 ```
 
 All `web` verbs follow the same `--target` / `--workspace`
@@ -476,6 +485,42 @@ user's real session.
 nex web open --private https://staging.example.com
 # Cookies + caches discarded on quit; tabs blank on restart.
 ```
+
+**(e) Agent-driven page interaction** — `web exec` lets the agent
+click, type, scroll, and read state without going through the
+human-driven element picker. Returns the JSON-serialised result of
+the JS expression so the agent can chain reasoning over it.
+
+```bash
+# Click a selector. Trailing `null` keeps the return JSON-clean.
+nex web exec --target <web-uuid> 'document.querySelector("a.next").click(); null'
+
+# Type into a controlled input (React/Vue need the synthetic event).
+nex web exec --target <web-uuid> '
+  const el = document.querySelector("input[name=q]");
+  el.value = "test";
+  el.dispatchEvent(new Event("input", {bubbles:true}));
+  null
+'
+
+# Wait for a selector to appear (poll from the orchestrator).
+until nex web exec --target <web-uuid> \
+  'document.querySelector("h1.loaded") ? "ok" : null' | grep -q ok
+do sleep 1
+done
+
+# Pull structured DOM state for the agent to reason over.
+nex web exec --target <web-uuid> \
+  'JSON.stringify([...document.querySelectorAll("article h2")].map(h => h.textContent))'
+
+# Multi-line scripts: load from a file.
+nex web exec --target <web-uuid> --file ./scrape.js --json
+```
+
+JS exceptions surface as a structured `js_error` (`name`, `message`,
+`line`, `column`) and the CLI exits non-zero — wrap with `||` to
+recover. The script runs at the page's origin, in the page's main
+frame, with full access to the loaded document.
 
 **Picker behaviour to design around:**
 - Arming is single-shot by default — exactly one click delivers, then

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -106,6 +106,7 @@ func printUsage() {
       nex web capture [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot]
       nex web private on|off [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web cookies list|clear|delete [...]
+      nex web exec [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--file path | <js>] [--json]
     \n
     """, stderr)
 }
@@ -773,6 +774,12 @@ func printWebUsage(stream: UnsafeMutablePointer<FILE>) {
       nex web inspect-result [--target ...] [--workspace ...] [--clear] [--json]
       nex web private    on|off [--target ...] [--workspace ...]
       nex web cookies    list|clear|delete [...]
+      nex web exec       [--target ...] [--workspace ...] [--file path | <js>] [--json]
+
+    `web exec` evaluates JavaScript in the resolved web pane's active
+    tab and prints the JSON-serialised result. Useful for agent-driven
+    interactions: click selectors, type into fields, read DOM state,
+    wait for elements, etc.
 
     When invoked from outside a Nex pane, --target must be a UUID
     or --workspace <name-or-id> must be passed (label resolution
@@ -1020,6 +1027,31 @@ func handleWeb(_ args: inout ArraySlice<String>) {
 
     case "cookies":
         handleWebCookies(&args)
+
+    case "exec":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        let asJSON = popSwitch("--json", from: &args)
+        let fromFile = parseFlag("--file", from: &args)
+        let script: String
+        if let fromFile {
+            guard let body = try? String(contentsOfFile: fromFile, encoding: .utf8) else {
+                fputs("nex web exec: cannot read --file '\(fromFile)'\n", stderr)
+                exit(1)
+            }
+            script = body
+        } else if let positional = args.popFirst(), !positional.isEmpty {
+            script = positional
+        } else {
+            fputs("Usage: nex web exec [--target X] [--workspace Y] [--file path | <js>] [--json]\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = [
+            "command": "web-exec",
+            "script": script
+        ]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "exec")
+        sendWebReplyAndPrintExec(payload, asJSON: asJSON)
 
     default:
         fputs("Unknown web action: \(action)\n", stderr)
@@ -1440,6 +1472,68 @@ private func sendWebReplyAndPrintCookiesDelete(_ payload: [String: Any]) {
         exit(1)
     }
     print("deleted \(deleted) cookie\(deleted == 1 ? "" : "s") named '\(name)'")
+}
+
+private func sendWebReplyAndPrintExec(_ payload: [String: Any], asJSON: Bool) {
+    // Use the raw reply rather than readWebReplyOrExit — exec replies
+    // can have `ok: false` with a structured js_error payload that
+    // callers usually want to see, not just an `error` string.
+    guard let data = sendJSONAndReadReply(payload) else {
+        fputs("nex web exec: transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    guard !data.isEmpty else {
+        fputs("nex web exec: no response from Nex (upgrade required?)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        fputs("nex web exec: invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if asJSON {
+        if let out = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]),
+           let s = String(data: out, encoding: .utf8) {
+            print(s)
+        }
+        let ok = (json["ok"] as? Bool) ?? false
+        exit(ok ? 0 : 1)
+    }
+    let ok = (json["ok"] as? Bool) ?? false
+    if ok {
+        // Pretty-print the result. Strings come back as-is so a script
+        // returning `"hello"` prints `hello`. Anything structured
+        // (object, array, number, bool, null) round-trips through JSON.
+        if let result = json["result"] {
+            if let str = result as? String {
+                print(str)
+            } else if result is NSNull {
+                print("null")
+            } else if let out = try? JSONSerialization.data(
+                withJSONObject: result, options: [.sortedKeys]
+            ), let s = String(data: out, encoding: .utf8) {
+                print(s)
+            } else {
+                print(String(describing: result))
+            }
+        }
+        exit(0)
+    } else {
+        if let jsErr = json["js_error"] as? [String: Any] {
+            let name = (jsErr["name"] as? String) ?? "Error"
+            let message = (jsErr["message"] as? String) ?? "unknown"
+            let line = jsErr["line"] as? Int
+            let col = jsErr["column"] as? Int
+            var loc = ""
+            if let line {
+                loc = col.map { " (\(line):\($0))" } ?? " (line \(line))"
+            }
+            fputs("nex web exec: \(name): \(message)\(loc)\n", stderr)
+        } else {
+            let msg = (json["error"] as? String) ?? "unknown error"
+            fputs("nex web exec: \(msg)\n", stderr)
+        }
+        exit(1)
+    }
 }
 
 // MARK: - pane list


### PR DESCRIPTION
## Summary

Adds `nex web exec`, the agent-side counterpart to the human-driven element picker. From another pane, an agent can click selectors, fill inputs, scroll, read DOM state, and wait for elements — same powers as DevTools' Console tab, exposed over the CLI as a single verb.

> **Stacked on #147.** Base is `feat/web-pane-phase-1` because the change depends on the web pane infrastructure shipped in #147. GitHub will rebase this onto `main` automatically once #147 merges. Review #147 first.

## What's in it

- `WebPaneCoordinator.executeJavaScript(tabID:, source:)` — wraps `WKWebView.evaluateJavaScript` and returns a `Sendable` `ExecResult` enum (`.value(Data)` JSON-encoded inside a `{"v": ...}` envelope so primitives round-trip / `.error(name, message, line, column)` carrying the WebKit exception fields).
- Wire command `web-exec` (reply-allowlisted), payload `{script}` plus the standard `pane_id` / `target` / `workspace` scoping.
- `AppReducer.handleWebExec` unwraps the envelope and emits `{ok, result, pane_id, workspace_id, tab_id}` on success or `{ok:false, error, js_error:{name, message, line, column}}` on a thrown JS exception.
- CLI `nex web exec [--target X] [--workspace Y] [--file path | <js>] [--json]`. Strings printed unwrapped (`nex web exec '"hello"'` → `hello`), `null` printed as `null`, structures JSON-encoded with sorted keys. `--file` for multi-line scripts. Non-zero exit on JS exception with a `Name: message (line:col)` stderr line.
- Bundled `nex-agentic` skill gets the new verb in the command reference and a fifth example under Pattern 4.

## Reviewer notes

- `ExecResult.value(Data)` wraps the JS return in `{"v": <result>}` because `JSONSerialization.data(withJSONObject:)` rejects bare primitives without `.fragmentsAllowed`. The wrapper lets primitives + structured values share one path.
- `sanitiseExecResult` coerces `[AnyHashable: Any]` (which `WKWebView.evaluateJavaScript` can return for JS `Map` / numeric-key objects) into `[String: Any]` so `JSONSerialization` doesn't reject the whole payload.
- The script runs at the page's origin in the main frame. Same powers as Console — sandboxed by the page's CSP, full access to the loaded document.
- No timeout enforced; long-running JS hangs the WebView's main thread. Worth following up with a `--timeout` flag if it bites; not in scope here.

## Test plan

Automated:
- [x] `xcodegen generate --spec project.yml`
- [x] `xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation build`
- [x] `xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation test` — 888 tests pass (4 new wire-parsing assertions in `SocketParsingTests`)
- [x] `swiftlint lint && swiftformat --lint .` — clean

Manual (after merge):
- [ ] `nex web open https://example.com` → grab the returned UUID
- [ ] `nex web exec --target <uuid> 'document.title'` → prints the page title
- [ ] `nex web exec --target <uuid> 'document.querySelector("a").click(); null'` → first link is navigated
- [ ] `nex web exec --target <uuid> 'throw new Error("boom")'` → exits non-zero with `Error: boom (line:col)` on stderr
- [ ] `until nex web exec --target <uuid> 'document.querySelector("h1.loaded") ? "ok" : null' | grep -q ok; do sleep 1; done` → polls until ready
- [ ] `nex web exec --target <uuid> --file ./scrape.js --json` → multi-line script via file, full JSON reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)