### PR TITLE
Web pane: nex web navigate verb + guard web open against silent --target footgun

### DIFF
--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -1559,6 +1559,31 @@ struct AppReducer {
         }
     }
 
+    func handleWebNavigate(
+        state: State,
+        scope: WebPaneScope,
+        url: String,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        guard let resolved = resolveWebPane(state: state, scope: scope, reply: reply)
+        else { return .none }
+        guard resolved.webState.activeTab != nil else {
+            reply?.error("web pane has no active tab")
+            return .none
+        }
+        let normalized = WebPaneCoordinator.normalizeURLInput(url)
+        reply?.sendAndClose([
+            "ok": true,
+            "pane_id": resolved.paneID.uuidString,
+            "workspace_id": resolved.workspace.id.uuidString,
+            "url": normalized
+        ])
+        return .send(.workspaces(.element(
+            id: resolved.workspace.id,
+            action: .webPaneNavigate(paneID: resolved.paneID, url: url)
+        )))
+    }
+
     func handleWebURL(
         state: State,
         scope: WebPaneScope,
@@ -4810,6 +4835,14 @@ struct AppReducer {
                         paneID: paneID,
                         url: url,
                         isPrivate: isPrivate,
+                        reply: reply
+                    )
+
+                case .webNavigate(let paneID, let target, let workspaceFilter, let url):
+                    return handleWebNavigate(
+                        state: state,
+                        scope: WebPaneScope(paneID: paneID, target: target, workspaceFilter: workspaceFilter),
+                        url: url,
                         reply: reply
                     )
 

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -93,6 +93,10 @@ enum SocketMessage: Equatable {
     /// `NEX_PANE_ID`) is informational; opening always creates a new
     /// pane in the active workspace, mirroring `nex diff`.
     case webOpen(paneID: UUID?, url: String, isPrivate: Bool)
+    /// Navigate the active tab of the resolved web pane to `url`.
+    /// Companion to `webOpen` for the "reuse an existing pane" case;
+    /// for "new tab" callers use `webTabNew` instead.
+    case webNavigate(paneID: UUID?, target: String?, workspace: String?, url: String)
     /// Read the active tab's current URL + title for the resolved pane.
     case webURL(paneID: UUID?, target: String?, workspace: String?)
     case webBack(paneID: UUID?, target: String?, workspace: String?)
@@ -276,7 +280,7 @@ enum SocketMessage: Equatable {
 private let replyCommandAllowlist: Set<String> = [
     "pane-list", "pane-close", "pane-capture", "pane-send", "pane-send-key",
     "graft-start", "graft-stop", "graft-status",
-    "web-open", "web-url", "web-back",
+    "web-open", "web-navigate", "web-url", "web-back",
     "web-forward", "web-reload", "web-capture",
     "web-tabs", "web-tab-new", "web-tab-close", "web-tab-select",
     "web-console", "web-inspect", "web-inspect-result",
@@ -938,6 +942,17 @@ final class SocketServer: Sendable {
             guard let url = wire.url, !url.isEmpty else { return nil }
             let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
             return (.webOpen(paneID: paneID, url: url, isPrivate: wire.isPrivate ?? false), wire)
+        }
+
+        if wire.command == "web-navigate" {
+            guard let scope = parseWebTarget(wire),
+                  let url = wire.url, !url.isEmpty else { return nil }
+            return (.webNavigate(
+                paneID: scope.paneID,
+                target: scope.target,
+                workspace: scope.workspace,
+                url: url
+            ), wire)
         }
 
         if wire.command == "web-url" {

--- a/NexTests/SocketParsingTests.swift
+++ b/NexTests/SocketParsingTests.swift
@@ -1013,6 +1013,40 @@ struct SocketParsingTests {
         ))
     }
 
+    @Test func parseWebNavigateByTargetLabel() {
+        let data = jsonData("""
+        {"command":"web-navigate","target":"web","workspace":"Dev","url":"https://example.com"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webNavigate(
+            paneID: nil, target: "web", workspace: "Dev", url: "https://example.com"
+        ))
+    }
+
+    @Test func parseWebNavigateByPaneID() {
+        let data = jsonData("""
+        {"command":"web-navigate","pane_id":"\(Self.paneIDString)","url":"https://example.com/path"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webNavigate(
+            paneID: Self.paneUUID, target: nil, workspace: nil, url: "https://example.com/path"
+        ))
+    }
+
+    @Test func parseWebNavigateRequiresURL() {
+        let data = jsonData("""
+        {"command":"web-navigate","pane_id":"\(Self.paneIDString)"}
+        """)
+        #expect(SocketServer.parseWireMessage(data) == nil)
+    }
+
+    @Test func parseWebNavigateRejectsEmptyURL() {
+        let data = jsonData("""
+        {"command":"web-navigate","pane_id":"\(Self.paneIDString)","url":""}
+        """)
+        #expect(SocketServer.parseWireMessage(data) == nil)
+    }
+
     @Test func parseWebPrivateOn() {
         let data = jsonData("""
         {"command":"web-private","pane_id":"\(Self.paneIDString)","private":true}

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -102,6 +102,7 @@ func printUsage() {
       nex graft stop [--workspace <name-or-uuid>] [--repo <name-or-path>]
       nex graft status [--json]
       nex web open [--private] <url>
+      nex web navigate <url> [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web url|back|forward|reload [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--hard]
       nex web capture [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot]
       nex web private on|off [--target <name-or-uuid>] [--workspace <name-or-uuid>]
@@ -802,8 +803,9 @@ func handlePane(_ args: inout ArraySlice<String>) {
 func printWebUsage(stream: UnsafeMutablePointer<FILE>) {
     fputs("""
     Usage:
-      nex web open [--private] <url>
-      nex web url      [--target <name-or-uuid>] [--workspace <name-or-uuid>]
+      nex web open      [--private] <url>
+      nex web navigate  [--target <name-or-uuid>] [--workspace <name-or-uuid>] <url>
+      nex web url       [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web back     [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web forward  [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web reload   [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--hard]
@@ -903,8 +905,18 @@ func handleWeb(_ args: inout ArraySlice<String>) {
     switch action {
     case "open":
         let isPrivate = popSwitch("--private", from: &args)
+        if args.contains("--target") || args.contains("--workspace") {
+            fputs("nex web open: --target / --workspace are not supported (open always creates a new pane).\n", stderr)
+            fputs("       Use `nex web navigate <url> --target X [--workspace Y]` to redirect an existing pane's active tab,\n", stderr)
+            fputs("       or `nex web tab-new <url> --target X` to open in a new tab.\n", stderr)
+            exit(1)
+        }
         guard let url = args.popFirst(), !url.isEmpty else {
             fputs("Usage: nex web open [--private] <url>\n", stderr)
+            exit(1)
+        }
+        if url.hasPrefix("-") {
+            fputs("nex web open: unexpected option '\(url)' (URL must not start with '-')\n", stderr)
             exit(1)
         }
         var payload: [String: Any] = [
@@ -919,6 +931,24 @@ func handleWeb(_ args: inout ArraySlice<String>) {
             payload["pane_id"] = originPaneID
         }
         sendWebReplyAndPrintBasic(payload, command: "open")
+
+    case "navigate":
+        let target = parseFlag("--target", from: &args)
+        let workspace = parseFlag("--workspace", from: &args)
+        guard let url = args.popFirst(), !url.isEmpty else {
+            fputs("Usage: nex web navigate <url> [--target <name-or-uuid>] [--workspace <name-or-uuid>]\n", stderr)
+            exit(1)
+        }
+        if url.hasPrefix("-") {
+            fputs("nex web navigate: unexpected option '\(url)' (URL must not start with '-')\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = [
+            "command": "web-navigate",
+            "url": url
+        ]
+        attachWebTargetScope(&payload, target: target, workspace: workspace, command: "navigate")
+        sendWebReplyAndPrintBasic(payload, command: "navigate")
 
     case "url":
         let target = parseFlag("--target", from: &args)


### PR DESCRIPTION
## Summary
- `nex web open --target X <url>` silently treated `--target` as the URL, opening a brand-new pane at `http://--target`. Tightens `open` to reject `--target` / `--workspace` with a usage error and rejects URLs starting with `-`.
- Adds `nex web navigate <url> [--target X] [--workspace Y]` — first-class in-place navigate verb that swaps the active tab's URL on an existing pane via the existing `webPaneNavigate` action. Removes the need to fall back to `nex web exec` + `window.location.href`.
- Keeps `web open` strictly about creating new panes (mirrors `nex diff`); `web tab-new <url> --target X` remains the path for "open in a new tab."

## Wire / reducer
- New `SocketMessage.webNavigate(paneID:target:workspace:url:)`, added to `replyCommandAllowlist`, parser branch in `SocketServer.parseWireMessage`.
- New `handleWebNavigate` in `AppReducer` resolves the web pane, replies with `pane_id` / `workspace_id` / normalized `url`, then dispatches `.webPaneNavigate` on the resolved workspace.
- NEX_PANE_ID / `--workspace` scope rules from issue #92 apply unchanged (reused `attachWebTargetScope`).

## Test plan
- [x] `xcodebuild ... -only-testing:NexTests/SocketParsingTests test` — 149 parsing tests pass, including 4 new `web-navigate` cases (label, pane-id, missing url, empty url).
- [x] Full `xcodebuild ... test` — 1024 tests pass.
- [x] `swiftformat --lint` and `swiftlint` clean on changed files.
- [x] Manual CLI sanity (compiled standalone):
  - `nex web open --target foo https://example.com` → rejects with pointer at `navigate` (exit 1)
  - `nex web open --workspace Dev https://example.com` → rejects (exit 1)
  - `nex web open` → usage (exit 1)
  - `nex web navigate` → usage (exit 1)
- [x] In the running app: open a web pane, then from another terminal run `nex web navigate https://example.org --target web` and confirm the active tab swaps URL in place.
- [x] Confirm `nex web tab-new https://example.org --target web` still opens a new tab unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)