### PR TITLE
fix(web pane): URL bar updates when switching tabs while focused (#151)

### DIFF
--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -437,19 +437,36 @@ struct WebURLField: NSViewRepresentable {
         field.delegate = context.coordinator
         context.coordinator.field = field
         context.coordinator.lastSeenToken = focusRequestToken
-        context.coordinator.lastSeenURL = initialURL
+        context.coordinator.lastWrittenURL = initialURL
         return field
     }
 
     func updateNSView(_ field: NSTextField, context: Context) {
         let coord = context.coordinator
         // Only overwrite the URL bar when the underlying URL actually
-        // changes and the user isn't actively editing — otherwise the
+        // changes and the user isn't actively typing — otherwise the
         // user's in-progress typing would be wiped on every render.
-        if coord.lastSeenURL != initialURL,
-           field.window?.firstResponder !== field.currentEditor() {
-            field.stringValue = initialURL
-            coord.lastSeenURL = initialURL
+        // "Actively typing" requires BOTH focus AND a divergence from
+        // what we last wrote; focus alone isn't enough (⌘L and click
+        // focus without typing, and tab switches must still update the
+        // bar even while the field is focused).
+        if coord.lastWrittenURL != initialURL {
+            let isFocused = field.window?.firstResponder === field.currentEditor()
+            let userIsEditing = isFocused && field.stringValue != coord.lastWrittenURL
+            if userIsEditing {
+                // Stash the pending URL; apply on blur in
+                // controlTextDidEndEditing so the user doesn't wind
+                // up staring at a stale draft after abandoning the edit.
+                coord.pendingURL = initialURL
+            } else {
+                field.stringValue = initialURL
+                coord.lastWrittenURL = initialURL
+                coord.pendingURL = nil
+            }
+        } else {
+            // The active URL matches what we last wrote; any stored
+            // pending update is moot.
+            coord.pendingURL = nil
         }
         if coord.lastSeenToken != focusRequestToken {
             coord.lastSeenToken = focusRequestToken
@@ -465,7 +482,16 @@ struct WebURLField: NSViewRepresentable {
         let onSubmit: (String) -> Void
         weak var field: NSTextField?
         var lastSeenToken: UInt64 = 0
-        var lastSeenURL: String = ""
+        /// Last URL we wrote into the field's `stringValue`. Tracks
+        /// our writes, not SwiftUI's intent — so when `updateNSView`
+        /// skips because the user is editing, this stays at the
+        /// pre-skip value (and `pendingURL` carries the intent forward).
+        var lastWrittenURL: String = ""
+        /// URL change that arrived while the user was editing.
+        /// Applied on blur (`controlTextDidEndEditing`) so a tab
+        /// switch or background navigation eventually shows up
+        /// instead of the user's abandoned draft.
+        var pendingURL: String?
 
         init(onSubmit: @escaping (String) -> Void) {
             self.onSubmit = onSubmit
@@ -474,11 +500,23 @@ struct WebURLField: NSViewRepresentable {
         func control(_: NSControl, textView _: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
                 if let value = field?.stringValue {
+                    // The user submitted their own URL; whatever was
+                    // pending from a tab switch is now irrelevant —
+                    // the navigation they just triggered will surface
+                    // the canonical URL via stateDidChange.
+                    pendingURL = nil
                     onSubmit(value)
                 }
                 return true
             }
             return false
+        }
+
+        func controlTextDidEndEditing(_: Notification) {
+            guard let field, let pending = pendingURL else { return }
+            field.stringValue = pending
+            lastWrittenURL = pending
+            pendingURL = nil
         }
     }
 }


### PR DESCRIPTION
## Summary

- `WebURLField.updateNSView` was skipping URL writes whenever the field had first-responder focus, treating focus alone as proof of in-flight typing. That left the URL bar showing the previous tab's URL after ⌘L (or any click into the field) + a tab switch.
- Tighten the guard so it only protects in-progress typing: skip only when the field is focused AND its `stringValue` has diverged from the last URL we wrote. ⌘L / click focus without typing now applies the new URL on tab switch.
- For genuine mid-edit tab switches, stash the incoming URL in `Coordinator.pendingURL` and apply it via `controlTextDidEndEditing` so the bar can't get stuck on an abandoned draft.
- Rename `lastSeenURL` → `lastWrittenURL` to match the new semantics (tracks what we wrote, not what SwiftUI most recently passed in).

Closes #151

## Reviewer notes

Skipped from the parallel review:

- **Add a focused-XCTest around the URL-field update decision** (Codex should-fix). The existing reducer-level `WebTabNewFocusTests` doesn't drive `WebURLField`, and standing up an NSTextField + window + first-responder harness for a single 8-line guard would dwarf the fix. The cua VM validator (`/Users/ben/code/cua/validate_issue_151.py`) provides the equivalent integration coverage by driving the bug repro end-to-end.
- **Explicit dirty flag via `controlTextDidChange`** (Codex nice-to-have). The value-based heuristic (`stringValue != lastWrittenURL`) only mismatches reality if the user types and undoes back to the exact original URL — a tiny corner case, not worth the extra state.

## Validation

Validated in a sandboxed macOS VM via cua/lume.

Per-issue assertions in `validate_issue_151.py`:

- Open Nex with one default pane, open a web pane on https://example.com (tab 1).
- `nex web tab-new https://www.iana.org/help/example-domains --target <web-pane>` (tab 2 becomes active).
- Activate Nex, click the URL bar region, send ⌘L (focus the URL bar).
- `nex web tab-select <tab1-id> --target <web-pane>`.
- Assert: `nex web url --target <web-pane>` returns https://example.com/ (reducer regression check).
- Assert: the web pane survives the operation.

Screenshots at `/Users/ben/code/cua/out/branches/issue-151-tab-switch-url-bar/issue-151/` (00 before → 04 after tab switch). The focus-sequence screenshots (03/04) happened to land while the Notification Center was over the Nex window, so the conclusive visual diff was performed manually via VNC in the keep-alive VM.

## Test plan

- [x] Build locally: `xcodegen generate --spec project.yml && xcodebuild -scheme Nex -destination 'platform=macOS' -skipMacroValidation build`
- [x] Open a web pane on URL A, ⌘T a second tab on URL B.
- [x] ⌘L to focus the URL bar without typing; click the first tab pill. URL bar must show URL A.
- [x] ⌘L again, type a partial URL (don't submit), click the other tab pill. URL bar keeps your draft (intentional — typing is in-flight).
- [x] Continue from above: click somewhere on the page (defocus the URL bar). URL bar must reconcile to the active tab's URL.
- [x] ⌘L, type a URL, hit Enter. URL bar follows the navigation as usual.
- [x] Regression: open a single-tab web pane, watch in-tab navigation (click links). URL bar updates with each navigation as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)