### PR TITLE
fix(pane): close no longer hangs the main thread on a SIGHUP-trapping child (#136)

### DIFF
--- a/Nex/Ghostty/GhosttyApp.swift
+++ b/Nex/Ghostty/GhosttyApp.swift
@@ -143,6 +143,72 @@ final class GhosttyApp {
         ghostty_app_tick(app)
     }
 
+    /// Serial queue for off-main surface teardown (issue #136).
+    ///
+    /// `ghostty_surface_free` calls `Surface.deinit`, which joins the
+    /// surface's IO thread (`ghostty/src/Surface.zig` `io_thr.join()`).
+    /// When the child process traps or ignores SIGHUP, libghostty's
+    /// `killPid` spins forever on `killpg(SIGHUP)` + `waitpid(WNOHANG)`
+    /// (`ghostty/src/termio/Exec.zig`) with no SIGKILL escalation, so the
+    /// join — and the main thread that called free synchronously — hangs
+    /// for tens of seconds. Running free here keeps the UI responsive;
+    /// worst case the surface struct lingers until the child finally dies.
+    ///
+    /// Only the *free* is offloaded. Surface creation (`ghostty_surface_new`)
+    /// makes the SurfaceView's NSView layer-hosting by assigning libghostty's
+    /// Metal layer to the view's `layer` property (`renderer/Metal.zig`
+    /// `surfaceInit` → `setProperty("layer", …)`; the `addSublayer:` branch is
+    /// iOS-only), a main-thread-only AppKit mutation, so creation cannot move
+    /// off-main. `ghostty_app_tick` iterates `App.surfaces` (via `hasSurface`
+    /// while draining the mailbox) and so must stay serialized with creation —
+    /// keeping it on main lets the run loop do that for free. The teardown
+    /// reads only cached surface state (`getContentScale`/`getSize`), and the
+    /// post-join `layer.release()` only drops libghostty's own retain — on
+    /// macOS the view *is* the layer host, so its `.layer` keeps the layer
+    /// alive until the NSView deallocs on main. Off-main free is therefore
+    /// safe as long as the view outlives the call (see `freeSurfaceAsync`).
+    ///
+    /// Residual race (accepted, not fully fixable in Swift): `ghostty_surface_free`
+    /// is a single C call, so free's own `App.deleteSurface` (a `swapRemove`
+    /// on the lock-free `App.surfaces` list) now runs on this queue and can
+    /// interleave with *any* main-thread libghostty call that touches that
+    /// list — not only `ghostty_surface_new` (append, may realloc) and `tick`'s
+    /// `hasSurface`, but also app-scoped / all-surfaces binding actions and
+    /// config reloads (`App.zig` `performAction` iterating `surfaces.items`).
+    /// Ordinary per-key input does *not* iterate the list, so in practice the
+    /// colliding window is small — `deleteSurface` runs at the very start of
+    /// free, before the long `io_thr.join()` — but the access is genuinely
+    /// unsynchronized, i.e. a rare latent crash. It is still vastly preferable
+    /// to the deterministic multi-second freeze it replaces. Closing this
+    /// fully needs a libghostty change (a split teardown API, an internal lock
+    /// on `App.surfaces`, or PID-export + SIGKILL-before-free — issue #136 plan
+    /// steps 3/4), none of which is possible against the prebuilt static lib.
+    ///
+    /// Head-of-line caveat: frees serialize on this queue, so a free whose
+    /// child never dies (SIGHUP-trapped) blocks every later free behind it —
+    /// those panes leave Nex's UI but their PTY children linger until the first
+    /// child finally exits. Bounding this needs the same SIGKILL escalation. A
+    /// concurrent queue would unblock them but let two `deleteSurface`s race
+    /// each other, so serial is the safer of the two imperfect choices here.
+    nonisolated let surfaceTeardownQueue = DispatchQueue(
+        label: "com.nex.ghostty.surface-teardown",
+        qos: .userInitiated
+    )
+
+    /// Free a libghostty surface off the main thread. `view` is retained
+    /// for the duration of the (potentially multi-second) free so its
+    /// NSView — whose CALayer libghostty renders into and releases during
+    /// teardown — stays alive throughout; the view's deallocation is then
+    /// forced back onto the main thread, where NSView dealloc belongs.
+    nonisolated func freeSurfaceAsync(_ rawSurface: ghostty_surface_t, retaining view: SurfaceView) {
+        let retainer = SurfaceViewRetainer(view)
+        surfaceTeardownQueue.async {
+            ghostty_surface_free(rawSurface)
+            // Release the retained view (and trigger NSView dealloc) on main.
+            DispatchQueue.main.async { _ = retainer }
+        }
+    }
+
     private nonisolated func handleAction(
         target: ghostty_target_s,
         action: ghostty_action_s
@@ -321,5 +387,17 @@ final class GhosttyApp {
         if let app {
             ghostty_app_free(app)
         }
+    }
+}
+
+/// Holds a `SurfaceView` alive across the off-main teardown hop in
+/// `GhosttyApp.freeSurfaceAsync` without tripping Swift 6 Sendable
+/// checks. The view is only retained (never accessed) off the main
+/// thread — ARC retain/release is atomic, and the final release is
+/// forced back onto main — so `@unchecked Sendable` is sound here.
+private final class SurfaceViewRetainer: @unchecked Sendable {
+    let view: SurfaceView
+    init(_ view: SurfaceView) {
+        self.view = view
     }
 }

--- a/Nex/Ghostty/SurfaceView.swift
+++ b/Nex/Ghostty/SurfaceView.swift
@@ -113,7 +113,44 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
     }
 
     deinit {
+        // Fallback only: the normal teardown path goes through
+        // SurfaceManager.destroySurface → detachForTeardown(), which nils
+        // ghosttySurface, so this is a no-op for managed surfaces. It still
+        // frees a surface for any view dropped without manager teardown
+        // (e.g. an orphaned/duplicate view that never registered).
+        //
+        // This fallback is intentionally synchronous: deinit cannot retain
+        // the dying view to keep its layer alive across an off-main free, so
+        // routing it through freeSurfaceAsync would risk a use-after-free of
+        // the NSView's layer during teardown. The cost is that an *unmanaged*
+        // view holding a SIGHUP-trapping surface would re-introduce the #136
+        // hang here — but no managed path hits this (all real teardowns go
+        // through destroySurface), so it stays the safe choice.
         ghosttySurface?.destroy()
+    }
+
+    /// Synchronously sever this view from its live libghostty surface
+    /// ahead of an off-main `ghostty_surface_free` (issue #136). Cancels
+    /// the pending resize, drops first-responder and view-hierarchy ties
+    /// so the view stops driving the dead surface, and hands the raw
+    /// surface pointer to the caller.
+    ///
+    /// Nil-ing `ghosttySurface` here is load-bearing beyond avoiding a
+    /// `deinit` double-free: every deferred main-thread block that touches
+    /// the surface — the `viewDidMoveToWindow` refresh/resize hop and the
+    /// `setFrameSize` debounce work item — guards on `ghosttySurface?`, so
+    /// clearing it on this same main-thread turn disarms any already-queued
+    /// block from poking a surface that is about to be freed off-main.
+    func detachForTeardown() -> ghostty_surface_t? {
+        resizeWorkItem?.cancel()
+        resizeWorkItem = nil
+        if window?.firstResponder === self {
+            window?.makeFirstResponder(nil)
+        }
+        removeFromSuperview()
+        let raw = ghosttySurface?.surface
+        ghosttySurface = nil
+        return raw
     }
 
     // MARK: - Layer

--- a/Nex/Services/SurfaceManager.swift
+++ b/Nex/Services/SurfaceManager.swift
@@ -52,8 +52,13 @@ final class SurfaceManager: Sendable {
         let surfaceView = lock.withLock {
             surfaces.removeValue(forKey: paneID)
         }
-        surfaceView?.ghosttySurface?.destroy()
-        surfaceView?.ghosttySurface = nil // Prevent double-free in SurfaceView.deinit
+        guard let surfaceView else { return }
+        // Detach the view synchronously on main, then free the surface off
+        // the main thread so a SIGHUP-trapping child can't hang the UI
+        // (issue #136). detachForTeardown() nils ghosttySurface, so the
+        // view's deinit won't double-free.
+        guard let rawSurface = surfaceView.detachForTeardown() else { return }
+        GhosttyApp.shared.freeSurfaceAsync(rawSurface, retaining: surfaceView)
     }
 
     @MainActor
@@ -64,8 +69,8 @@ final class SurfaceManager: Sendable {
             return copy
         }
         for (_, surfaceView) in all {
-            surfaceView.ghosttySurface?.destroy()
-            surfaceView.ghosttySurface = nil
+            guard let rawSurface = surfaceView.detachForTeardown() else { continue }
+            GhosttyApp.shared.freeSurfaceAsync(rawSurface, retaining: surfaceView)
         }
     }
 


### PR DESCRIPTION
## Summary

Closing a pane could freeze the entire Nex UI for tens of seconds when the pane's child process traps or ignores `SIGHUP` (`claude`, some `vim`/`ssh` setups, `trap '' HUP; sleep 99999`, ...). `ghostty_surface_free` ran synchronously on the main thread and blocked in `io_thr.join()`, because libghostty's `killPid` loops on `killpg(SIGHUP)` + `waitpid(WNOHANG)` with no SIGKILL escalation.

This moves **only** `ghostty_surface_free` onto a dedicated serial queue so the main thread never blocks. `SurfaceManager.destroySurface`/`destroyAll` now detach the view synchronously on main (cancel the pending resize, drop first responder, remove from the hierarchy, nil `ghosttySurface` to disarm deferred blocks and prevent a deinit double-free) and then free off-main, retaining the `SurfaceView` until the free completes so libghostty's CALayer teardown has a live, layer-hosting NSView.

Addresses #136 (lands the Step 2 mitigation; the residual race + Steps 3-4 remain tracked on #136 — see Follow-up)

## Why only `free` moves off-main (correction to the issue's Step 2)

The issue suggested moving `ghostty_app_tick` and creation off-main too. Verified in the ghostty Zig source that this is wrong:
- `ghostty_surface_new` → `Renderer.surfaceInit` makes the NSView **layer-hosting** (`Metal.zig` `setProperty("layer", …)`), a main-thread-only AppKit mutation, so **creation cannot move off-main**.
- With creation pinned to main, moving `tick` (which iterates `App.surfaces` via `hasSurface`) to a background queue would introduce a *more frequent* create-vs-tick race than it removes. So `new` and `tick` stay on main, serialized by the run loop; only the blocking `free` is offloaded.

## Known limitation (mitigation, not root-cause fix)

`ghostty_surface_free` is one C call that both removes the surface from libghostty's lock-free `App.surfaces` (`swapRemove`) **and** does the blocking join. Running it off-main leaves a genuine, unsynchronized residual race: free's `deleteSurface` can interleave with main-thread libghostty calls that iterate `App.surfaces` (`tick`, creation, app-scoped/all-surfaces binding actions, config reloads). The colliding window is microseconds (the removal runs before the long join) and ordinary per-key input does not iterate the list, so it's a rare latent crash — strictly preferable to the deterministic multi-second freeze it replaces. There's also a head-of-line caveat: frees serialize, so a never-dying SIGHUP-trapped child blocks later frees behind it, leaving their PTY children lingering.

Both are fully closable only with a libghostty change (split teardown API / internal lock on `App.surfaces`, or PID-export + SIGKILL-before-free) — the issue's **Steps 3-4**, which can't be built/validated against the prebuilt `libghostty.a`. These tradeoffs are documented inline in `GhosttyApp.swift` and match the issue author's stated Step 2 intent.

## Review

- Two independent reviews (correctness + scope) plus an adversarial **Codex (gpt-5.5)** review. No double-free, use-after-free, or Swift 6 Sendable unsoundness found.
- Codex sharpened the residual-race analysis (it's broader than just `new`/`tick`) and caught a comment inaccuracy (macOS is layer-hosting, not `addSublayer:`). All accurate in-scope fixes (documentation) were applied; the code-level fixes all require the out-of-scope libghostty change above.

## Validation

Validated in a sandboxed macOS VM via cua/lume (fresh build from this branch, ad-hoc signed):
- **Arm**: created a victim pane and ran `trap '' HUP; sleep 99999` in it.
- **Close trapped pane**: returned in **0.0s** (pre-fix: ~30s main-thread freeze to timeout).
- **Responsiveness probe**: a follow-up `nex pane list` immediately after the close returned in **0.0s** — main thread not wedged. Victim gone, unrelated pane survived.
- **Regression**: a normal pane still closes cleanly in 0.0s.
- Screenshots: `out/branches/fix-136-pane-close-main-thread-hang/issue-136/` (Nex responsive, no beachball).
- All 1064 unit tests pass; SwiftFormat + SwiftLint clean.

## Follow-up

- libghostty root-cause fix (PID-export + SIGKILL-before-free, or bounded SIGHUP→SIGKILL inside `killPid`) — eliminates the residual race and the head-of-line child leak. Tracked separately as Steps 3-4.

## Test plan

- [x] In a pane, run `trap '' HUP; sleep 99999`, then `⌘W` — window stays responsive (no beachball) instead of freezing ~30s.
- [x] Same via CLI: `nex pane create` a victim, `nex pane send` the trap, `nex pane close --target <victim>` returns instantly and other panes stay responsive.
- [x] Normal pane open / split / close still works; typing, focus, and resize unaffected.
- [x] Workspace switching still preserves surfaces (no teardown regression).