### PR TITLE
fix(web pane): auto-focus URL bar when opening a blank new tab

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1569F35B72EC7C133643190E /* PaneType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377C07C6C4B00D0699682EA3 /* PaneType.swift */; };
 		1E6354C9BBDF122BF0FB255F /* WorktreeOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CBC99B6D8094F73CDFBD80 /* WorktreeOperationTests.swift */; };
 		2061570DEABB0E43847DBB5D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A198A2F5EA992907A3031ED /* ContentView.swift */; };
+		21BAC97B61C9367EADD1315A /* WebTabNewFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52ED6952E87B8F73B2450D7 /* WebTabNewFocusTests.swift */; };
 		2364A5458060B16493954543 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 281D0362CA8542610B8329F6 /* Metal.framework */; };
 		2522628FFD6A46B52CE2D490 /* GraftService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E79DA6455C6FF3D2124CBA9 /* GraftService.swift */; };
 		27D6386295651D4FE9A3DF6B /* Pane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D96CD47FF756C95404DF4F6 /* Pane.swift */; };
@@ -330,6 +331,7 @@
 		E0625B2E7935BDDF63DC5D19 /* RingBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBufferTests.swift; sourceTree = "<group>"; };
 		E08D39F8F87D7505CD32D25D /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		E3F9EB3CC6EA8ED5CEE1F156 /* WebPaneExecWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneExecWrapper.swift; sourceTree = "<group>"; };
+		E52ED6952E87B8F73B2450D7 /* WebTabNewFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebTabNewFocusTests.swift; sourceTree = "<group>"; };
 		E5859C5B2E1850D1262AFE4B /* Nex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nex.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5A4C5D8F4C099C65A7EA890 /* ScratchpadEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadEditorView.swift; sourceTree = "<group>"; };
 		E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowSpacesBinding.swift; sourceTree = "<group>"; };
@@ -476,6 +478,7 @@
 				12DB8491263633C87CA73D00 /* WebPaneActuatorWaitTests.swift */,
 				310A7BC6CBE6160568122935 /* WebPaneExecWrapperTests.swift */,
 				06845D1AC00D409504EDAB61 /* WebPaneURLNormalisationTests.swift */,
+				E52ED6952E87B8F73B2450D7 /* WebTabNewFocusTests.swift */,
 				94D09D767C96B3F96E4DF7C5 /* WindowSpacesBindingTests.swift */,
 				28D977DB42ACD0B176225711 /* WorkspaceColorSelectionTests.swift */,
 				E01C66D4D59D04F6372D8AD7 /* WorkspaceDropTargetTests.swift */,
@@ -884,6 +887,7 @@
 				B0FA5E756635F6DFC402CD7C /* WebPaneActuatorWaitTests.swift in Sources */,
 				2AB792CA68A7B12D55C2F834 /* WebPaneExecWrapperTests.swift in Sources */,
 				53AD8B876DA9611918F5F585 /* WebPaneURLNormalisationTests.swift in Sources */,
+				21BAC97B61C9367EADD1315A /* WebTabNewFocusTests.swift in Sources */,
 				DDD05A3B3A535DEA66485A47 /* WindowSpacesBindingTests.swift in Sources */,
 				5C4AA6204D49398B2E63A18B /* WorkspaceColorSelectionTests.swift in Sources */,
 				F01CDB667AE2A0CF2A825AD3 /* WorkspaceDropTargetTests.swift in Sources */,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -3990,6 +3990,12 @@ struct AppReducer {
             case .webPaneOpenNewTab(let paneID, let url):
                 guard let workspace = state.workspaceContainingPane(paneID) else { return .none }
                 let newTabID = uuid()
+                // Blank new tab → auto-focus the URL bar so the user can
+                // type a URL immediately. A tab opened with a preset URL
+                // is loading content, so leave focus to the WKWebView.
+                if url?.isEmpty ?? true {
+                    state.webPaneURLFocusTokens[paneID, default: 0] &+= 1
+                }
                 return .send(.workspaces(.element(
                     id: workspace.id,
                     action: .webPaneTabOpen(

--- a/NexTests/WebTabNewFocusTests.swift
+++ b/NexTests/WebTabNewFocusTests.swift
@@ -1,0 +1,79 @@
+import Clocks
+import ComposableArchitecture
+import Foundation
+@testable import Nex
+import Testing
+
+/// Issue #153: opening a blank new tab in a web pane should bump
+/// `webPaneURLFocusTokens[paneID]` so the URL bar gets first
+/// responder. A new tab opened with a preset URL is loading content,
+/// so focus stays with the WKWebView — the token is unchanged.
+@MainActor
+struct WebTabNewFocusTests {
+    private static let wsID = UUID(uuidString: "90000000-0000-0000-0000-000000000001")!
+    private static let paneID = UUID(uuidString: "00000000-0000-0000-0000-00000000C001")!
+
+    private func makeStore() -> TestStoreOf<AppReducer> {
+        let pane = Pane(id: Self.paneID, type: .web)
+        let workspace = WorkspaceFeature.State(
+            id: Self.wsID, name: "alpha", slug: "alpha", color: .blue,
+            panes: [pane],
+            layout: .leaf(Self.paneID),
+            focusedPaneID: Self.paneID,
+            createdAt: Date(timeIntervalSince1970: 1000),
+            lastAccessedAt: Date(timeIntervalSince1970: 1000),
+            webPanes: [
+                Self.paneID: WebPaneState(
+                    tabs: [WebTab(id: UUID(), url: "https://example.com")],
+                    activeTabID: nil,
+                    isPrivate: false
+                )
+            ]
+        )
+
+        var appState = AppReducer.State()
+        appState.workspaces = [workspace]
+        appState.activeWorkspaceID = Self.wsID
+        appState.topLevelOrder = [.workspace(Self.wsID)]
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+        return store
+    }
+
+    @Test func blankNewTabBumpsURLFocusToken() async {
+        let store = makeStore()
+        #expect(store.state.webPaneURLFocusTokens[Self.paneID] == nil)
+
+        await store.send(.webPaneOpenNewTab(paneID: Self.paneID, url: nil)) {
+            $0.webPaneURLFocusTokens[Self.paneID] = 1
+        }
+    }
+
+    @Test func emptyStringURLAlsoBumpsToken() async {
+        let store = makeStore()
+
+        await store.send(.webPaneOpenNewTab(paneID: Self.paneID, url: "")) {
+            $0.webPaneURLFocusTokens[Self.paneID] = 1
+        }
+    }
+
+    @Test func preloadedURLDoesNotBumpToken() async {
+        let store = makeStore()
+
+        await store.send(
+            .webPaneOpenNewTab(paneID: Self.paneID, url: "https://example.com")
+        )
+        // Token stays nil — the WKWebView gets focus once the page loads.
+        #expect(store.state.webPaneURLFocusTokens[Self.paneID] == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Bump `webPaneURLFocusTokens[paneID]` when `.webPaneOpenNewTab` opens a blank tab (`url == nil || url.isEmpty`), reusing the same focus-token plumbing that drives ⌘L → URL bar focus.
- Tabs opened with a preset URL (the page is loading) intentionally leave focus on the WKWebView.
- CLI path (`handleWebTabNew` / `nex web tab-new`) intentionally untouched: silent first-responder steals would be a footgun for scripted automation.

Closes #153

## Reviewer notes
- Skipped: defensive whitespace-only URL handling. No caller produces a whitespace URL today and `WebPaneCoordinator.normalizeURLInput` already trims to `""`, so it'd be redundancy without an observable win.
- Skipped: applying the same focus behaviour to the brand-new-pane case (`.openWebPane`). Out of scope per the issue body; would also need a tweak to `WebPaneHost.makeNSView` to avoid the WKWebView stealing focus on first mount.

## Validation
- Validated in a sandboxed macOS VM via cua/lume (vm `hollow-ferret`).
- Assertions:
  - `nex web open https://example.com` → page loads, 1 tab.
  - ⌘T → 2 tabs in pane.
  - Typing `https://example.org` + Enter → URL bar received the keystrokes, navigated to example.org (the killer assertion — proves URL bar got focus).
- Screenshots: `/Users/ben/code/cua/out/branches/issue-153-new-tab-focus-url/issue-153/`

## Test plan
- [x] Open a web pane, press ⌘T, immediately start typing → URL bar accepts input without an extra click.
- [x] Repeat ⌘T multiple times in the same web pane → URL bar re-focuses each time.
- [x] Run `nex web tab-new https://example.com --target <web-pane>` → URL bar should NOT auto-focus for preset URLs (focus stays with the WKWebView).
- [x] ⌘L on an existing tab still focuses + select-alls the URL bar (regression check on the shared token mechanism).
- [x] Switching between tabs with ⌘⇧[ / ⌘⇧] still works, URL bar shows the tab's URL.