### PR TITLE
docs(nex-agentic): document `nex web navigate` and `web open` --target guard

### DIFF
--- a/Resources/skills/nex-agentic/SKILL.md
+++ b/Resources/skills/nex-agentic/SKILL.md
@@ -207,8 +207,13 @@ lowest layer that solves your problem; `exec` is the escape hatch.
 #### Infrastructure (pane + tabs + capture + cookies)
 
 ```bash
-# Create a new web pane in the active workspace
+# Create a new web pane in the active workspace.
+# `web open` always creates a NEW pane; --target / --workspace are rejected.
+# Use `web navigate` to redirect an existing pane, or `web tab-new` for a new tab.
 nex web open [--private] <url>
+
+# Redirect the active tab of an existing web pane to <url>
+nex web navigate <url> [--target <name-or-uuid>] [--workspace <name-or-uuid>]
 
 # Read the active tab's URL + title
 nex web url --target <name-or-uuid> [--workspace <name-or-uuid>]


### PR DESCRIPTION
## Summary

Docs follow-up to #150. Surfaces the new `nex web navigate` verb in the agentic skill and notes that `nex web open` always creates a new pane (rejects `--target`/`--workspace`), pointing the reader at `web navigate` for in-place redirects and `web tab-new` for new-tab opens.

## Test plan

- [ ] Pure docs change; no code paths touched. Render the SKILL.md section "Infrastructure (pane + tabs + capture + cookies)" and confirm the new lines for `web open` and `web navigate` read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)