### PR TITLE
fix(sidebar): give the New Workspace bottom bar a solid background

### DIFF
--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -351,6 +351,13 @@ struct WorkspaceListView: View {
                 }
                 .menuStyle(.borderlessButton)
                 .padding(12)
+                // Opaque fill matching the sidebar root background
+                // (ContentView paints the same colour). `safeAreaInset`
+                // lets the scroll view's rows slide *under* this bar, so
+                // without a solid background the colour pill and pane
+                // count of the row above bleed through behind the button.
+                .frame(maxWidth: .infinity)
+                .background(Color(nsColor: .controlBackgroundColor))
             }
         }
     }


### PR DESCRIPTION
## Summary
- The "+ New Workspace" button at the bottom of the workspace sidebar sat in a `.safeAreaInset(edge: .bottom)`, which lets the `ScrollView`'s rows slide *under* it. With no background of its own, the colored accent pill and pane count of the row above bled through behind the button.
- Fill that bottom bar with the sidebar's own `Color(nsColor: .controlBackgroundColor)` (the same token `ContentView` paints on the sidebar root) and stretch it full width, so it reads as a solid, seamless, opaque footer.

Closes #173

## Reviewer notes
- Two parallel reviewers (correctness + scope) ran over the diff. Both came back clean.
- Scope review confirmed the sibling `filteredListBody` path is immune by construction: it's a plain `VStack` + `ScrollView` with no `.safeAreaInset`, so nothing overlays its scroll content. The fix is complete for #173, not one-of-two.
- No unit test added: this is a view-only cosmetic change with no reducer/model logic, and the TCA suite covers reducers, not SwiftUI rendering. Verified visually in the VM instead (below).

## Validation
- Validated in a sandboxed macOS VM via cua/lume, built from the branch worktree.
- Assertions (all passed): launched Nex, flooded the sidebar with 40 colored (mostly red) workspaces so the list overflows and a colored row lands under the bottom bar; asserted every `workspace create` exited 0, the pane count grew exactly 1 -> 41 (each workspace seeds one pane, none dropped), the original pane survived, and `pane list` stayed responsive (no crash/wedge) after the stress.
- Screenshot review: the "+ New Workspace" bar renders with a solid opaque background; the row directly above it (a blue/red accent pill) stops cleanly at the bar with no bleed-through.
- Screenshots: `/Users/ben/code/cua/out/branches/issue-173-new-workspace-button-bg/issue-173/`

## Test plan
- [x] Open Nex with several colored workspaces; scroll the sidebar so a strongly-colored (e.g. red) row sits directly behind the "+ New Workspace" bar — confirm no color bleeds through.
- [x] Toggle Light/Dark appearance and confirm the bar still matches the sidebar background.
- [x] Click "+ New Workspace" (opens the sheet) and the chevron menu (New Workspace / New Group) — both still work.
- [x] Sanity-check the filtered sidebar (type in the filter field) still renders correctly.