### PR TITLE
fix(repo picker): explicit confirm + checkbox-style multi-select (#144)

### DIFF
--- a/Nex/Features/RepoRegistry/RepoPickerView.swift
+++ b/Nex/Features/RepoRegistry/RepoPickerView.swift
@@ -125,7 +125,14 @@ struct RepoPickerView: View {
         .contentShape(Rectangle())
         .opacity(isAlready ? 0.5 : 1.0)
         .onTapGesture {
-            if !isAlready { onSelect(repo) }
+            guard !isAlready else { return }
+            // The click moves focus into the list, which makes
+            // `isHighlighted` true for whichever row matches
+            // `highlightedRepoID`. Without updating it here, the
+            // initial value (first row) is highlighted just before
+            // the sheet dismisses, not the clicked row (#144).
+            highlightedRepoID = repo.id
+            onSelect(repo)
         }
     }
 

--- a/Nex/Features/RepoRegistry/RepoPickerView.swift
+++ b/Nex/Features/RepoRegistry/RepoPickerView.swift
@@ -1,30 +1,64 @@
 import ComposableArchitecture
 import SwiftUI
 
-/// Fuzzy search picker for selecting a repo from the global registry.
+/// Fuzzy search picker for selecting one or more repos from the
+/// global registry. Selection is decoupled from confirmation: clicks
+/// build a selection, an explicit Confirm button (Return) commits it.
+///
+/// `.multiple` mode behaves like a checkbox list — each click toggles
+/// the row's selection independently. Shift-click extends from the
+/// anchor without dropping the previous selection.
+///   - plain click   : toggle the clicked row in/out of the selection
+///   - shift-click   : add the range from the anchor to the clicked row
+///   - double-click  : select only this row and confirm immediately
+///
+/// `.single` mode keeps the standard radio-button behaviour: each
+/// click replaces the selection with the clicked row.
 struct RepoPickerView: View {
-    /// Focusable controls in tab order. The repo list is a single Tab stop:
-    /// once focused, Up/Down arrows move the highlight and Return/Space
-    /// selects. This keeps Tab predictable regardless of list length and the
-    /// macOS "Keyboard navigation" system setting (#64).
+    enum SelectionMode: Hashable {
+        case single
+        case multiple
+    }
+
     private enum Field: Hashable {
         case search
         case list
         case cancel
+        case confirm
     }
 
     let repos: IdentifiedArrayOf<Repo>
     let alreadyAssociatedRepoIDs: Set<UUID>
-    let onSelect: (Repo) -> Void
+    let selectionMode: SelectionMode
+    let confirmLabel: String
+    let onConfirm: ([Repo]) -> Void
     let onCancel: () -> Void
 
+    init(
+        repos: IdentifiedArrayOf<Repo>,
+        alreadyAssociatedRepoIDs: Set<UUID>,
+        selectionMode: SelectionMode = .single,
+        confirmLabel: String = "Add",
+        onConfirm: @escaping ([Repo]) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.repos = repos
+        self.alreadyAssociatedRepoIDs = alreadyAssociatedRepoIDs
+        self.selectionMode = selectionMode
+        self.confirmLabel = confirmLabel
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+    }
+
     @State private var searchText = ""
-    @State private var highlightedRepoID: UUID?
+    @State private var selectedRepoIDs: Set<UUID> = []
+    /// Last interacted-with row. Drives keyboard nav and shift-click ranges.
+    @State private var anchorRepoID: UUID?
     @FocusState private var focusedField: Field?
 
     var body: some View {
         VStack(spacing: 12) {
-            Text("Add Repository")
+            Text(selectionMode == .multiple ? "Add Repositories" : "Add Repository")
                 .font(.headline)
 
             TextField("Search repos...", text: $searchText)
@@ -32,9 +66,9 @@ struct RepoPickerView: View {
                 .focused($focusedField, equals: .search)
                 .onKeyPress(keys: [.tab]) { handleTab($0) }
                 .onChange(of: searchText) { _, _ in
-                    clampHighlight()
+                    clampAnchor()
                 }
-                .onSubmit { _ = selectHighlighted() }
+                .onSubmit { _ = confirmIfPossible() }
 
             if filteredRepos.isEmpty {
                 VStack(spacing: 4) {
@@ -55,14 +89,19 @@ struct RepoPickerView: View {
                     .focused($focusedField, equals: .cancel)
                     .onKeyPress(keys: [.tab]) { handleTab($0) }
                 Spacer()
+                Button(confirmLabel) { _ = confirmIfPossible() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canConfirm)
+                    .focused($focusedField, equals: .confirm)
+                    .onKeyPress(keys: [.tab]) { handleTab($0) }
             }
         }
         .padding(16)
-        .frame(width: 360, height: 300)
+        .frame(width: 360, height: 340)
         .onAppear {
             DispatchQueue.main.async {
                 focusedField = .search
-                highlightedRepoID = filteredRepos.first?.id
+                anchorRepoID = firstSelectableID
             }
         }
     }
@@ -86,10 +125,10 @@ struct RepoPickerView: View {
             .clipShape(RoundedRectangle(cornerRadius: 6))
             .focusable()
             .focused($focusedField, equals: .list)
-            .onKeyPress(.upArrow) { moveHighlight(by: -1, proxy: proxy) }
-            .onKeyPress(.downArrow) { moveHighlight(by: 1, proxy: proxy) }
-            .onKeyPress(.return) { selectHighlighted() }
-            .onKeyPress(.space) { selectHighlighted() }
+            .onKeyPress(keys: [.upArrow]) { handleArrow($0, delta: -1, proxy: proxy) }
+            .onKeyPress(keys: [.downArrow]) { handleArrow($0, delta: 1, proxy: proxy) }
+            .onKeyPress(.return) { confirmIfPossible() }
+            .onKeyPress(.space) { toggleAnchor() }
             .onKeyPress(keys: [.tab]) { handleTab($0) }
         }
     }
@@ -97,8 +136,14 @@ struct RepoPickerView: View {
     @ViewBuilder
     private func row(for repo: Repo) -> some View {
         let isAlready = alreadyAssociatedRepoIDs.contains(repo.id)
-        let isHighlighted = focusedField == .list && highlightedRepoID == repo.id
-        HStack {
+        let isSelected = selectedRepoIDs.contains(repo.id)
+        let isAnchor = anchorRepoID == repo.id && focusedField == .list
+        HStack(spacing: 6) {
+            if selectionMode == .multiple {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 13))
+                    .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+            }
             VStack(alignment: .leading, spacing: 2) {
                 Text(repo.name)
                     .font(.system(size: 13, weight: .medium))
@@ -120,20 +165,77 @@ struct RepoPickerView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 4)
-                .fill(isHighlighted ? Color.accentColor.opacity(0.25) : Color.clear)
+                .fill(rowBackground(isSelected: isSelected, isAnchor: isAnchor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .strokeBorder(
+                    isAnchor && !isSelected ? Color.accentColor.opacity(0.5) : Color.clear,
+                    lineWidth: 1
+                )
         )
         .contentShape(Rectangle())
         .opacity(isAlready ? 0.5 : 1.0)
+        .onTapGesture(count: 2) {
+            guard !isAlready else { return }
+            selectedRepoIDs = [repo.id]
+            anchorRepoID = repo.id
+            _ = confirmIfPossible()
+        }
         .onTapGesture {
             guard !isAlready else { return }
-            // The click moves focus into the list, which makes
-            // `isHighlighted` true for whichever row matches
-            // `highlightedRepoID`. Without updating it here, the
-            // initial value (first row) is highlighted just before
-            // the sheet dismisses, not the clicked row (#144).
-            highlightedRepoID = repo.id
-            onSelect(repo)
+            handleClick(repo: repo)
         }
+    }
+
+    private func rowBackground(isSelected: Bool, isAnchor: Bool) -> Color {
+        if isSelected {
+            return Color.accentColor.opacity(focusedField == .list ? 0.4 : 0.25)
+        }
+        if isAnchor {
+            return Color.accentColor.opacity(0.1)
+        }
+        return .clear
+    }
+
+    private func handleClick(repo: Repo) {
+        let isShift = NSEvent.modifierFlags.contains(.shift)
+        anchorIntoList()
+
+        switch selectionMode {
+        case .single:
+            selectedRepoIDs = [repo.id]
+            anchorRepoID = repo.id
+        case .multiple:
+            // Checkbox semantics: each click toggles the row's
+            // selection independently. Shift-click adds the range
+            // from the anchor to the clicked row without removing
+            // the previous selection.
+            if isShift, let anchor = anchorRepoID, anchor != repo.id {
+                selectedRepoIDs.formUnion(rangeIDs(from: anchor, to: repo.id))
+            } else {
+                if selectedRepoIDs.contains(repo.id) {
+                    selectedRepoIDs.remove(repo.id)
+                } else {
+                    selectedRepoIDs.insert(repo.id)
+                }
+            }
+            anchorRepoID = repo.id
+        }
+    }
+
+    /// IDs of all selectable rows between `from` and `to`, inclusive,
+    /// in the order they appear in `filteredRepos`. Already-associated
+    /// rows are skipped. Used by shift-click range selection.
+    private func rangeIDs(from: UUID, to: UUID) -> Set<UUID> {
+        let rows = filteredRepos
+        guard let i = rows.firstIndex(where: { $0.id == from }),
+              let j = rows.firstIndex(where: { $0.id == to }) else {
+            return [to]
+        }
+        let lo = min(i, j)
+        let hi = max(i, j)
+        return Set(rows[lo...hi].map(\.id).filter { !alreadyAssociatedRepoIDs.contains($0) })
     }
 
     private var filteredRepos: IdentifiedArrayOf<Repo> {
@@ -146,12 +248,25 @@ struct RepoPickerView: View {
         }
     }
 
+    private var firstSelectableID: UUID? {
+        filteredRepos.first { !alreadyAssociatedRepoIDs.contains($0.id) }?.id
+            ?? filteredRepos.first?.id
+    }
+
+    private var canConfirm: Bool {
+        !selectedRepoIDs.isEmpty
+            && selectedRepoIDs.contains { !alreadyAssociatedRepoIDs.contains($0) }
+    }
+
     private var visibleFields: [Field] {
         var fields: [Field] = [.search]
         if !filteredRepos.isEmpty {
             fields.append(.list)
         }
         fields.append(.cancel)
+        if canConfirm {
+            fields.append(.confirm)
+        }
         return fields
     }
 
@@ -166,37 +281,92 @@ struct RepoPickerView: View {
         let count = fields.count
         let next = fields[(idx + delta + count) % count]
         focusedField = next
-        if next == .list, highlightedRepoID == nil {
-            highlightedRepoID = filteredRepos.first?.id
+        if next == .list, anchorRepoID == nil {
+            anchorRepoID = firstSelectableID
         }
         return .handled
     }
 
-    private func moveHighlight(by delta: Int, proxy: ScrollViewProxy) -> KeyPress.Result {
+    private func handleArrow(_ press: KeyPress, delta: Int, proxy: ScrollViewProxy) -> KeyPress.Result {
+        let extend = selectionMode == .multiple && press.modifiers.contains(.shift)
+        return moveAnchor(by: delta, extend: extend, proxy: proxy)
+    }
+
+    @discardableResult
+    private func moveAnchor(by delta: Int, extend: Bool, proxy: ScrollViewProxy) -> KeyPress.Result {
         let rows = filteredRepos
         guard !rows.isEmpty else { return .ignored }
-        let currentIdx = rows.firstIndex(where: { $0.id == highlightedRepoID }) ?? 0
+        let currentIdx = rows.firstIndex(where: { $0.id == anchorRepoID }) ?? 0
         let newIdx = min(max(currentIdx + delta, 0), rows.count - 1)
         let newID = rows[newIdx].id
-        highlightedRepoID = newID
+        anchorRepoID = newID
+        switch selectionMode {
+        case .single:
+            // Selection follows the anchor in single mode so the row
+            // the keyboard cursor lands on is what Return confirms.
+            if !alreadyAssociatedRepoIDs.contains(newID) {
+                selectedRepoIDs = [newID]
+            }
+        case .multiple:
+            // Checkbox semantics: plain arrows move the cursor but do
+            // not change selection (use Space to toggle). Shift-arrows
+            // extend the selection from the previous anchor.
+            if extend {
+                let lo = min(currentIdx, newIdx)
+                let hi = max(currentIdx, newIdx)
+                let span = rows[lo...hi].map(\.id).filter { !alreadyAssociatedRepoIDs.contains($0) }
+                selectedRepoIDs.formUnion(span)
+            }
+        }
         withAnimation(.linear(duration: 0.1)) {
             proxy.scrollTo(newID, anchor: .center)
         }
         return .handled
     }
 
-    private func selectHighlighted() -> KeyPress.Result {
-        guard let id = highlightedRepoID,
-              let repo = filteredRepos[id: id],
+    private func toggleAnchor() -> KeyPress.Result {
+        guard let id = anchorRepoID,
               !alreadyAssociatedRepoIDs.contains(id) else { return .ignored }
-        onSelect(repo)
+        switch selectionMode {
+        case .single:
+            selectedRepoIDs = [id]
+        case .multiple:
+            if selectedRepoIDs.contains(id) {
+                selectedRepoIDs.remove(id)
+            } else {
+                selectedRepoIDs.insert(id)
+            }
+        }
         return .handled
     }
 
-    private func clampHighlight() {
-        if let current = highlightedRepoID, filteredRepos[id: current] != nil {
+    @discardableResult
+    private func confirmIfPossible() -> KeyPress.Result {
+        guard canConfirm else { return .ignored }
+        let chosen = filteredRepos
+            .filter { selectedRepoIDs.contains($0.id) && !alreadyAssociatedRepoIDs.contains($0.id) }
+        guard !chosen.isEmpty else { return .ignored }
+        onConfirm(Array(chosen))
+        return .handled
+    }
+
+    /// Mouse clicks on a `.focusable()` SwiftUI control don't always
+    /// promote it to focused (especially when another field had
+    /// keyboard focus). Force it so selection styles render at full
+    /// opacity and Return/Space land on the list, not the prior field.
+    private func anchorIntoList() {
+        if focusedField != .list {
+            focusedField = .list
+        }
+    }
+
+    private func clampAnchor() {
+        if let current = anchorRepoID, filteredRepos[id: current] != nil {
+            // Trim any selected rows that vanished from the filter.
+            selectedRepoIDs = selectedRepoIDs.filter { filteredRepos[id: $0] != nil }
             return
         }
-        highlightedRepoID = filteredRepos.first?.id
+        anchorRepoID = firstSelectableID
+        selectedRepoIDs = selectedRepoIDs.filter { filteredRepos[id: $0] != nil }
     }
 }

--- a/Nex/Features/Workspace/NewWorkspaceSheet.swift
+++ b/Nex/Features/Workspace/NewWorkspaceSheet.swift
@@ -160,8 +160,9 @@ struct NewWorkspaceSheet: View {
                 RepoPickerView(
                     repos: store.repoRegistry,
                     alreadyAssociatedRepoIDs: Set(selectedRepos.map(\.id)),
-                    onSelect: { repo in
-                        selectedRepos.append(repo)
+                    selectionMode: .multiple,
+                    onConfirm: { chosen in
+                        selectedRepos.append(contentsOf: chosen)
                         isRepoPickerPresented = false
                     },
                     onCancel: {

--- a/Nex/Features/Workspace/WorkspaceInspectorView.swift
+++ b/Nex/Features/Workspace/WorkspaceInspectorView.swift
@@ -65,15 +65,18 @@ struct WorkspaceInspectorView: View {
                     RepoPickerView(
                         repos: store.repoRegistry,
                         alreadyAssociatedRepoIDs: Set(workspace.repoAssociations.map(\.repoID)),
-                        onSelect: { repo in
-                            let assoc = RepoAssociation(
-                                repoID: repo.id,
-                                worktreePath: repo.path
-                            )
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .addRepoAssociation(assoc)
-                            )))
+                        selectionMode: .multiple,
+                        onConfirm: { chosen in
+                            for repo in chosen {
+                                let assoc = RepoAssociation(
+                                    repoID: repo.id,
+                                    worktreePath: repo.path
+                                )
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .addRepoAssociation(assoc)
+                                )))
+                            }
                             isRepoPickerPresented = false
                         },
                         onCancel: {
@@ -85,7 +88,10 @@ struct WorkspaceInspectorView: View {
                     RepoPickerView(
                         repos: store.repoRegistry,
                         alreadyAssociatedRepoIDs: [],
-                        onSelect: { repo in
+                        selectionMode: .single,
+                        confirmLabel: "Choose",
+                        onConfirm: { chosen in
+                            guard let repo = chosen.first else { return }
                             isWorktreePickerPresented = false
                             worktreeRepoID = repo.id
                             worktreeName = ""


### PR DESCRIPTION
## Summary
- Fix #144: clicking a repo in `RepoPickerView` used to flash the top row instead of the clicked row right before the sheet dismissed. Root cause: `isHighlighted` was gated on `focusedField == .list`, the click moved focus into the list, and `highlightedRepoID` had never been updated by tap handling — so the initial first-row value rendered as highlighted.
- Redesign the picker around an explicit Confirm button so clicks build a selection rather than committing one. The Inspector "Add Repository" sheet and `NewWorkspaceSheet` repo picker become **multi-select with checkbox semantics**: every plain click toggles a row independently and the previous selection survives. Shift-click adds the range from the anchor to the clicked row. Double-click selects only that row and confirms immediately. The "New Worktree" picker stays single-select (radio-button) since the downstream worktree sheet only takes one repo.

Closes #144

## Reviewer notes
- Selection and confirmation are now separate concepts. `onSelect: (Repo) -> Void` is replaced by `onConfirm: ([Repo]) -> Void`; single-mode call sites unwrap `chosen.first` themselves.
- Selection-vs-highlight split structurally retires the #144 race: dismissal only happens on Confirm, so there is no longer a frame where the wrong row can render highlighted.
- The "Add Repository" multi-select in the inspector now batches `addRepoAssociation` for each chosen repo. No reducer changes — the existing action is invoked once per repo in a `for` loop.
- The worktree picker uses `confirmLabel: "Choose"` because the downstream sheet is "New Worktree", so "Choose" reads more naturally than "Add".

## Validation
- Validated in a sandboxed macOS VM via cua/lume.
- Per-issue assertions: smoke test only (CLI version, initial pane list, `nex workspace create` round-trip). The behaviour change is in `RepoPickerView`'s click/keyboard handlers which only fire from SwiftUI sheets — there is no programmatic CLI path that reaches them, so the visual behaviour is verified manually in the VM via VNC.
- Screenshots: `/Users/ben/code/cua/out/branches/fix-144-repo-picker-click-highlight/issue-144/`

## Test plan
- [x] Inspector "Add Repository" sheet (multi-select): plain click toggles each row, prior selection survives, shift-click adds a range, "Add" commits all selected
- [x] Inspector "New Worktree" sheet (single-select): each click replaces selection, "Choose" opens the worktree-name sheet for the picked repo
- [x] NewWorkspaceSheet "Add Repository" (multi-select): same checkbox semantics as inspector
- [x] Keyboard: Tab to list; Up/Down moves the cursor (multi-mode does not change selection); Space toggles cursor row; Shift+Down extends selection; Return confirms; Esc cancels
- [x] Double-click any row → only that row selected and sheet dismisses
- [x] Already-associated repos: greyed with "Added" label, not selectable (click, shift-click range, and keyboard toggle all skip them)
- [x] Search filtering: typing in the search field narrows rows; previously-selected rows that fall out of the filter are trimmed from the selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)