### PR TITLE
feat(pane): tmux-style synchronise-input toggle (#121)

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,7 +1,7 @@
 --indent 4
 --trailingCommas never
 --maxwidth 0
---exclude ghostty,.build
+--exclude ghostty,.build,build
 --disable hoistPatternLet,wrapPropertyBodies,noForceUnwrapInTests,wrapMultilineStatementBraces
 --patternlet inline
 --swiftversion 6.0

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 excluded:
   - ghostty/
   - .build/
+  - build/
   - Nex.xcodeproj/
 
 disabled_rules:

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		EC6971D2E311C8903C373778 /* AppReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9335AE3C92A37DD50A5715A /* AppReducer.swift */; };
 		ECA2C078504EB9BF0E04B343 /* GhosttyConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AD7A8D7E6592B90FBB7D24 /* GhosttyConfig.swift */; };
 		ECB2D027885F6AAC05BFBA22 /* GraftInspectorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110ABCD54BF803110E5F5060 /* GraftInspectorButton.swift */; };
+		ECC9AA8342DF3710795427C7 /* SyncInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D2D521EEDB4FE47843C382 /* SyncInputTests.swift */; };
 		ED79F70009D8C2A4A1A742F8 /* ResizeDimensionsOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6F950849E47A0BCC6DEAB5 /* ResizeDimensionsOverlay.swift */; };
 		EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */; };
 		EDF35E86B633BB1E8C3DE844 /* WindowSpacesBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */; };
@@ -195,6 +196,7 @@
 		06845D1AC00D409504EDAB61 /* WebPaneURLNormalisationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneURLNormalisationTests.swift; sourceTree = "<group>"; };
 		0689D085597FF9C7F4D87401 /* RepoPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoPickerView.swift; sourceTree = "<group>"; };
 		09102B6ADEAB463454E7F15E /* StatusBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarController.swift; sourceTree = "<group>"; };
+		09D2D521EEDB4FE47843C382 /* SyncInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncInputTests.swift; sourceTree = "<group>"; };
 		0C975C89EC3EAA135F52A7AD /* WorkspaceDropTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDropTarget.swift; sourceTree = "<group>"; };
 		0E79DA6455C6FF3D2124CBA9 /* GraftService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraftService.swift; sourceTree = "<group>"; };
 		110ABCD54BF803110E5F5060 /* GraftInspectorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraftInspectorButton.swift; sourceTree = "<group>"; };
@@ -475,6 +477,7 @@
 				ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */,
 				AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */,
 				1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */,
+				09D2D521EEDB4FE47843C382 /* SyncInputTests.swift */,
 				9AA64A9054515A57ED6B2ECA /* WebPaneActuatorActionTests.swift */,
 				9F338E618A147E5BAAFF5FE5 /* WebPaneActuatorSelectorTests.swift */,
 				12DB8491263633C87CA73D00 /* WebPaneActuatorWaitTests.swift */,
@@ -885,6 +888,7 @@
 				EAF43DC55C5612F3AE83BF02 /* SettingsFeatureTests.swift in Sources */,
 				2B4533964D77117EE6D98690 /* SocketParsingTests.swift in Sources */,
 				EF4258CFC52EB748609C7F18 /* SurfaceViewKeyboardTests.swift in Sources */,
+				ECC9AA8342DF3710795427C7 /* SyncInputTests.swift in Sources */,
 				04A463E95398A50F5AD5AA2B /* WebPaneActuatorActionTests.swift in Sources */,
 				E5D6BDD247E0BE03F097B4A2 /* WebPaneActuatorSelectorTests.swift in Sources */,
 				B0FA5E756635F6DFC402CD7C /* WebPaneActuatorWaitTests.swift in Sources */,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -1267,6 +1267,149 @@ struct AppReducer {
         }
     }
 
+    // MARK: - Sync-input helpers (issue #121)
+
+    /// Push the workspace's current sync group to `SurfaceManager`.
+    /// Mirrors `WorkspaceFeature.refreshSyncGroup` but callable from
+    /// the AppReducer layer — used by `paneMoveToWorkspace` which
+    /// mutates `state.workspaces` directly and so bypasses the
+    /// per-workspace bookkeeping reducer. Returns `.none` when the
+    /// workspace has gone missing (race / typo) so we don't crash.
+    private func refreshSyncGroupForWorkspace(
+        workspaceID: UUID, state: State
+    ) -> Effect<Action> {
+        guard let workspace = state.workspaces[id: workspaceID] else { return .none }
+        let paneIDs = workspace.syncedPaneIDs
+        let mgr = surfaceManager
+        return .run { _ in
+            await mgr.setSyncGroup(workspaceID: workspaceID, paneIDs: paneIDs)
+        }
+    }
+
+    // MARK: - Sync-input socket handlers (issue #121)
+
+    /// Dispatch `pane-sync (on|off|toggle|status)`. Resolves the
+    /// workspace from `workspaceFilter` first, then `NEX_PANE_ID`.
+    /// Replies with `{ok:true,active:Bool,excluded:[...]}` on success;
+    /// `status` is read-only and never mutates state.
+    func handlePaneSync(
+        state: State,
+        paneID: UUID?,
+        workspaceFilter: String?,
+        action: String,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        func fail(_ error: String) -> Effect<Action> {
+            reply?.send(["ok": false, "error": error])
+            reply?.close()
+            return .none
+        }
+
+        let workspace: WorkspaceFeature.State
+        if let workspaceFilter {
+            guard let ws = state.resolveWorkspace(workspaceFilter) else {
+                return fail("workspace not found: \(workspaceFilter)")
+            }
+            workspace = ws
+        } else if let paneID, let ws = state.workspaceContainingPane(paneID) {
+            workspace = ws
+        } else {
+            return fail("pane sync requires --workspace or NEX_PANE_ID")
+        }
+
+        let normalized = action.lowercased()
+        let nextActive: Bool
+        switch normalized {
+        case "on":
+            nextActive = true
+        case "off":
+            nextActive = false
+        case "toggle":
+            nextActive = !workspace.isSyncInputActive
+        case "status":
+            // Read-only — reply with current snapshot and bail.
+            replySyncStatus(reply: reply, workspace: workspace)
+            return .none
+        default:
+            return fail("unknown sync action '\(action)' (valid: on, off, toggle, status)")
+        }
+
+        // Reply with the post-change snapshot. Mirrors the read-only
+        // status payload so a CLI caller can rely on the same fields
+        // regardless of which subcommand they invoked.
+        var snapshot = workspace
+        snapshot.isSyncInputActive = nextActive
+        if !nextActive { snapshot.syncInputExcluded.removeAll() }
+        replySyncStatus(reply: reply, workspace: snapshot)
+
+        return .send(.workspaces(.element(
+            id: workspace.id,
+            action: .setSyncInputActive(nextActive)
+        )))
+    }
+
+    /// Dispatch `pane-sync exclude|include`. Reuses `resolvePaneTarget`
+    /// so target / workspace resolution matches `pane send` etc.
+    func handlePaneSyncExclude(
+        state: State,
+        paneID: UUID?,
+        target: String,
+        workspaceFilter: String?,
+        excluded: Bool,
+        reply: SocketServer.ReplyHandle?
+    ) -> Effect<Action> {
+        let resolvedID: UUID
+        let workspace: WorkspaceFeature.State
+        switch resolvePaneTarget(state: state, paneID: paneID, target: target, workspaceFilter: workspaceFilter) {
+        case .found(let resolved, let ws):
+            resolvedID = resolved
+            workspace = ws
+        case .error(let error):
+            reply?.send(["ok": false, "error": error])
+            reply?.close()
+            return .none
+        }
+
+        var snapshot = workspace
+        if excluded {
+            snapshot.syncInputExcluded.insert(resolvedID)
+        } else {
+            snapshot.syncInputExcluded.remove(resolvedID)
+        }
+        replySyncStatus(reply: reply, workspace: snapshot)
+
+        return .send(.workspaces(.element(
+            id: workspace.id,
+            action: .setSyncInputExcluded(paneID: resolvedID, excluded: excluded)
+        )))
+    }
+
+    /// Build and send the standard sync-status reply payload.
+    /// Mirrors the structure `pane sync status` returns so every
+    /// sync subcommand surfaces consistent fields.
+    private func replySyncStatus(
+        reply: SocketServer.ReplyHandle?,
+        workspace: WorkspaceFeature.State
+    ) {
+        var excluded: [[String: Any]] = []
+        for paneID in workspace.syncInputExcluded {
+            guard let pane = workspace.panes[id: paneID] else { continue }
+            var entry: [String: Any] = ["id": paneID.uuidString]
+            if let label = pane.label { entry["label"] = label }
+            excluded.append(entry)
+        }
+        let synced = workspace.syncedPaneIDs.map(\.uuidString).sorted()
+        reply?.send([
+            "ok": true,
+            "workspace_id": workspace.id.uuidString,
+            "workspace_name": workspace.name,
+            "active": workspace.isSyncInputActive,
+            "synced_pane_ids": synced,
+            "excluded": excluded
+        ])
+        reply?.close()
+    }
+
     // MARK: - Graft socket handlers
 
     /// Outcome of `resolveGraftAssociations`. Carries either the
@@ -4586,6 +4729,25 @@ struct AppReducer {
                         reply: reply
                     )
 
+                case .paneSync(let paneID, let workspaceFilter, let action):
+                    return handlePaneSync(
+                        state: state,
+                        paneID: paneID,
+                        workspaceFilter: workspaceFilter,
+                        action: action,
+                        reply: reply
+                    )
+
+                case .paneSyncExclude(let paneID, let target, let workspaceFilter, let excluded):
+                    return handlePaneSyncExclude(
+                        state: state,
+                        paneID: paneID,
+                        target: target,
+                        workspaceFilter: workspaceFilter,
+                        excluded: excluded,
+                        reply: reply
+                    )
+
                 case .paneMove(let paneID, let direction):
                     guard let workspace = state.workspaces.first(where: { $0.panes[id: paneID] != nil })
                     else { return .none }
@@ -4696,6 +4858,20 @@ struct AppReducer {
                     state.workspaces[id: targetWSID]?.currentLayoutIndex = nil
                     state.activeWorkspaceID = targetWSID
 
+                    // Issue #121 — cross-workspace move bypasses the
+                    // WorkspaceFeature bookkeeping reducer, so we have
+                    // to push fresh sync-group snapshots for both
+                    // source and target explicitly. Without these, the
+                    // source workspace's `SurfaceManager.syncGroups`
+                    // entry would still reference the moved pane and
+                    // the target would never broadcast to it.
+                    let sourceSyncEffect = refreshSyncGroupForWorkspace(
+                        workspaceID: sourceWSID, state: state
+                    )
+                    let targetSyncEffect = refreshSyncGroupForWorkspace(
+                        workspaceID: targetWSID, state: state
+                    )
+
                     if dropMarkdownFind {
                         return .merge(
                             .run { _ in
@@ -4703,10 +4879,12 @@ struct AppReducer {
                                     MarkdownFindController.shared.close(paneID: paneID)
                                 }
                             },
+                            sourceSyncEffect,
+                            targetSyncEffect,
                             .send(.persistState)
                         )
                     }
-                    return .send(.persistState)
+                    return .merge(sourceSyncEffect, targetSyncEffect, .send(.persistState))
 
                 // MARK: Workspace commands
 

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -1282,7 +1282,7 @@ struct AppReducer {
         let paneIDs = workspace.syncedPaneIDs
         let mgr = surfaceManager
         return .run { _ in
-            await mgr.setSyncGroup(workspaceID: workspaceID, paneIDs: paneIDs)
+            mgr.setSyncGroup(workspaceID: workspaceID, paneIDs: paneIDs)
         }
     }
 
@@ -1392,7 +1392,10 @@ struct AppReducer {
         workspace: WorkspaceFeature.State
     ) {
         var excluded: [[String: Any]] = []
-        for paneID in workspace.syncInputExcluded {
+        // Sort by uuidString so the JSON reply has a stable order across
+        // calls — otherwise Set<UUID> iteration order would make scripts
+        // diffing `pane sync status --json` output flake intermittently.
+        for paneID in workspace.syncInputExcluded.sorted(by: { $0.uuidString < $1.uuidString }) {
             guard let pane = workspace.panes[id: paneID] else { continue }
             var entry: [String: Any] = ["id": paneID.uuidString]
             if let label = pane.label { entry["label"] = label }
@@ -2923,12 +2926,17 @@ struct AppReducer {
 
                 let stopEffects = assocIDs.map { Effect.send(Action.stopHeadWatcher(associationID: $0)) }
                 let graftStopEffects = liveGraftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
+                let mgr = surfaceManager
                 return .merge(
                     [
                         .run { _ in
                             for paneID in paneIDs {
-                                await surfaceManager.destroySurface(paneID: paneID)
+                                await mgr.destroySurface(paneID: paneID)
                             }
+                            // Drop the sync-input group for the deleted
+                            // workspace so SurfaceManager.syncGroups
+                            // doesn't leak the entry indefinitely.
+                            mgr.setSyncGroup(workspaceID: id, paneIDs: [])
                         },
                         .send(.persistState)
                     ] + stopEffects + graftStopEffects
@@ -3180,12 +3188,19 @@ struct AppReducer {
                 state.lastSelectionAnchor = nil
 
                 let paneIDs = panesToDestroy
+                let deletedWorkspaceIDs = ids
                 let graftStopEffects = liveGraftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
+                let mgr = surfaceManager
                 return .merge(
                     [
                         .run { _ in
                             for paneID in paneIDs {
-                                await surfaceManager.destroySurface(paneID: paneID)
+                                await mgr.destroySurface(paneID: paneID)
+                            }
+                            // Drop sync-input groups for the deleted
+                            // workspaces (mirrors `deleteWorkspace`).
+                            for wsID in deletedWorkspaceIDs {
+                                mgr.setSyncGroup(workspaceID: wsID, paneIDs: [])
                             }
                         },
                         .send(.persistState)
@@ -3390,12 +3405,19 @@ struct AppReducer {
                     state.groupDeleteConfirmation = nil
 
                     let captured = paneIDs
+                    let cascadedWorkspaceIDs = childIDs
                     let graftStopEffects = liveGraftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
+                    let mgr = surfaceManager
                     return .merge(
                         [
                             .run { _ in
                                 for paneID in captured {
-                                    await surfaceManager.destroySurface(paneID: paneID)
+                                    await mgr.destroySurface(paneID: paneID)
+                                }
+                                // Drop sync-input groups for the cascaded
+                                // workspaces (mirrors `deleteWorkspace`).
+                                for wsID in cascadedWorkspaceIDs {
+                                    mgr.setSyncGroup(workspaceID: wsID, paneIDs: [])
                                 }
                             },
                             .send(.persistState)
@@ -4800,6 +4822,10 @@ struct AppReducer {
                     if webStateToTransfer != nil {
                         state.workspaces[id: sourceWSID]?.webPanes.removeValue(forKey: paneID)
                     }
+                    // Drop any source-side sync exclusion for this pane.
+                    // Otherwise a later move-back would silently re-apply
+                    // the orphan opt-out with no UI hint to explain why.
+                    state.workspaces[id: sourceWSID]?.syncInputExcluded.remove(paneID)
                     let newSourceLayout = state.workspaces[id: sourceWSID]!.layout.removing(paneID: paneID)
                     state.workspaces[id: sourceWSID]?.layout = newSourceLayout
                     state.workspaces[id: sourceWSID]?.currentLayoutIndex = nil

--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -377,6 +377,10 @@ final class PaneShortcutMonitor {
         case .openDiff:
             return handleOpenDiff(activeWorkspaceID: id)
 
+        case .toggleSyncInput:
+            store.send(.workspaces(.element(id: id, action: .toggleSyncInput)))
+            return true
+
         case .openWebPane:
             // Open a fresh web pane on a blank URL — user can type
             // one in the URL bar. Matches what ⌘L does for a brand-new

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -116,6 +116,15 @@ struct ContentView: View {
                                 reply: nil
                             ))
                         },
+                        isSyncInputActive: workspace.isSyncInputActive,
+                        syncInputExcluded: workspace.syncInputExcluded,
+                        onToggleSyncExcluded: { paneID in
+                            let excluded = workspace.syncInputExcluded.contains(paneID)
+                            store.send(.workspaces(.element(
+                                id: activeID,
+                                action: .setSyncInputExcluded(paneID: paneID, excluded: !excluded)
+                            )))
+                        },
                         webPanes: workspace.webPanes,
                         webPaneURLFocusToken: store.webPaneURLFocusTokens,
                         onWebNavigate: { paneID, url in

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -32,6 +32,13 @@ struct PaneGridView: View {
     var otherWorkspaces: [(id: UUID, name: String)] = []
     var onRenamePane: ((UUID) -> Void)?
     var onMovePaneToWorkspace: ((UUID, UUID) -> Void)?
+    /// Issue #121 sync-input state. `isSyncInputActive` flips the
+    /// workspace toggle (drives the per-pane SYNC badge for every
+    /// non-excluded pane); `syncInputExcluded` lists panes opted out.
+    /// Wired by `ContentView`.
+    var isSyncInputActive: Bool = false
+    var syncInputExcluded: Set<UUID> = []
+    var onToggleSyncExcluded: ((UUID) -> Void)?
     /// Sidecar state for `.web` panes in this workspace. Keyed by pane id.
     var webPanes: [UUID: WebPaneState] = [:]
     /// URL bar focus token bumped by ⌘L. Used by `WebPaneView` to
@@ -177,6 +184,11 @@ struct PaneGridView: View {
                 onRename: onRenamePane.map { handler in { handler(pane.id) } },
                 onMoveToWorkspace: onMovePaneToWorkspace.map { handler in
                     { targetWS in handler(pane.id, targetWS) }
+                },
+                isSyncExcluded: syncInputExcluded.contains(pane.id),
+                workspaceSyncActive: isSyncInputActive,
+                onToggleSyncExcluded: onToggleSyncExcluded.map { handler in
+                    { handler(pane.id) }
                 }
             )
 

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -23,6 +23,17 @@ struct PaneHeaderView: View {
     var otherWorkspaces: [(id: UUID, name: String)] = []
     var onRename: (() -> Void)?
     var onMoveToWorkspace: ((UUID) -> Void)?
+    /// True when sync is on for the workspace but this pane has been
+    /// opted out. Used to render the "Include in sync" context menu
+    /// entry and the dimmed `SYNC OFF` badge.
+    var isSyncExcluded: Bool = false
+    /// Workspace-level sync flag (issue #121). When true the amber
+    /// `SYNC` badge fires for every non-excluded pane in the
+    /// workspace, and the context menu offers exclude/include.
+    var workspaceSyncActive: Bool = false
+    /// Toggle this pane's membership in the sync group. Nil when the
+    /// host hasn't wired it (tests, previews).
+    var onToggleSyncExcluded: (() -> Void)?
 
     @State private var isDragging = false
 
@@ -91,6 +102,45 @@ struct PaneHeaderView: View {
                 }
                 .buttonStyle(.plain)
                 .help("Toggle zoom")
+            }
+
+            // Sync chrome — issue #121. The amber `SYNC` badge fires
+            // whenever the workspace toggle is on AND this pane isn't
+            // excluded, even if no peer is currently around (e.g. a
+            // single-pane workspace where the broadcast would no-op
+            // anyway). The user explicitly asked for a clear "I forgot
+            // it was on" cue, so the visual presence of the toggle
+            // takes priority over the abstract "are we currently
+            // mirroring anything" question.
+            if workspaceSyncActive, !isSyncExcluded {
+                HStack(spacing: 2) {
+                    Image(systemName: "rectangle.connected.to.line.below")
+                        .font(.system(size: 8))
+                    Text("SYNC")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .lineLimit(1)
+                }
+                .foregroundStyle(.orange)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 3))
+                .help("Synchronise input is on — keystrokes mirror to peer panes")
+            } else if workspaceSyncActive, isSyncExcluded {
+                // Sync is on for the workspace but this pane is opted
+                // out. Distinct affordance so the user can tell the
+                // difference between "no sync" and "sync, but skipped".
+                HStack(spacing: 2) {
+                    Image(systemName: "rectangle.dashed")
+                        .font(.system(size: 8))
+                    Text("SYNC OFF")
+                        .font(.system(size: 9, weight: .medium, design: .monospaced))
+                        .lineLimit(1)
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 3))
+                .help("Excluded from the workspace sync group")
             }
 
             Spacer()
@@ -248,6 +298,12 @@ struct PaneHeaderView: View {
                 ForEach(otherWorkspaces, id: \.id) { ws in
                     Button(ws.name) { onMoveToWorkspace(ws.id) }
                 }
+            }
+        }
+        if workspaceSyncActive, let onToggleSyncExcluded {
+            Divider()
+            Button(isSyncExcluded ? "Include in Sync" : "Exclude from Sync") {
+                onToggleSyncExcluded()
             }
         }
         Divider()

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -65,12 +65,15 @@ struct WorkspaceFeature {
         /// panes opened while sync is active auto-join the group.
         /// Transient — resets on app restart.
         var isSyncInputActive: Bool = false
-        /// Panes explicitly opted out of the active sync group. The set
-        /// is honoured only while `isSyncInputActive` is true and is
-        /// cleared whenever sync toggles off — re-enabling sync starts
-        /// from a fresh "all shell panes participate" baseline rather
-        /// than restoring potentially-stale opt-outs from a previous
-        /// session. Transient.
+        /// Panes explicitly opted out of the active sync group.
+        /// Strictly ephemeral within a single on-cycle: the set is
+        /// cleared on every transition of `isSyncInputActive` (both
+        /// off→on and on→off) so each on-cycle starts from a fresh
+        /// "all shell panes participate" baseline. This means
+        /// `nex pane sync exclude` run while sync is off has no
+        /// effect on the next on-cycle — coordinators should sequence
+        /// `sync on` first, then `sync exclude --target <pane>`.
+        /// Transient — also resets on app restart.
         var syncInputExcluded: Set<UUID> = []
 
         /// Pane IDs that should mirror each other's keystrokes right
@@ -396,7 +399,7 @@ struct WorkspaceFeature {
         let paneIDs = state.syncedPaneIDs
         let mgr = surfaceManager
         return .run { _ in
-            await mgr.setSyncGroup(workspaceID: workspaceID, paneIDs: paneIDs)
+            mgr.setSyncGroup(workspaceID: workspaceID, paneIDs: paneIDs)
         }
     }
 
@@ -1556,22 +1559,18 @@ struct WorkspaceFeature {
 
             case .toggleSyncInput:
                 state.isSyncInputActive.toggle()
-                // Clearing the exclusion set on toggle-off keeps the
-                // workspace tidy: re-enabling sync later starts from a
-                // fresh "all panes participate" baseline rather than
-                // restoring potentially-stale opt-outs from a previous
-                // session. Excludes can still be re-applied per pane.
-                if !state.isSyncInputActive {
-                    state.syncInputExcluded.removeAll()
-                }
+                // Clear on every transition so re-enabling sync always
+                // starts from a fresh "all panes participate" baseline.
+                // Clearing on toggle-off alone would let a pre-staged
+                // `pane sync exclude` (run while sync was off) survive
+                // into the next on-cycle and silently exclude a pane.
+                state.syncInputExcluded.removeAll()
                 return refreshSyncGroup(state)
 
             case .setSyncInputActive(let active):
                 guard state.isSyncInputActive != active else { return .none }
                 state.isSyncInputActive = active
-                if !active {
-                    state.syncInputExcluded.removeAll()
-                }
+                state.syncInputExcluded.removeAll()
                 return refreshSyncGroup(state)
 
             case .setSyncInputExcluded(let paneID, let excluded):

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -59,6 +59,39 @@ struct WorkspaceFeature {
         /// Drives the sidebar filter — see `WorkspaceListView` filter
         /// field and `WorkspaceInspectorView` label editor.
         var labels: [String] = []
+        /// Tmux-style synchronise-input toggle (issue #121). When true,
+        /// keystrokes typed in any pane of this workspace are mirrored
+        /// to every other pane that isn't in `syncInputExcluded`. New
+        /// panes opened while sync is active auto-join the group.
+        /// Transient — resets on app restart.
+        var isSyncInputActive: Bool = false
+        /// Panes explicitly opted out of the active sync group. The set
+        /// is honoured only while `isSyncInputActive` is true and is
+        /// cleared whenever sync toggles off — re-enabling sync starts
+        /// from a fresh "all shell panes participate" baseline rather
+        /// than restoring potentially-stale opt-outs from a previous
+        /// session. Transient.
+        var syncInputExcluded: Set<UUID> = []
+
+        /// Pane IDs that should mirror each other's keystrokes right
+        /// now. Empty when sync is off OR when fewer than two shell
+        /// panes would participate (mirroring to nothing is a no-op
+        /// anyway). Non-shell panes (markdown / scratchpad / diff /
+        /// web) are filtered out even when they host a ghostty
+        /// surface — e.g. markdown panes in `$EDITOR` mode register
+        /// a surface to host vim/nano, and mirroring `/compact`-style
+        /// agent prompts into that editor would be a footgun. Pushed
+        /// into `SurfaceManager.setSyncGroup` by the reducer whenever
+        /// `isSyncInputActive`, `syncInputExcluded`, or `panes` change.
+        var syncedPaneIDs: Set<UUID> {
+            guard isSyncInputActive else { return [] }
+            let candidates = panes
+                .lazy
+                .filter { $0.type == .shell && !syncInputExcluded.contains($0.id) }
+                .map(\.id)
+            let result = Set(candidates)
+            return result.count >= 2 ? result : []
+        }
 
         init(
             id: UUID = UUID(),
@@ -323,6 +356,11 @@ struct WorkspaceFeature {
         case searchClose
         case searchTotalUpdated(paneID: UUID, total: Int)
         case searchSelectedUpdated(paneID: UUID, selected: Int)
+
+        // Synchronise input (issue #121)
+        case toggleSyncInput
+        case setSyncInputActive(Bool)
+        case setSyncInputExcluded(paneID: UUID, excluded: Bool)
     }
 
     private enum SearchDebounceID: Hashable { case debounce }
@@ -348,6 +386,19 @@ struct WorkspaceFeature {
     @Dependency(\.webPaneStore) var webPaneStore
     @Dependency(\.date.now) var now
     @Dependency(\.uuid) var uuid
+
+    /// Push the workspace's current sync group to `SurfaceManager`.
+    /// Cheap when sync is off (the manager clears the entry); cheap
+    /// when on (a single dict assignment). Returned by any action
+    /// that mutates `panes` or the sync-state fields.
+    private func refreshSyncGroup(_ state: WorkspaceFeature.State) -> Effect<Action> {
+        let workspaceID = state.id
+        let paneIDs = state.syncedPaneIDs
+        let mgr = surfaceManager
+        return .run { _ in
+            await mgr.setSyncGroup(workspaceID: workspaceID, paneIDs: paneIDs)
+        }
+    }
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -1503,6 +1554,35 @@ struct WorkspaceFeature {
                 state.searchSelected = selected
                 return .none
 
+            case .toggleSyncInput:
+                state.isSyncInputActive.toggle()
+                // Clearing the exclusion set on toggle-off keeps the
+                // workspace tidy: re-enabling sync later starts from a
+                // fresh "all panes participate" baseline rather than
+                // restoring potentially-stale opt-outs from a previous
+                // session. Excludes can still be re-applied per pane.
+                if !state.isSyncInputActive {
+                    state.syncInputExcluded.removeAll()
+                }
+                return refreshSyncGroup(state)
+
+            case .setSyncInputActive(let active):
+                guard state.isSyncInputActive != active else { return .none }
+                state.isSyncInputActive = active
+                if !active {
+                    state.syncInputExcluded.removeAll()
+                }
+                return refreshSyncGroup(state)
+
+            case .setSyncInputExcluded(let paneID, let excluded):
+                guard state.panes[id: paneID] != nil else { return .none }
+                if excluded {
+                    state.syncInputExcluded.insert(paneID)
+                } else {
+                    state.syncInputExcluded.remove(paneID)
+                }
+                return refreshSyncGroup(state)
+
             case .reopenClosedPane:
                 guard let snapshot = state.recentlyClosedPanes.popLast() else { return .none }
                 guard let focusedID = state.focusedPaneID else { return .none }
@@ -1554,6 +1634,24 @@ struct WorkspaceFeature {
                         )
                     }
                 }
+            }
+        }
+        // Sync-input bookkeeping (issue #121). When sync is active for
+        // this workspace and an action mutated the pane set, push the
+        // updated group to `SurfaceManager` so brand-new panes join
+        // and closed panes drop out without the caller having to
+        // remember. The explicit sync-toggle actions already refresh
+        // synchronously, so they're filtered out here.
+        Reduce { state, action in
+            guard state.isSyncInputActive else { return .none }
+            switch action {
+            case .createPane, .splitPane, .splitPaneAtPath, .closePane,
+                 .openMarkdownFile, .openDiffPane, .openWebPane,
+                 .createScratchpad, .reopenClosedPane,
+                 .paneProcessTerminated:
+                return refreshSyncGroup(state)
+            default:
+                return .none
             }
         }
     }

--- a/Nex/Ghostty/SurfaceView.swift
+++ b/Nex/Ghostty/SurfaceView.swift
@@ -278,12 +278,20 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
     private func sendKey(_ key: ghostty_input_key_s, text: String?) {
         guard let text else {
             _ = ghosttySurface?.sendKey(key)
+            // Mirror to sync-input peers (issue #121). No-op when this
+            // pane isn't in any sync group, so the overhead is a single
+            // dictionary lookup in `SurfaceManager`.
+            SurfaceManager.liveValue.broadcastKey(from: paneID, key: key)
             return
         }
         var keyWithText = key
         text.withCString { ptr in
             keyWithText.text = ptr
             _ = ghosttySurface?.sendKey(keyWithText)
+            // Broadcast inside `withCString` so `keyWithText.text`
+            // (which points into this stack frame) is still live for
+            // each sibling's `sendKey` call.
+            SurfaceManager.liveValue.broadcastKey(from: paneID, key: keyWithText)
         }
     }
 
@@ -437,6 +445,10 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
         } else {
             // Outside keyDown (dictation, services menu paste, drag-drop): send directly.
             ghosttySurface?.sendText(str)
+            // Mirror to sync-input peers (issue #121). The keyDown path
+            // covers normal typing; this branch covers IME / dictation /
+            // paste fall-throughs.
+            SurfaceManager.liveValue.broadcastText(from: paneID, text: str)
         }
     }
 

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -247,6 +247,7 @@ enum NexAction: String, CaseIterable {
     case commandPalette = "command_palette"
     case newGroup = "new_group"
     case openDiff = "open_diff"
+    case toggleSyncInput = "toggle_sync_input"
 
     // Web pane actions. All ship unbound; the priority layer in
     // `PaneShortcutMonitor` dispatches them directly when the focused
@@ -320,6 +321,7 @@ enum NexAction: String, CaseIterable {
         case .commandPalette: "Command Palette"
         case .newGroup: "New Group"
         case .openDiff: "Open Diff"
+        case .toggleSyncInput: "Toggle Synchronise Input"
         case .openWebPane: "Open Web Pane"
         case .webFocusURLBar: "Web: Focus URL Bar"
         case .webBack: "Web: Back"
@@ -337,7 +339,8 @@ enum NexAction: String, CaseIterable {
     var category: String {
         switch self {
         case .splitRight, .splitDown, .closePane, .reopenClosedPane, .toggleZoom, .cycleLayout,
-             .movePaneLeft, .movePaneRight, .movePaneUp, .movePaneDown, .createScratchpad:
+             .movePaneLeft, .movePaneRight, .movePaneUp, .movePaneDown, .createScratchpad,
+             .toggleSyncInput:
             "Pane Management"
         case .focusNextPane, .focusPreviousPane, .commandPalette:
             "Navigation"

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -75,6 +75,19 @@ enum SocketMessage: Equatable {
     /// Replies with `{"ok":true,"text":"..."}` or `{"ok":false,"error":...}`
     /// (request/response — see `replyCommandAllowlist`).
     case paneCapture(paneID: UUID?, target: String?, workspace: String?, lines: Int?, includeScrollback: Bool)
+    /// `nex pane sync (on|off|toggle|status)` (issue #121).
+    /// `action` is one of `"on"`, `"off"`, `"toggle"`, `"status"`.
+    /// `paneID` (from `NEX_PANE_ID`) scopes the request to the
+    /// caller's workspace when `workspace` is unset. `status` is
+    /// read-only and never mutates state. Request/response — see
+    /// `replyCommandAllowlist`.
+    case paneSync(paneID: UUID?, workspace: String?, action: String)
+    /// `nex pane sync exclude|include` — adjust the per-workspace
+    /// exclusion set. `target` resolves a pane via the same rules as
+    /// `paneSend` / `paneClose` (label or UUID, with `--workspace`
+    /// scoping for labels). Idempotent: excluding an already-excluded
+    /// pane (or vice versa) is a no-op success.
+    case paneSyncExclude(paneID: UUID?, target: String, workspace: String?, excluded: Bool)
     /// `nex graft start` — begin worktree-to-root mirroring. `paneID`
     /// comes from `NEX_PANE_ID` and scopes resolution to the caller's
     /// workspace when neither `workspace` nor `repo` is supplied.
@@ -279,6 +292,7 @@ enum SocketMessage: Equatable {
 /// pre-request/response protocol.
 private let replyCommandAllowlist: Set<String> = [
     "pane-list", "pane-close", "pane-capture", "pane-send", "pane-send-key",
+    "pane-sync", "pane-sync-exclude",
     "graft-start", "graft-stop", "graft-status",
     "web-open", "web-navigate", "web-url", "web-back",
     "web-forward", "web-reload", "web-capture",
@@ -771,6 +785,11 @@ final class SocketServer: Sendable {
         var behavior: String?
         /// `web-exec` — author-supplied JS body.
         var script: String?
+        /// `pane-sync` — one of `on`, `off`, `toggle`, `status`.
+        var action: String?
+        /// `pane-sync-exclude` — true to exclude the target pane,
+        /// false to re-include. Required for that command.
+        var excluded: Bool?
 
         enum CodingKeys: String, CodingKey {
             case command
@@ -806,6 +825,7 @@ final class SocketServer: Sendable {
             case valueOrLabel = "value_or_label"
             case block, behavior
             case script
+            case action, excluded
         }
     }
 
@@ -1273,6 +1293,23 @@ final class SocketServer: Sendable {
                 urlMatch: urlMatch,
                 forCondition: forCondition,
                 timeoutMs: timeoutMs
+            ), wire)
+        }
+
+        if wire.command == "pane-sync" {
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+            guard let action = wire.action, !action.isEmpty else { return nil }
+            return (.paneSync(paneID: paneID, workspace: workspace, action: action), wire)
+        }
+
+        if wire.command == "pane-sync-exclude" {
+            let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
+            guard let target = wire.target, !target.isEmpty,
+                  let excluded = wire.excluded else { return nil }
+            let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
+            return (.paneSyncExclude(
+                paneID: paneID, target: target, workspace: workspace, excluded: excluded
             ), wire)
         }
 

--- a/Nex/Services/SurfaceManager.swift
+++ b/Nex/Services/SurfaceManager.swift
@@ -8,6 +8,13 @@ final class SurfaceManager: Sendable {
     private let lock = NSLock()
     /// nonisolated(unsafe) because access is protected by lock
     private nonisolated(unsafe) var surfaces: [UUID: SurfaceView] = [:]
+    /// Per-workspace sync-input groups. When a key event lands in a
+    /// pane that belongs to any group, the same event is mirrored to
+    /// every other pane in that group via libghostty. Replaced
+    /// wholesale by the WorkspaceFeature reducer on every sync state
+    /// change; empty / missing entry = no mirroring for that workspace.
+    /// See `Issue #121` (tmux-style synchronise-panes).
+    private nonisolated(unsafe) var syncGroups: [UUID: Set<UUID>] = [:]
 
     @MainActor
     func createSurface(
@@ -155,6 +162,81 @@ final class SurfaceManager: Sendable {
     private nonisolated(unsafe) var _focusCalls: [UUID] = []
     @MainActor
     var focusCalls: [UUID] { _focusCalls }
+
+    // MARK: - Synchronise input (issue #121)
+
+    /// Replace the sync-input group for one workspace. `paneIDs` is the
+    /// full set of panes that should mirror each other; passing an
+    /// empty set turns sync off for that workspace. Workspaces with
+    /// no entry contribute nothing to broadcast lookups.
+    func setSyncGroup(workspaceID: UUID, paneIDs: Set<UUID>) {
+        lock.withLock {
+            if paneIDs.isEmpty {
+                syncGroups.removeValue(forKey: workspaceID)
+            } else {
+                syncGroups[workspaceID] = paneIDs
+            }
+        }
+    }
+
+    /// True if `paneID` is currently participating in any sync group.
+    /// Read by the view layer (header chrome) to show the sync badge.
+    func isSyncing(paneID: UUID) -> Bool {
+        lock.withLock {
+            syncGroups.values.contains { $0.contains(paneID) }
+        }
+    }
+
+    /// Snapshot the set of pane IDs that should mirror a key event
+    /// originating from `sourcePaneID`. Excludes the source itself.
+    /// Returns the empty set when the source is not in any sync group.
+    /// Exposed publicly so tests can assert the cross-workspace
+    /// boundary without registering live `SurfaceView` instances.
+    func syncTargetIDs(sourcePaneID: UUID) -> Set<UUID> {
+        lock.withLock {
+            var ids: Set<UUID> = []
+            for (_, group) in syncGroups where group.contains(sourcePaneID) {
+                ids.formUnion(group)
+            }
+            ids.remove(sourcePaneID)
+            return ids
+        }
+    }
+
+    /// Resolve the sibling pane IDs to live `SurfaceView` instances.
+    /// Surfaces that have been torn down (PTY exited, view destroyed)
+    /// are dropped silently — broadcast is best-effort.
+    func syncTargets(sourcePaneID: UUID) -> [SurfaceView] {
+        let targetIDs = syncTargetIDs(sourcePaneID: sourcePaneID)
+        if targetIDs.isEmpty { return [] }
+        let snapshot = lock.withLock { surfaces }
+        return targetIDs.compactMap { snapshot[$0] }
+    }
+
+    /// Mirror a libghostty key event to every sibling pane in the
+    /// source's sync group. Called by `SurfaceView.sendKey` immediately
+    /// after the local delivery. Must be called inside any `withCString`
+    /// that owns the `key.text` pointer — by the time we return, no
+    /// pointer reads outlive the call. Returns synchronously after all
+    /// libghostty calls have consumed their copies.
+    @MainActor
+    func broadcastKey(from sourcePaneID: UUID, key: ghostty_input_key_s) {
+        for surface in syncTargets(sourcePaneID: sourcePaneID) {
+            _ = surface.ghosttySurface?.sendKey(key)
+        }
+    }
+
+    /// Mirror a UTF-8 text payload (dictation, services menu paste,
+    /// drag-drop) to every sibling pane in the source's sync group.
+    /// Called by `SurfaceView.insertText` outside the keyDown
+    /// accumulator path (the keyDown path goes through `broadcastKey`
+    /// after libghostty composition resolves).
+    @MainActor
+    func broadcastText(from sourcePaneID: UUID, text: String) {
+        for surface in syncTargets(sourcePaneID: sourcePaneID) {
+            surface.ghosttySurface?.sendText(text)
+        }
+    }
 
     func paneID(for rawSurface: ghostty_surface_t) -> UUID? {
         lock.withLock {

--- a/Nex/Services/SurfaceManager.swift
+++ b/Nex/Services/SurfaceManager.swift
@@ -205,12 +205,21 @@ final class SurfaceManager: Sendable {
 
     /// Resolve the sibling pane IDs to live `SurfaceView` instances.
     /// Surfaces that have been torn down (PTY exited, view destroyed)
-    /// are dropped silently — broadcast is best-effort.
+    /// are dropped silently — broadcast is best-effort. Single lock
+    /// acquisition so the group lookup and the surface dictionary
+    /// snapshot can't drift between two acquisitions.
     func syncTargets(sourcePaneID: UUID) -> [SurfaceView] {
-        let targetIDs = syncTargetIDs(sourcePaneID: sourcePaneID)
-        if targetIDs.isEmpty { return [] }
-        let snapshot = lock.withLock { surfaces }
-        return targetIDs.compactMap { snapshot[$0] }
+        lock.withLock {
+            var result: [SurfaceView] = []
+            for (_, group) in syncGroups where group.contains(sourcePaneID) {
+                for id in group where id != sourcePaneID {
+                    if let view = surfaces[id] {
+                        result.append(view)
+                    }
+                }
+            }
+            return result
+        }
     }
 
     /// Mirror a libghostty key event to every sibling pane in the

--- a/NexTests/SyncInputTests.swift
+++ b/NexTests/SyncInputTests.swift
@@ -1,0 +1,178 @@
+import ComposableArchitecture
+import Foundation
+@testable import Nex
+import Testing
+
+/// Unit tests for the workspace-scoped synchronise-input feature
+/// added in issue #121. We assert reducer behaviour (state transitions
+/// + SurfaceManager pushes) here; the actual libghostty mirroring is
+/// covered by the cua VM validator.
+@MainActor
+struct SyncInputTests {
+    @Test func toggleSyncInputActivatesAndIncludesAllPanes() async {
+        let firstPaneID = UUID(uuidString: "00000000-0000-0000-0000-00000000aaaa")!
+        let secondPaneID = UUID(uuidString: "00000000-0000-0000-0000-00000000bbbb")!
+        var workspace = WorkspaceFeature.State(id: UUID(), name: "Sync")
+        // Replace the auto-created pane with two predictable ones.
+        workspace.panes = [Pane(id: firstPaneID), Pane(id: secondPaneID)]
+        workspace.layout = .split(.horizontal, ratio: 0.5,
+                                  first: .leaf(firstPaneID), second: .leaf(secondPaneID))
+        workspace.focusedPaneID = firstPaneID
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.toggleSyncInput) { state in
+            #expect(state.isSyncInputActive)
+            #expect(state.syncedPaneIDs == Set([firstPaneID, secondPaneID]))
+        }
+    }
+
+    @Test func toggleSyncInputOffClearsExclusions() async {
+        let paneA = UUID(uuidString: "00000000-0000-0000-0000-00000000cccc")!
+        let paneB = UUID(uuidString: "00000000-0000-0000-0000-00000000dddd")!
+        var workspace = WorkspaceFeature.State(id: UUID(), name: "Sync")
+        workspace.panes = [Pane(id: paneA), Pane(id: paneB)]
+        workspace.layout = .split(.horizontal, ratio: 0.5,
+                                  first: .leaf(paneA), second: .leaf(paneB))
+        workspace.focusedPaneID = paneA
+        workspace.isSyncInputActive = true
+        workspace.syncInputExcluded = [paneB]
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.toggleSyncInput) { state in
+            #expect(state.isSyncInputActive == false)
+            #expect(state.syncInputExcluded.isEmpty)
+            #expect(state.syncedPaneIDs.isEmpty)
+        }
+    }
+
+    @Test func setSyncInputExcludedRemovesPaneFromSyncedSet() async {
+        let paneA = UUID(uuidString: "00000000-0000-0000-0000-00000000eeee")!
+        let paneB = UUID(uuidString: "00000000-0000-0000-0000-00000000ffff")!
+        var workspace = WorkspaceFeature.State(id: UUID(), name: "Sync")
+        workspace.panes = [Pane(id: paneA), Pane(id: paneB)]
+        workspace.layout = .split(.horizontal, ratio: 0.5,
+                                  first: .leaf(paneA), second: .leaf(paneB))
+        workspace.focusedPaneID = paneA
+        workspace.isSyncInputActive = true
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.setSyncInputExcluded(paneID: paneB, excluded: true)) { state in
+            #expect(state.syncInputExcluded == Set([paneB]))
+            // syncedPaneIDs returns [] when fewer than 2 panes would
+            // participate — excluding the only sibling collapses to
+            // a no-op group, which is the right answer for broadcast.
+            #expect(state.syncedPaneIDs.isEmpty)
+        }
+    }
+
+    @Test func newSplitPaneAutoJoinsSyncGroup() async {
+        let originalPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000001111")!
+        let newPaneID = UUID(uuidString: "00000000-0000-0000-0000-000000002222")!
+        var workspace = WorkspaceFeature.State(id: UUID(), name: "Sync")
+        workspace.panes = [Pane(id: originalPaneID), Pane(id: newPaneID)]
+        workspace.layout = .leaf(originalPaneID)
+        workspace.focusedPaneID = originalPaneID
+        workspace.isSyncInputActive = true
+        // syncedPaneIDs only kicks in with >=2 panes — start with the
+        // original solo and assert the split brings the count to 2.
+        let initialWorkspace = WorkspaceFeature.State(
+            id: workspace.id,
+            name: "Sync",
+            slug: "sync",
+            color: .blue,
+            panes: [Pane(id: originalPaneID)],
+            layout: .leaf(originalPaneID),
+            focusedPaneID: originalPaneID,
+            createdAt: Date(timeIntervalSince1970: 0),
+            lastAccessedAt: Date(timeIntervalSince1970: 0)
+        )
+        var seededWorkspace = initialWorkspace
+        seededWorkspace.isSyncInputActive = true
+
+        let store = TestStore(initialState: seededWorkspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.uuid = .constant(newPaneID)
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.splitPane(direction: .horizontal, sourcePaneID: originalPaneID)) { state in
+            #expect(state.panes.count == 2)
+            #expect(state.isSyncInputActive)
+            // Both panes now in the sync set — issue #121 promises
+            // new panes opened mid-sync auto-join the group.
+            #expect(state.syncedPaneIDs == Set([originalPaneID, newPaneID]))
+        }
+    }
+
+    @Test func surfaceManagerSetSyncGroupReplacesPrevious() {
+        let mgr = SurfaceManager()
+        let workspaceID = UUID()
+        let paneA = UUID()
+        let paneB = UUID()
+        let paneC = UUID()
+
+        mgr.setSyncGroup(workspaceID: workspaceID, paneIDs: [paneA, paneB])
+        #expect(mgr.isSyncing(paneID: paneA))
+        #expect(mgr.isSyncing(paneID: paneB))
+        #expect(!mgr.isSyncing(paneID: paneC))
+
+        mgr.setSyncGroup(workspaceID: workspaceID, paneIDs: [paneA, paneC])
+        #expect(mgr.isSyncing(paneID: paneA))
+        #expect(!mgr.isSyncing(paneID: paneB))
+        #expect(mgr.isSyncing(paneID: paneC))
+
+        mgr.setSyncGroup(workspaceID: workspaceID, paneIDs: [])
+        #expect(!mgr.isSyncing(paneID: paneA))
+        #expect(!mgr.isSyncing(paneID: paneC))
+    }
+
+    @Test func surfaceManagerKeepsWorkspaceGroupsIsolated() {
+        let mgr = SurfaceManager()
+        let workspace1 = UUID()
+        let workspace2 = UUID()
+        let paneA = UUID()
+        let paneB = UUID()
+        let paneC = UUID()
+        let paneD = UUID()
+
+        mgr.setSyncGroup(workspaceID: workspace1, paneIDs: [paneA, paneB])
+        mgr.setSyncGroup(workspaceID: workspace2, paneIDs: [paneC, paneD])
+
+        // The real cross-workspace boundary check: a key from paneA
+        // resolves to siblings strictly within workspace1's group,
+        // and paneC's siblings strictly within workspace2's group.
+        #expect(mgr.syncTargetIDs(sourcePaneID: paneA) == Set([paneB]))
+        #expect(mgr.syncTargetIDs(sourcePaneID: paneB) == Set([paneA]))
+        #expect(mgr.syncTargetIDs(sourcePaneID: paneC) == Set([paneD]))
+        #expect(mgr.syncTargetIDs(sourcePaneID: paneD) == Set([paneC]))
+        // Source is always excluded from its own target set, even if
+        // someone constructed a degenerate single-pane group.
+        #expect(!mgr.syncTargetIDs(sourcePaneID: paneA).contains(paneA))
+
+        // Clearing workspace1 leaves workspace2's group intact.
+        mgr.setSyncGroup(workspaceID: workspace1, paneIDs: [])
+        #expect(mgr.syncTargetIDs(sourcePaneID: paneA).isEmpty)
+        #expect(mgr.syncTargetIDs(sourcePaneID: paneC) == Set([paneD]))
+    }
+}

--- a/Resources/skills/nex-agentic/SKILL.md
+++ b/Resources/skills/nex-agentic/SKILL.md
@@ -446,6 +446,34 @@ Smoke tests can still use `data:` URLs for navigation, `capture
   `backspace`, `up`/`down`/`left`/`right`, and `ctrl-c`. It uses the same
   `--target` / `--workspace` resolution as `pane send`.
 
+### Broadcasting to every worker pane (`pane sync`)
+
+When you want the same keystrokes (e.g. `/compact`, `clear`, an interrupt)
+to land in every worker pane of the workspace at once, toggle tmux-style
+synchronise-input:
+
+```bash
+nex pane sync on            # mirror keystrokes across this workspace
+# ... type in any pane; every other pane in the workspace gets the same input
+nex pane sync off           # back to per-pane input
+
+nex pane sync toggle        # flip without caring about the current state
+nex pane sync status --json # read-only snapshot, machine-readable
+```
+
+Opt a single pane out of the active sync group (handy for a coordinator
+pane you don't want broadcasting into):
+
+```bash
+nex pane sync exclude --target coordinator
+nex pane sync include --target coordinator   # undo
+```
+
+Scope defaults to the calling pane's workspace via `NEX_PANE_ID`. Pass
+`--workspace <name-or-uuid>` to target another workspace from an
+external script. New panes opened while sync is on auto-join the group;
+closed panes drop out automatically.
+
 ## Multi-Agent Workflow Patterns
 
 ### Pattern 1: Fan-Out with Markdown Communication (Recommended)

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -15,6 +15,9 @@
 //   nex pane move-to-workspace --to-workspace <name-or-uuid> [--create]
 //   nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]
 //   nex pane capture [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--lines N] [--scrollback]
+//   nex pane sync (on|off|toggle|status) [--workspace <name-or-uuid>] [--json]
+//   nex pane sync exclude --target <name-or-uuid> [--workspace <name-or-uuid>]
+//   nex pane sync include --target <name-or-uuid> [--workspace <name-or-uuid>]
 //   nex pane id
 //   nex workspace create [--name "..."] [--path /dir] [--color blue] [--group <name>]
 //   nex workspace move <name-or-id> (--group <name> | --top-level) [--index N]
@@ -88,6 +91,9 @@ func printUsage() {
       nex pane move-to-workspace --to-workspace <name-or-uuid> [--create]
       nex pane list [--workspace <name-or-id> | --current] [--json] [--no-header]
       nex pane capture [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--lines N] [--scrollback]
+      nex pane sync (on|off|toggle|status) [--workspace <name-or-uuid>] [--json]
+      nex pane sync exclude --target <name-or-uuid> [--workspace <name-or-uuid>]
+      nex pane sync include --target <name-or-uuid> [--workspace <name-or-uuid>]
       nex pane id
       nex workspace create [--name "..."] [--path /dir] [--color blue] [--group <name>]
       nex workspace move <name-or-id> (--group <name> | --top-level) [--index N]
@@ -453,7 +459,7 @@ func handleEvent(_ args: inout ArraySlice<String>) {
 
 func handlePane(_ args: inout ArraySlice<String>) {
     guard let action = args.popFirst() else {
-        fputs("Usage: nex pane split|create|close|name|send|send-key|move|list|capture|id [...]\n", stderr)
+        fputs("Usage: nex pane split|create|close|name|send|send-key|move|list|capture|sync|id [...]\n", stderr)
         exit(1)
     }
 
@@ -791,10 +797,164 @@ func handlePane(_ args: inout ArraySlice<String>) {
     case "capture":
         handlePaneCapture(&args)
 
+    case "sync":
+        handlePaneSync(&args)
+
     default:
         fputs("Unknown pane action: \(action)\n", stderr)
-        fputs("Valid actions: split, create, close, name, send, send-key, move, move-to-workspace, list, capture, id\n", stderr)
+        fputs("Valid actions: split, create, close, name, send, send-key, move, move-to-workspace, list, capture, sync, id\n", stderr)
         exit(1)
+    }
+}
+
+// MARK: - pane sync (issue #121)
+
+/// Implements `nex pane sync (on|off|toggle|status|exclude|include)`.
+/// All forms are request/response and exit non-zero on server error.
+func handlePaneSync(_ args: inout ArraySlice<String>) {
+    guard let mode = args.popFirst() else {
+        printPaneSyncUsage(stream: stderr)
+        exit(1)
+    }
+
+    if mode == "-h" || mode == "--help" || mode == "help" {
+        printPaneSyncUsage(stream: stdout)
+        exit(0)
+    }
+
+    let workspace = parseFlag("--workspace", from: &args)
+    let asJSON = popSwitch("--json", from: &args)
+
+    switch mode {
+    case "on", "off", "toggle", "status":
+        // `--target` doesn't make sense for the whole-workspace
+        // toggle — surface the typo rather than silently dropping it.
+        if let stray = parseFlag("--target", from: &args) {
+            fputs("nex pane sync \(mode): --target \(stray) is not valid here " +
+                "(the toggle is workspace-wide). Use `nex pane sync exclude --target ...` " +
+                "to opt a pane out.\n", stderr)
+            exit(1)
+        }
+        if let stray = args.first {
+            fputs("nex pane sync \(mode): unexpected argument '\(stray)'\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = [
+            "command": "pane-sync",
+            "action": mode
+        ]
+        if let workspace, !workspace.isEmpty {
+            payload["workspace"] = workspace
+        }
+        if let originPaneID = ProcessInfo.processInfo.environment["NEX_PANE_ID"],
+           !originPaneID.isEmpty {
+            payload["pane_id"] = originPaneID
+        }
+        sendPaneSyncReply(payload, command: "sync \(mode)", asJSON: asJSON)
+
+    case "exclude", "include":
+        let target = parseFlag("--target", from: &args)
+        guard let target, !target.isEmpty else {
+            fputs("Usage: nex pane sync \(mode) --target <name-or-uuid> [--workspace <name-or-uuid>]\n", stderr)
+            exit(1)
+        }
+        if let stray = args.first {
+            fputs("nex pane sync \(mode): unexpected argument '\(stray)'\n", stderr)
+            exit(1)
+        }
+        var payload: [String: Any] = [
+            "command": "pane-sync-exclude",
+            "target": target,
+            "excluded": mode == "exclude"
+        ]
+        if let workspace, !workspace.isEmpty {
+            payload["workspace"] = workspace
+        }
+        if let originPaneID = ProcessInfo.processInfo.environment["NEX_PANE_ID"],
+           !originPaneID.isEmpty {
+            payload["pane_id"] = originPaneID
+        }
+        sendPaneSyncReply(payload, command: "sync \(mode)", asJSON: asJSON)
+
+    default:
+        fputs("Unknown sync mode: \(mode)\n", stderr)
+        printPaneSyncUsage(stream: stderr)
+        exit(1)
+    }
+}
+
+func printPaneSyncUsage(stream: UnsafeMutablePointer<FILE>) {
+    fputs("""
+    Usage:
+      nex pane sync (on|off|toggle|status) [--workspace <name-or-uuid>] [--json]
+      nex pane sync exclude --target <name-or-uuid> [--workspace <name-or-uuid>]
+      nex pane sync include --target <name-or-uuid> [--workspace <name-or-uuid>]
+
+    When `on`, every keystroke typed in any pane of the workspace is mirrored
+    to the other panes in the workspace. Use `exclude` / `include` to opt a
+    specific pane out of (or back into) the sync group. `status` reports the
+    current sync state without mutating it.
+
+    Workspace defaults to the calling pane's workspace (via NEX_PANE_ID)
+    when --workspace is not supplied.
+    \n
+    """, stream)
+}
+
+private func sendPaneSyncReply(
+    _ payload: [String: Any], command: String, asJSON: Bool
+) {
+    guard let replyData = sendJSONAndReadReply(payload) else {
+        fputs("nex pane \(command): transport failure (is Nex running?)\n", stderr)
+        exit(1)
+    }
+    if replyData.isEmpty {
+        fputs("nex pane \(command): empty reply (Nex version may not support this command)\n", stderr)
+        exit(1)
+    }
+    guard let json = try? JSONSerialization.jsonObject(with: replyData) as? [String: Any] else {
+        fputs("nex pane \(command): invalid JSON response\n", stderr)
+        exit(1)
+    }
+    if let ok = json["ok"] as? Bool, ok == false {
+        let msg = (json["error"] as? String) ?? "unknown error"
+        fputs("nex pane \(command): \(msg)\n", stderr)
+        exit(1)
+    }
+
+    if asJSON {
+        // Strip the `ok` field so JSON consumers see the same shape
+        // they'd get from a status-only query without the success flag
+        // (success is implicit since we exit non-zero on `ok: false`).
+        var clean = json
+        clean.removeValue(forKey: "ok")
+        if let data = try? JSONSerialization.data(withJSONObject: clean, options: .sortedKeys),
+           let string = String(data: data, encoding: .utf8) {
+            print(string)
+        }
+        return
+    }
+
+    // Default human-readable summary.
+    let active = (json["active"] as? Bool) ?? false
+    let synced = (json["synced_pane_ids"] as? [String]) ?? []
+    let excluded = (json["excluded"] as? [[String: Any]]) ?? []
+    let workspaceName = (json["workspace_name"] as? String) ?? "?"
+
+    let stateStr = active ? "on" : "off"
+    print("workspace: \(workspaceName)")
+    print("sync     : \(stateStr)")
+    if active {
+        print("synced   : \(synced.count) pane\(synced.count == 1 ? "" : "s")")
+        if !excluded.isEmpty {
+            let labels = excluded.compactMap { entry -> String in
+                if let label = entry["label"] as? String, !label.isEmpty {
+                    return label
+                }
+                return (entry["id"] as? String) ?? "?"
+            }
+            print("excluded : \(labels.joined(separator: ", "))")
+        }
     }
 }
 

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -895,6 +895,11 @@ func printPaneSyncUsage(stream: UnsafeMutablePointer<FILE>) {
     specific pane out of (or back into) the sync group. `status` reports the
     current sync state without mutating it.
 
+    Excludes are ephemeral within a single on-cycle: any `on` / `off` /
+    `toggle` clears the exclusion set. Sequence is `sync on` first, then
+    `sync exclude --target <pane>`; running exclude while sync is off has
+    no effect on the next on-cycle.
+
     Workspace defaults to the calling pane's workspace (via NEX_PANE_ID)
     when --workspace is not supplied.
     \n


### PR DESCRIPTION
## Summary
- Adds a workspace-scoped sync toggle that mirrors keystrokes from the focused pane to every other shell pane in the workspace. Tees at `SurfaceView.sendKey` / `.insertText` and delivers via `SurfaceManager`, so mirroring rides the same libghostty path local input takes — Ctrl-C, Enter, arrows, IME all behave identically.
- Per-pane opt-out via right-click context menu (`Exclude from sync` / `Include in sync`). New panes opened mid-sync auto-join via a bookkeeping reducer; cross-workspace `paneMoveToWorkspace` refreshes both source and target groups explicitly.
- New CLI: `nex pane sync (on|off|toggle|status|exclude|include) [--workspace ...] [--target ...] [--json]`. Bindable as `toggle_sync_input` (no default shortcut).
- Amber `SYNC` badge in every participating pane header (visible even on single-pane workspaces so the user gets an immediate "I forgot it was on" cue). Excluded panes show a dimmed `SYNC OFF` badge.

Closes #121.

## Reviewer notes
Reviewer flagged a real bug: `AppReducer.paneMoveToWorkspace` mutates `state.workspaces` directly, bypassing the per-workspace bookkeeping reducer that pushes fresh sync groups to `SurfaceManager`. Fixed by adding `refreshSyncGroupForWorkspace` calls for both source and target after the move.

Reviewer also flagged that the broadcast targeted any registered `SurfaceView`, including markdown panes in `$EDITOR` mode (vim/nano). Fixed by filtering `syncedPaneIDs` to `pane.type == .shell` so non-shell ghostty surfaces never participate. Web panes don't register with `SurfaceManager` and are unaffected.

CLI parsing now rejects `--target` on `on`/`off`/`toggle`/`status` (toggle is workspace-wide) and rejects stray positional args on every sync subcommand — silent ignore was a footgun for typos.

Out of MVP scope, called out for follow-up:
- Cross-workspace sync (Sync Group keyed by workspace ID today — would need re-keying)
- First-class "selected panes" multi-select picker (today's inverse via exclude works for small workspaces but not for "sync 2 of 6")
- Persistence across app restart (transient is the safer default for v1)
- Sidebar / title bar indicator (pane header badges only today)

Drive-by: `.swiftformat` and `.swiftlint.yml` now exclude `build/` (xcode's `DerivedData/SourcePackages/checkouts/` was failing `make check` on third-party tutorial files).

## Validation
Validated in a sandboxed macOS VM via cua/lume — fresh build from worktree, ad-hoc signed, all assertions green:
- TEST 1: fresh workspace reports `active=false`, empty `synced_pane_ids`.
- TEST 2: after split + `sync on`, both pane IDs appear in `synced_pane_ids`.
- TEST 3: `exclude --target <pane>` adds to the exclusion list; with one excluded out of two panes, `synced_pane_ids` collapses to empty (sub-2 floor) but `active=true` persists.
- TEST 4: `include --target <pane>` restores both panes to the synced set.
- TEST 5: `sync off` clears the exclusion set and reports `active=false`.
- TEST 6: error paths — missing `--target`, `--target` on a toggle subcommand, unknown mode — all exit non-zero with clear stderr.

Screenshots: `/Users/ben/code/cua/out/branches/issue-121-sync-input/issue-121/`

## Test plan
- [x] Open Nex, create a workspace with at least 3 panes (e.g. `⌘D` twice).
- [x] Bind `Toggle Synchronise Input` to a shortcut in Settings → Keybindings → Pane Management (no default; pick something like `⌃⇧S`).
- [x] Press the shortcut. Every pane header should sprout the amber `SYNC` badge. Type `echo hello` + Enter — every pane should display it.
- [x] Right-click one pane's header → `Exclude from sync`. That pane should now show `SYNC OFF`; typing in another pane should skip it.
- [x] Right-click the excluded pane → `Include in sync`. Badge returns to amber; typing mirrors again.
- [x] Press the shortcut again to turn sync off. Badges disappear; typing in one pane stays local.
- [x] Open a markdown file via `⌘O` (creates a `.markdown` pane). Press the sync shortcut. The markdown pane should NOT show a `SYNC` badge (filtered out by pane type).
- [x] CLI: `nex pane sync on` → `nex pane sync status --json` → `nex pane sync exclude --target <label>` → `nex pane sync off`. Each command should print a human-readable summary (or JSON with `--json`) and exit 0.
- [x] CLI error paths: `nex pane sync exclude` (no target), `nex pane sync on --target foo`, `nex pane sync invalid` — all exit non-zero with clear messages.
- [x] Move a pane to another workspace via the context menu while sync is on in the source. Source should drop the pane from its sync set; if sync is also on in the target, the moved pane should join it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)