### PR TITLE
feat(web pane): commit annotation comment with Cmd-Enter

### DIFF
--- a/Nex/Features/WebPane/WebPaneBatchMarkerScript.swift
+++ b/Nex/Features/WebPane/WebPaneBatchMarkerScript.swift
@@ -20,7 +20,7 @@ import Foundation
 /// Bridge messages:
 /// - `{ id }`                              — user clicked a badge.
 /// - `{ commentChanged: { id, comment } }` — popover textarea edit.
-/// - `{ dismiss: { id } }`                 — Done button / Esc in popover.
+/// - `{ dismiss: { id } }`                 — Done button / Esc / Cmd-Enter in popover.
 /// - `{ remove:  { id } }`                 — Remove button in popover.
 enum WebPaneBatchMarkerScript {
     static let source: String = """
@@ -195,11 +195,16 @@ enum WebPaneBatchMarkerScript {
                     });
                 } catch (e) {}
             });
-            // Esc inside the popover = Done. Don't let it bubble to
-            // the inspector picker (which uses Esc to cancel arming
-            // entirely).
+            // Esc or Cmd-Enter inside the popover = Done. Esc must not
+            // bubble to the inspector picker (which uses Esc to cancel
+            // arming entirely), and Cmd-Enter must not insert a newline
+            // into the textarea.
             popoverTextarea.addEventListener('keydown', function(ev) {
-                if (ev.key === 'Escape') {
+                var isEsc = ev.key === 'Escape';
+                // Skip Cmd-Enter while an IME is composing so CJK input
+                // isn't committed (and truncated) mid-composition.
+                var isCmdEnter = !ev.isComposing && ev.metaKey && (ev.key === 'Enter' || ev.key === 'Return');
+                if (isEsc || isCmdEnter) {
                     ev.preventDefault();
                     ev.stopPropagation();
                     if (focusedID) sendDismiss(focusedID);


### PR DESCRIPTION
## Summary
- The on-page batch-annotation comment popover only committed via the **Done** button or **Esc**. Treat **Cmd-Enter** the same so a comment can be committed without leaving the keyboard.
- `preventDefault` stops a newline being inserted into the textarea; an `isComposing` guard avoids committing CJK input mid-composition.
- Change is one injected-JS handler in `WebPaneBatchMarkerScript.swift`; the `dismiss` bridge message and its Swift handler already exist and are reused unchanged.

Closes #169

## Reviewer notes
- Two parallel independent reviews (correctness + scope/edge-cases) found no must-fix. Applied the one should-fix (IME `isComposing` guard) and a doc-comment update.
- `Cmd-Enter` only, not `Ctrl-Enter` (matches the issue and an explicit choice during planning).
- `metaKey`-only check means `Cmd-Shift-Enter` also commits (lenient, avoids a dead keystroke) - intentional.
- Out of scope: the SwiftUI `WebBatchInspectPanel` TextField has no per-item Done semantic to map Cmd-Enter to, so it is left unchanged.

## Validation
- Validated in a sandboxed macOS VM via cua/lume (clean build from the branch worktree, ad-hoc signed).
- Assertions (all passed): web pane opens (`nex web open`), page renders + web pane responsive (`nex web capture --mode text` returned the page text), batch picker arms (`nex web inspect`) and a synthetic click succeeds (`nex web click`), and `nex web console` reports no script errors after the edited script injects.
- The actual `Cmd-Enter` keystroke needs GUI keyboard focus inside the WKWebView textarea (the CLI cannot synthesise it), so it was verified manually via VNC in the kept-alive VM.
- Screenshots: `/Users/ben/code/cua/out/branches/issue-169-comment-cmd-enter/issue-169/`

## Test plan
- [x] Arm the web-pane element picker, click an element, type a comment, press Cmd-Enter -> popover commits and closes (same as Done).
- [x] Esc still commits; the Done button still commits; plain Enter still inserts a newline.
- [x] With a CJK IME, Cmd-Enter mid-composition does NOT commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)