### PR TITLE
feat(markdown pane): copy button on fenced code blocks (#125)

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		ED79F70009D8C2A4A1A742F8 /* ResizeDimensionsOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6F950849E47A0BCC6DEAB5 /* ResizeDimensionsOverlay.swift */; };
 		EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */; };
 		EDF35E86B633BB1E8C3DE844 /* WindowSpacesBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */; };
+		EEE8E1F9A5BF3A99FF11CF0D /* MarkdownCodeCopyScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDE8815715F4B6A37D353E8 /* MarkdownCodeCopyScript.swift */; };
 		EF4258CFC52EB748609C7F18 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */; };
 		EFDCA64CD227A833D2801893 /* CLIInstallService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EC869803E36C99B3653FF5 /* CLIInstallService.swift */; };
 		F01CDB667AE2A0CF2A825AD3 /* WorkspaceDropTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E01C66D4D59D04F6372D8AD7 /* WorkspaceDropTargetTests.swift */; };
@@ -313,6 +314,7 @@
 		CBF3FB912BD029F17AF0AA25 /* KeyBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBinding.swift; sourceTree = "<group>"; };
 		CD30BE0FDF3CC57813A5DB46 /* GroupCustomEmojiSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupCustomEmojiSheet.swift; sourceTree = "<group>"; };
 		CF4114D723403D4FF8F4AC1B /* ConfigParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigParser.swift; sourceTree = "<group>"; };
+		CFDE8815715F4B6A37D353E8 /* MarkdownCodeCopyScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeCopyScript.swift; sourceTree = "<group>"; };
 		CFE42A23C94DA8DA930C61E3 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		D0CED7EFE254E4491327CAE0 /* EditorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorService.swift; sourceTree = "<group>"; };
 		D6B83DC43AEA38B4929307FA /* AppReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReducerTests.swift; sourceTree = "<group>"; };
@@ -683,6 +685,7 @@
 			isa = PBXGroup;
 			children = (
 				852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */,
+				CFDE8815715F4B6A37D353E8 /* MarkdownCodeCopyScript.swift */,
 				7ED3289901F70616FC36F80B /* MarkdownEditorView.swift */,
 				37DDBBE36E6F9BC00B9EB07E /* MarkdownFindController.swift */,
 				3B4FA41668CB28EB0FFA7911 /* MarkdownFindScript.swift */,
@@ -940,6 +943,7 @@
 				E0ABD2D68012C6BF24A92E7D /* KeybindingService.swift in Sources */,
 				6CF210BA0C7BFE62B90844F7 /* KeybindingsSettingsView.swift in Sources */,
 				6C50041FBB0F31598067D4FA /* LineNumberRulerView.swift in Sources */,
+				EEE8E1F9A5BF3A99FF11CF0D /* MarkdownCodeCopyScript.swift in Sources */,
 				291A22061671351813971551 /* MarkdownEditorView.swift in Sources */,
 				F4F95104BEADCDD6F5C79CF2 /* MarkdownFindController.swift in Sources */,
 				692A08796F7DF555CFAF0653 /* MarkdownFindScript.swift in Sources */,

--- a/Nex/Features/MarkdownPane/MarkdownCodeCopyScript.swift
+++ b/Nex/Features/MarkdownPane/MarkdownCodeCopyScript.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// JavaScript injected into every markdown preview WKWebView. Wires the
+/// per-code-block copy button: posts the raw code text through the
+/// `copyCodeBlock` script message handler and shows a transient
+/// checkmark on the button via the `.copied` class.
+enum MarkdownCodeCopyScript {
+    static let source: String = """
+    (function() {
+        if (window.__nexCopyCodeBound) { return; }
+        window.__nexCopyCodeBound = true;
+
+        var COPIED_MS = 1500;
+
+        document.addEventListener('click', function(e) {
+            var btn = e.target.closest && e.target.closest('.code-copy-btn');
+            if (!btn) { return; }
+            // Re-entry guard so a second click during the "copied" window
+            // doesn't reset the visual state mid-animation.
+            if (btn.classList.contains('copied')) { return; }
+            var wrap = btn.parentNode;
+            if (!wrap) { return; }
+            // `:scope >` requires a direct <pre> child so we don't pick up
+            // a nested code block if the structure ever changes.
+            var code = wrap.querySelector(':scope > pre > code');
+            if (!code) { return; }
+            var text = code.textContent;
+            if (!text) { return; }
+            try {
+                window.webkit.messageHandlers.copyCodeBlock.postMessage(text);
+            } catch (err) {
+                return;
+            }
+            btn.classList.add('copied');
+            // Announce the success state to assistive tech by swapping the
+            // aria-label; the .copied class only changes a CSS icon.
+            var origLabel = btn.getAttribute('aria-label') || 'Copy code';
+            btn.setAttribute('aria-label', 'Copied');
+            setTimeout(function() {
+                btn.classList.remove('copied');
+                btn.setAttribute('aria-label', origLabel);
+            }, COPIED_MS);
+        });
+    })();
+    """
+}

--- a/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
+++ b/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
@@ -69,7 +69,14 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
         let lang = codeBlock.language ?? ""
         let langAttr = lang.isEmpty ? "" : " class=\"language-\(escapeHTML(lang))\""
         let code = escapeHTML(codeBlock.code)
-        return "<pre><code\(langAttr)>\(code)</code></pre>\n"
+        // Wrap fenced/indented code blocks so the copy button can anchor
+        // against the wrapper without affecting <pre>'s horizontal scroll.
+        // Front-matter pres emit no inner <code>, so the JS click handler's
+        // `:scope > pre > code` selector skips them naturally.
+        return "<div class=\"code-block\">"
+            + "<pre><code\(langAttr)>\(code)</code></pre>"
+            + "<button class=\"code-copy-btn\" type=\"button\" aria-label=\"Copy code\"></button>"
+            + "</div>\n"
     }
 
     mutating func visitUnorderedList(_ list: UnorderedList) -> String {
@@ -441,6 +448,63 @@ enum MarkdownRenderer {
             margin: 0 0 1.5em;
         }
         .dark pre.frontmatter-raw { border-left-color: #3d444d; }
+        .code-block { position: relative; }
+        /* Margin/padding on the wrapper, not on the <pre>, so the <pre>'s
+           default block spacing collapses naturally and code-block stacks the
+           same way as the old bare <pre>. */
+        .code-block > pre { margin: 0; }
+        .code-block { margin: 1em 0; }
+        .code-copy-btn {
+            position: absolute;
+            top: 6px;
+            right: 6px;
+            width: 28px;
+            height: 24px;
+            padding: 0;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(255, 255, 255, 0.85);
+            border: 1px solid #d1d9e0;
+            border-radius: 4px;
+            color: #1f2328;
+            cursor: pointer;
+            opacity: 0;
+            transition: opacity 0.15s ease, color 0.15s ease;
+        }
+        .code-block:hover .code-copy-btn,
+        .code-block:focus-within .code-copy-btn,
+        .code-copy-btn:focus { opacity: 1; }
+        .code-copy-btn:focus-visible {
+            outline: 2px solid #0969da;
+            outline-offset: 1px;
+        }
+        .code-copy-btn:hover { background: #f6f8fa; }
+        .code-copy-btn.copied { color: #1a7f37; }
+        .dark .code-copy-btn {
+            background: rgba(22, 27, 34, 0.85);
+            border-color: #3d444d;
+            color: #e6edf3;
+        }
+        .dark .code-copy-btn:hover { background: #21262d; }
+        .dark .code-copy-btn.copied { color: #3fb950; }
+        .dark .code-copy-btn:focus-visible { outline-color: #58a6ff; }
+        /* Icon drawn via mask so it picks up the button's `currentColor`
+           (greys in light/dark, green when .copied). */
+        .code-copy-btn::before {
+            content: "";
+            display: block;
+            width: 14px;
+            height: 14px;
+            background-color: currentColor;
+            -webkit-mask-repeat: no-repeat;
+            -webkit-mask-position: center;
+            -webkit-mask-size: 14px 14px;
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z'/%3E%3Cpath d='M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z'/%3E%3C/svg%3E");
+        }
+        .code-copy-btn.copied::before {
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z'/%3E%3C/svg%3E");
+        }
         """
     }
 }

--- a/Nex/Features/MarkdownPane/MarkdownPaneView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownPaneView.swift
@@ -38,6 +38,7 @@ struct MarkdownPaneView: NSViewRepresentable {
         let handler = context.coordinator
         config.userContentController.add(handler, name: "scrollHandler")
         config.userContentController.add(handler, name: "nexFind")
+        config.userContentController.add(handler, name: "copyCodeBlock")
         config.userContentController.addUserScript(WKUserScript(
             source: """
             window.addEventListener('scroll', function() {
@@ -51,6 +52,11 @@ struct MarkdownPaneView: NSViewRepresentable {
         ))
         config.userContentController.addUserScript(WKUserScript(
             source: MarkdownFindScript.source,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        ))
+        config.userContentController.addUserScript(WKUserScript(
+            source: MarkdownCodeCopyScript.source,
             injectionTime: .atDocumentEnd,
             forMainFrameOnly: true
         ))
@@ -222,6 +228,11 @@ struct MarkdownPaneView: NSViewRepresentable {
                     object: nil,
                     userInfo: ["paneID": paneID, "total": total, "current": current]
                 )
+            case "copyCodeBlock":
+                guard let text = message.body as? String, !text.isEmpty else { return }
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(text, forType: .string)
             default:
                 break
             }
@@ -397,6 +408,12 @@ struct MarkdownPaneView: NSViewRepresentable {
                 );
                 for (var i = 0; i < fm.length; i++) {
                     fm[i].parentNode.removeChild(fm[i]);
+                }
+                // Strip the in-DOM copy buttons so they don't leak into the
+                // RTF/HTML pasteboard payloads as a literal "Copy" glyph.
+                var btns = clone.querySelectorAll('.code-copy-btn');
+                for (var j = 0; j < btns.length; j++) {
+                    btns[j].parentNode.removeChild(btns[j]);
                 }
                 return clone.innerHTML;
             })();

--- a/NexTests/MarkdownHTMLRendererTests.swift
+++ b/NexTests/MarkdownHTMLRendererTests.swift
@@ -360,6 +360,63 @@ struct MarkdownHTMLRendererTests {
         #expect(html.contains("two line two"))
     }
 
+    // MARK: - Code block copy button
+
+    @Test func fencedCodeBlockWrappedWithCopyButton() {
+        let html = MarkdownRenderer.renderToHTML("```\nhello\n```")
+        #expect(html.contains("<div class=\"code-block\">"))
+        #expect(html.contains("<pre><code>hello\n</code></pre>"))
+        #expect(html.contains("class=\"code-copy-btn\""))
+        #expect(html.contains("aria-label=\"Copy code\""))
+    }
+
+    @Test func fencedCodeBlockWithLanguageStillWrapped() {
+        let html = MarkdownRenderer.renderToHTML("```swift\nlet x = 1\n```")
+        #expect(html.contains("<div class=\"code-block\">"))
+        #expect(html.contains("class=\"language-swift\""))
+        #expect(html.contains("class=\"code-copy-btn\""))
+    }
+
+    @Test func inlineCodeNotWrapped() {
+        let html = MarkdownRenderer.renderToHTML("Use `foo` here.")
+        #expect(html.contains("<code>foo</code>"))
+        // The class names appear in the inlined stylesheet — assert on the
+        // wrapper element instead so a body-side wrap is what fails.
+        #expect(!html.contains("<div class=\"code-block\">"))
+        #expect(!html.contains("class=\"code-copy-btn\""))
+    }
+
+    @Test func frontMatterRawNotWrapped() {
+        // Malformed YAML falls back to <pre class="frontmatter-raw"> with no
+        // inner <code> — copy button must not be injected.
+        let yaml = "---\n: malformed:\n---\nbody"
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(html.contains("frontmatter-raw"))
+        #expect(!html.contains("class=\"code-copy-btn\""))
+    }
+
+    @Test func frontMatterNestedNotWrapped() {
+        // Multi-line nested YAML values render via <pre class="frontmatter-nested">
+        // (no inner <code>) — copy button must not be injected.
+        let yaml = """
+        ---
+        block: |
+          line one
+          line two
+        ---
+        """
+        let html = MarkdownRenderer.renderToHTML(yaml)
+        #expect(html.contains("frontmatter-nested"))
+        #expect(!html.contains("class=\"code-copy-btn\""))
+    }
+
+    @Test func htmlInsideFencedCodeStillEscaped() {
+        // Wrapping must not affect inner-content escaping.
+        let html = MarkdownRenderer.renderToHTML("```\n<script>alert(1)</script>\n```")
+        #expect(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"))
+        #expect(!html.contains("<script>alert(1)"))
+    }
+
     @Test func frontMatterAliasResolvedByYamsCompose() {
         // Yams.compose resolves aliases to their anchored value, so an alias
         // reference surfaces as the target's content. Both cells should render


### PR DESCRIPTION
## Summary
- Wrap each fenced code block in `<div class="code-block">` with a hover-revealed copy button drawn via `-webkit-mask-image` (icon picks up `currentColor`, green when copied)
- New `copyCodeBlock` WKScriptMessageHandler writes the raw code text (no fence markers, no language tag) to NSPasteboard; the button briefly swaps to a checkmark and its `aria-label` flips to "Copied" for assistive tech
- `copyAsRichText` strips the in-DOM buttons before exporting so they don't leak into the RTF/HTML pasteboard payloads

Closes #125

## Reviewer notes
- Inline code and front-matter pres are unaffected because the JS `:scope > pre > code` selector and the render-time wrapper only target fenced blocks
- swift-markdown's `CodeBlock` AST node fires for both fenced and indented code blocks; the existing renderer already treated them identically. Indented blocks therefore also get a button, which is consistent with how they render (same `<pre><code>` shape) — not introduced by this PR
- Hover-only visibility matches GitHub / Stack Overflow / MDN; `:focus-within` + button `:focus-visible` keeps it keyboard-reachable

## Validation
- Validated in a sandboxed macOS VM via cua/lume (build from worktree → launch → assertions → keep-alive)
- Assertions: open markdown fixture (front-matter + paragraph with inline code + fenced Python block) → markdown pane is created with `type=markdown` → pane stays alive → right-click still shows existing "Copy as Markdown" / "Copy as Rich Text" items
- Screenshots: `/Users/ben/code/cua/out/branches/ship-issue-125-md-copy-button/issue-125/`
- 1032 tests pass locally (5 new renderer tests for the wrapper / inline / front-matter / nested-front-matter / escape behaviour)

## Test plan
- [ ] Open a markdown file with a fenced code block; hover over it — copy button fades in at the top-right
- [ ] Click the button — checkmark appears for ~1.5s then reverts
- [ ] Paste into a text editor — clipboard contains the raw code, no fence markers, no language tag
- [ ] Hover over inline `code` — no button appears
- [ ] Open a markdown file with YAML front-matter — front-matter table has no button
- [ ] Toggle macOS light/dark and reopen the file — button styling adapts
- [ ] Right-click the code block — "Copy as Markdown" and "Copy as Rich Text" entries still present and work