### PR TITLE
feat(sidebar): add "New Workspace" action to the group context menu (#180)

### DIFF
--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -419,11 +419,10 @@ struct WorkspaceListView: View {
                     value: sidebarLayoutKey
                 )
                 .contextMenu {
-                    Button("New Workspace") {
-                        store.send(.showNewWorkspaceSheet(groupID: groupID))
-                    }
+                    // `groupContextMenu` already leads with "New Workspace",
+                    // so the empty-group placeholder reuses it wholesale
+                    // rather than duplicating that button.
                     if let group = store.groups[id: groupID] {
-                        Divider()
                         groupContextMenu(groupID: groupID, group: group)
                     }
                 }
@@ -895,6 +894,10 @@ struct WorkspaceListView: View {
     /// and delete (which routes through the confirmation alert).
     @ViewBuilder
     private func groupContextMenu(groupID: UUID, group: WorkspaceGroup) -> some View {
+        Button("New Workspace") {
+            store.send(.showNewWorkspaceSheet(groupID: groupID))
+        }
+        Divider()
         Button("Rename...") {
             store.send(.beginRenameGroup(groupID))
         }


### PR DESCRIPTION
## Summary
- Right-clicking a group header now offers a **New Workspace** action at the top of its context menu, which opens the new-workspace sheet pre-scoped to that group (`showNewWorkspaceSheet(groupID:)` → `createWorkspace(groupID:)`).
- Added the button to the shared `groupContextMenu`, so both populated group headers and the empty-group placeholder surface it; removed the placeholder's now-duplicate standalone button to avoid showing it twice.

Closes #180

## Reviewer notes
- Two parallel reviewers (correctness + scope/edge-cases) found no must-fix or should-fix items. Two NITs, both intentionally kept as-is:
  - The item also appears in the rename-state context-menu branch (that branch already exposed the full group menu; the inline rename commits on focus loss when the sheet takes first responder).
  - Label is "New Workspace" (matching every other entry point) rather than the issue's casual "Create workspace" wording.
- No new unit test: the dispatched action and the create-into-group path are already covered (`showNewWorkspaceSheetScopedToGroup`, `createWorkspaceWithGroupIDPlacesInGroupChildOrder`, `...ExpandsCollapsedGroup`, `...FallsBackToTopLevel`, `createWorkspaceClearsPendingSheetGroupID`). The SwiftUI menu wiring itself isn't unit-testable in this stack.
- No reducer/socket/CLI changes — `nex workspace create --group` already existed.

## Validation
- `make check` green (format, lint, build, 1064 tests).
- Validated in a sandboxed macOS VM via cua/lume (built from the branch, ad-hoc signed, launched clean as nex 0.27.0).
- Per-issue assertions (all passed): initial state is 1 `Default` pane; `nex workspace create --group QA-Group` placed `InGroup` into the group while the original `Default` pane survived (non-destructive); a second create accumulated `InGroup2` in the same group. The context-menu click itself can't be driven by the validator (GUI limitation), so it was exercised manually in the keep-alive VM; the menu→action wiring is covered by unit tests.
- Screenshots: `/Users/ben/code/cua/out/branches/issue-180-group-create-workspace/issue-180/`

## Test plan
- [x] Right-click a populated group header → "New Workspace" appears at the top (above Rename), opens the sheet with that group pre-selected, and the created workspace lands inside the group.
- [x] Collapse the group, repeat → group auto-expands and the new workspace appears nested.
- [x] Right-click an empty group → "New Workspace" appears exactly once (no duplicate).
- [x] Regression: top-level "New Workspace" button and the group's Rename/Color/Change Icon/Collapse/Delete items still work.