### PR TITLE
fix(pane grid): pane chrome leaked past pane edge when inspector visible

### DIFF
--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -284,14 +284,20 @@ struct PaneGridView: View {
                 )
             }
         }
-        // Clamp the VStack to the computed pane rect BEFORE the overlays
-        // and background attach, so they size to this rect rather than the
-        // underlying view's natural bounds. Without this the focus-ring
-        // overlay sat on stale bounds when the inspector was toggled and
-        // appeared shifted past the pane edge (#143). The outer `.frame`
-        // at the end of the chain stays — it keeps `.onHover` hit-testing
-        // anchored to the same rect.
+        // Clamp the VStack to the computed pane rect and clip overflow.
+        // `.frame(width:height:)` only assigns a layout slot — SwiftUI
+        // does not strictly force the inner content to render within
+        // those bounds. PaneHeaderView's `.background { Color }` and
+        // its focused accent line size to the HStack's actual rendered
+        // width, and the embedded `NSViewRepresentable` can keep stale
+        // Auto Layout bounds during inspector / sidebar toggles. The
+        // result was that the header chrome and focus ring spilled past
+        // the pane's right edge into the inspector strip (#143).
+        // `.clipped()` enforces the visible bounds; the outer `.frame`
+        // at the end of the chain stays put so `.onHover` hit-testing
+        // is anchored to the same rect.
         .frame(width: frame.width, height: frame.height)
+        .clipped()
         .overlay(alignment: .topTrailing) {
             if searchingPaneID == pane.id {
                 PaneSearchOverlay(

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -284,6 +284,14 @@ struct PaneGridView: View {
                 )
             }
         }
+        // Clamp the VStack to the computed pane rect BEFORE the overlays
+        // and background attach, so they size to this rect rather than the
+        // underlying view's natural bounds. Without this the focus-ring
+        // overlay sat on stale bounds when the inspector was toggled and
+        // appeared shifted past the pane edge (#143). The outer `.frame`
+        // at the end of the chain stays — it keeps `.onHover` hit-testing
+        // anchored to the same rect.
+        .frame(width: frame.width, height: frame.height)
         .overlay(alignment: .topTrailing) {
             if searchingPaneID == pane.id {
                 PaneSearchOverlay(

--- a/Nex/Features/RepoRegistry/RepoPickerView.swift
+++ b/Nex/Features/RepoRegistry/RepoPickerView.swift
@@ -235,7 +235,7 @@ struct RepoPickerView: View {
         }
         let lo = min(i, j)
         let hi = max(i, j)
-        return Set(rows[lo...hi].map(\.id).filter { !alreadyAssociatedRepoIDs.contains($0) })
+        return Set(rows[lo ... hi].map(\.id).filter { !alreadyAssociatedRepoIDs.contains($0) })
     }
 
     private var filteredRepos: IdentifiedArrayOf<Repo> {
@@ -314,7 +314,7 @@ struct RepoPickerView: View {
             if extend {
                 let lo = min(currentIdx, newIdx)
                 let hi = max(currentIdx, newIdx)
-                let span = rows[lo...hi].map(\.id).filter { !alreadyAssociatedRepoIDs.contains($0) }
+                let span = rows[lo ... hi].map(\.id).filter { !alreadyAssociatedRepoIDs.contains($0) }
                 selectedRepoIDs.formUnion(span)
             }
         }


### PR DESCRIPTION
## Summary

The active pane's focus ring AND header chrome (dark background bar + accent line) rendered past the pane's right edge into the inspector strip whenever the inspector panel was visible (#143). Two-commit fix in `Nex/Features/PaneGrid/PaneGridView.swift`:

- **`f7431be`** — add an inner `.frame(width: frame.width, height: frame.height)` before the overlays/background so the focus-highlight overlay sizes to the constrained pane rect instead of the underlying view's natural bounds. The outer `.frame` at the end of the chain is retained so `.onHover` (focus-follows-mouse) hit-testing keeps the same semantics.
- **`b82bcb4`** — add `.clipped()` after the inner `.frame`. SwiftUI's `.frame(width:height:)` only assigns a layout slot; it doesn't strictly force the inner content to render within those bounds. `PaneHeaderView`'s `.background { Color }` and the embedded `NSViewRepresentable`'s Auto Layout bounds could still leak past the slot during inspector / sidebar toggles. `.clipped()` enforces the visual bounds.

Drive-by: fix two pre-existing `lo...hi` whitespace lint errors in `Nex/Features/RepoRegistry/RepoPickerView.swift` that landed in ef43ba0 and were blocking `swiftformat --lint .` locally.

Closes #143

## Reviewer notes

- Parallel multi-agent review (correctness + scope/edge-cases) was run after the first commit; both reviewers identified the modifier-reorder as the correct approach and confirmed the reorder also latently fixes the search overlay + background sizing. The clipping addition (second commit) was prompted by visual verification in a sandboxed macOS VM showing the header chrome still leaked even with the reorder in place — the root cause is broader than just the focus overlay.
- The chosen approach is a two-line addition (inner `.frame` + `.clipped()`) rather than lifting the focus ring into a separate ZStack sibling of `paneView`. The reorder fixes the entire class of "overlay anchored to wrong width" bugs in one place; the sibling-lift would only address the focus ring and leave the search overlay / header / background still vulnerable.

## Validation

- Validated in a sandboxed macOS VM via cua/lume (worktree-only build, two consecutive runs).
- Per-issue assertions in `validate_issue_143.py`:
  - `nex --version` succeeds, initial pane count = 1.
  - `nex pane split --direction horizontal` succeeds, pane count = 2.
  - Toggle inspector ON via `⌘I` (Quartz hotkey via `sb.keyboard.keypress(["cmd","i"])`) — pane set unchanged, screenshot captured.
  - Toggle inspector OFF — screenshot captured.
  - Toggle inspector ON again — pane set unchanged, screenshot captured. Covers the mid-animation edge case flagged in plan review.
- Screenshots: `/Users/ben/code/cua/out/branches/fix-143-pane-highlight-inspector-offset/issue-143/` (01 baseline, 02 inspector open, 03 inspector closed again, 04 inspector open again).
- User verified via VNC into the keep-alive VM that the focused-pane chrome is now flush with the pane edge.
- Repo-level `make check` fails on `format-check` / `lint` because `.swiftformat` and `.swiftlint.yml` exclude `.build/` but not `build/`, so SPM checkouts in `build/DerivedData/SourcePackages/checkouts/` get scanned. Pre-existing local env issue, unrelated to this fix. Lint / format / build / test pass cleanly against the changed files (1027 tests green).

## Test plan

- [ ] Open Nex. Focus a pane (terminal). Press `⌘I` to toggle the inspector. The focus highlight and header background should track the pane's right edge — no overrun into the inspector strip.
- [ ] Split the focused pane right (`⌘D`) so there are at least two side-by-side panes. Focus the rightmost. Toggle inspector. The right pane's chrome stays flush.
- [ ] Toggle the inspector multiple times in quick succession — chrome stays aligned across each animation.
- [ ] Drag the divider between two panes while the inspector is open — header chrome follows the new widths.
- [ ] Toggle the sidebar (`⌘B`) with inspector also visible. Both edges of the pane chrome stay clean.
- [ ] Cycle layouts with `⌘⇧Space`. Focus highlight tracks the focused pane through each layout.
- [ ] Switch workspaces in the sidebar with inspector open. New workspace's focus highlight is correctly placed.
- [ ] Open the in-pane search overlay (focus a terminal pane, `⌘F`) with inspector also visible. Search overlay sits flush at the pane's top-right, no overrun.
- [ ] Spot-check non-shell pane types: open a `.md` file (`⌘O`), focus it, toggle inspector. Repeat with a `nex diff` pane and a `nex web` pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)