### PR TITLE
Refined warm-chrome UI reskin

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		CCBCDD690DA8A082B0C3D1EF /* StatusBarPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110D5179A9834B4AB19B705B /* StatusBarPopoverView.swift */; };
 		CF6DEC598C1A3508555E8EB3 /* LabelPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D6C6671997547A9F95AD39 /* LabelPresetTests.swift */; };
 		D0B97CB294CE96D259C08960 /* GraftCLIReplyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD93535314E9897122ED638 /* GraftCLIReplyTests.swift */; };
+		D46A8198421B464BC6CE04AC /* BuiltInChromeThemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AC09DCB2726BE14209A6AD /* BuiltInChromeThemes.swift */; };
 		D5E5F5395113992874C7D4D7 /* RootChromeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6762B22A5CA7CC5867025DA2 /* RootChromeView.swift */; };
 		D9A2EC37D7FABEAFE48E109A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB65E3CCBB3A287C413A6015 /* Foundation.framework */; };
 		DA4AC555E9C3FC84061F2FB9 /* PaneFocusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD9BCE4ABC267C7E34EAF09 /* PaneFocusView.swift */; };
@@ -382,6 +383,7 @@
 		F5CE8D708EEECA4A82BE0AC1 /* PaneCloseReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneCloseReplyTests.swift; sourceTree = "<group>"; };
 		F7AC7FA0FAA2F922FF783A82 /* ActuatorTestHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActuatorTestHost.swift; sourceTree = "<group>"; };
 		F7F9C43CA9B19E7281082913 /* WorkspaceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceListView.swift; sourceTree = "<group>"; };
+		F8AC09DCB2726BE14209A6AD /* BuiltInChromeThemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuiltInChromeThemes.swift; sourceTree = "<group>"; };
 		F90FF9C2E7F0BC50E51C47DE /* RepoRegistryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoRegistryView.swift; sourceTree = "<group>"; };
 		F9DA0C4B28F4E3DAF4CF1EB0 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		F9F22E5DD60C8A8D83A0B4F8 /* PaneListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneListTests.swift; sourceTree = "<group>"; };
@@ -772,6 +774,7 @@
 		F095B23294C4398DA905D114 /* Theme */ = {
 			isa = PBXGroup;
 			children = (
+				F8AC09DCB2726BE14209A6AD /* BuiltInChromeThemes.swift */,
 				C58B38C97ABA021104E1C5AB /* ChromeStyleTheme.swift */,
 				483277A20C203022712FB04D /* ChromeTheme.swift */,
 			);
@@ -981,6 +984,7 @@
 				759B67A4E8D35868EC6E2295 /* AppActivation.swift in Sources */,
 				1397C2AF47888F6A056F5970 /* AppDelegate.swift in Sources */,
 				EC6971D2E311C8903C373778 /* AppReducer.swift in Sources */,
+				D46A8198421B464BC6CE04AC /* BuiltInChromeThemes.swift in Sources */,
 				EFDCA64CD227A833D2801893 /* CLIInstallService.swift in Sources */,
 				B23A46CD372F9E16C2C1D716 /* CheckForUpdatesView.swift in Sources */,
 				65FD103A31E7591016424457 /* ChromeStyleTheme.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		630837DB73DACFE99190C60D /* WebPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B04ED477C0C51A44953A8C /* WebPaneState.swift */; };
 		64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A24C1FEC6EA31096603326 /* SurfaceManager.swift */; };
 		654B31F33D5872341839A91E /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8908AF59D359222CBC0EF21D /* GameController.framework */; };
+		65FD103A31E7591016424457 /* ChromeStyleTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58B38C97ABA021104E1C5AB /* ChromeStyleTheme.swift */; };
 		692A08796F7DF555CFAF0653 /* MarkdownFindScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4FA41668CB28EB0FFA7911 /* MarkdownFindScript.swift */; };
 		696312BB96D35569F48B7CAE /* MarkdownFrontMatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43F769C33118440222BF5FA /* MarkdownFrontMatter.swift */; };
 		6ACFF31A3875EBE87E78C587 /* RepoAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 257A1CB3D7653911EF93F8F5 /* RepoAssociation.swift */; };
@@ -119,6 +120,7 @@
 		A8626EC08DC12588F912E1EF /* WebPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A94E80914F7411EED712E5 /* WebPaneStore.swift */; };
 		A895048D11AFDC1FDA5DF846 /* WebPaneChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DFA60F59651234F0F59BE9 /* WebPaneChrome.swift */; };
 		A8F1A82072120476BAEC2D52 /* UserDefaultsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C693AF419763177AE1CEA0F /* UserDefaultsClient.swift */; };
+		ABDC80C6FF2934417FFC931B /* ChromeStyleThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF0C410566DD2211C2A5EE9 /* ChromeStyleThemeTests.swift */; };
 		AC234A5AAADE90A7EC7BB5F8 /* MarkdownHTMLRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E7D450881FC7318F58CB78F /* MarkdownHTMLRenderer.swift */; };
 		AD62C235AF0D846B08655B16 /* RingBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0625B2E7935BDDF63DC5D19 /* RingBufferTests.swift */; };
 		AF0F22742F34298F1E06A238 /* WorkspaceGroupSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F7D5571F89D43BC6C76928 /* WorkspaceGroupSocketTests.swift */; };
@@ -257,6 +259,7 @@
 		3B2687F4D886D153C83D8A60 /* WorkspaceGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroup.swift; sourceTree = "<group>"; };
 		3B4FA41668CB28EB0FFA7911 /* MarkdownFindScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFindScript.swift; sourceTree = "<group>"; };
 		3DD93535314E9897122ED638 /* GraftCLIReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraftCLIReplyTests.swift; sourceTree = "<group>"; };
+		3EF0C410566DD2211C2A5EE9 /* ChromeStyleThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeStyleThemeTests.swift; sourceTree = "<group>"; };
 		42A24C1FEC6EA31096603326 /* SurfaceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceManager.swift; sourceTree = "<group>"; };
 		439174A029FAFE2C252A1B8B /* KeybindingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingsSettingsView.swift; sourceTree = "<group>"; };
 		45141531B99E3E1B79620ECA /* StoragePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePanel.swift; sourceTree = "<group>"; };
@@ -332,6 +335,7 @@
 		BECB2222837AC350E94222BB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		BF16F0C4A6A8BF8151651F53 /* InspectPayloadSanitiser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectPayloadSanitiser.swift; sourceTree = "<group>"; };
 		C4D5453E5B7EB4E8E7F11453 /* PaneSendReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSendReplyTests.swift; sourceTree = "<group>"; };
+		C58B38C97ABA021104E1C5AB /* ChromeStyleTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeStyleTheme.swift; sourceTree = "<group>"; };
 		C58BE92A0878D9CCC786A657 /* WorkspaceRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRowView.swift; sourceTree = "<group>"; };
 		C711FF0D53387D16F50C5EA6 /* UpdaterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterService.swift; sourceTree = "<group>"; };
 		CAA7FF54B539D06E39903C41 /* PaneShortcutMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneShortcutMonitorTests.swift; sourceTree = "<group>"; };
@@ -484,6 +488,7 @@
 				A2554566AF4F790EB30637E3 /* AgentLifecycleTests.swift */,
 				D6B83DC43AEA38B4929307FA /* AppReducerTests.swift */,
 				ADBC4A3F4B30336A12D32DF4 /* AutoDetectRepoTests.swift */,
+				3EF0C410566DD2211C2A5EE9 /* ChromeStyleThemeTests.swift */,
 				89FC5F004277851CEA0CFF3F /* CommandPaletteTests.swift */,
 				309F641591BB580429299666 /* ConfigParserTests.swift */,
 				21064C4AB47888B6A02CCD73 /* DatabaseMigrationTests.swift */,
@@ -767,6 +772,7 @@
 		F095B23294C4398DA905D114 /* Theme */ = {
 			isa = PBXGroup;
 			children = (
+				C58B38C97ABA021104E1C5AB /* ChromeStyleTheme.swift */,
 				483277A20C203022712FB04D /* ChromeTheme.swift */,
 			);
 			path = Theme;
@@ -913,6 +919,7 @@
 				840B487024194CA181EE42F8 /* AgentLifecycleTests.swift in Sources */,
 				B5EDCEE4998F1F0B6F844814 /* AppReducerTests.swift in Sources */,
 				DC11308E0E92225F551CF162 /* AutoDetectRepoTests.swift in Sources */,
+				ABDC80C6FF2934417FFC931B /* ChromeStyleThemeTests.swift in Sources */,
 				FD494AFC9E74F4C5D7E125B8 /* CommandPaletteTests.swift in Sources */,
 				A1937931A23F2D0EB8472737 /* ConfigParserTests.swift in Sources */,
 				B652FDDE5CE91C5CA1DAC8E2 /* DatabaseMigrationTests.swift in Sources */,
@@ -976,6 +983,7 @@
 				EC6971D2E311C8903C373778 /* AppReducer.swift in Sources */,
 				EFDCA64CD227A833D2801893 /* CLIInstallService.swift in Sources */,
 				B23A46CD372F9E16C2C1D716 /* CheckForUpdatesView.swift in Sources */,
+				65FD103A31E7591016424457 /* ChromeStyleTheme.swift in Sources */,
 				C35AD7E358BD4B5B0EABF5E9 /* ChromeTheme.swift in Sources */,
 				B221D950378165611A0DF932 /* ClipboardImageHelper.swift in Sources */,
 				3C74513CA9D5FD60E672B477 /* CommandPaletteItem.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		2CD77355541CE17C3427C610 /* InspectPayloadSanitiserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D0AA21761E50EFDA70A0E9 /* InspectPayloadSanitiserTests.swift */; };
 		2D8754E0B3E9AD185D7EB6B0 /* ConfigParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4114D723403D4FF8F4AC1B /* ConfigParser.swift */; };
 		2F440D3EB93B6C127A1FF003 /* WebPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A97924791DAA26F0E4B0BA /* WebPaneView.swift */; };
+		33B0CCD680CE4BAC31407678 /* SystemStatsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A55FFAEAAEA23FA5688599 /* SystemStatsService.swift */; };
 		3B60C0FC48A2AAF6282CAB40 /* WorkspaceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F9C43CA9B19E7281082913 /* WorkspaceListView.swift */; };
 		3C74513CA9D5FD60E672B477 /* CommandPaletteItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1870562A61E6F66FFE03A8BA /* CommandPaletteItem.swift */; };
 		3DF88C2A2966C7B0209E22FE /* RepoPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0689D085597FF9C7F4D87401 /* RepoPickerView.swift */; };
@@ -287,6 +288,7 @@
 		8322D3C28268495A01EA0597 /* SettingsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeature.swift; sourceTree = "<group>"; };
 		8340B6640D25908803B93C2A /* GlobalHotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalHotkeyService.swift; sourceTree = "<group>"; };
 		8344DA5EFC15BF047C2003A4 /* PaneCaptureReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneCaptureReplyTests.swift; sourceTree = "<group>"; };
+		83A55FFAEAAEA23FA5688599 /* SystemStatsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsService.swift; sourceTree = "<group>"; };
 		84D4EC6AC4CDFB5377057239 /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
 		852AC6AE9B24B4528577F454 /* LineNumberRulerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineNumberRulerView.swift; sourceTree = "<group>"; };
 		86B88C15DF87E94A115F9FD7 /* GitHeadWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHeadWatcherTests.swift; sourceTree = "<group>"; };
@@ -631,6 +633,7 @@
 				140051AE1CBF1087B5F289F7 /* RecursiveFSWatcher.swift */,
 				309D0F6F13F12FDC350DE875 /* SocketServer.swift */,
 				42A24C1FEC6EA31096603326 /* SurfaceManager.swift */,
+				83A55FFAEAAEA23FA5688599 /* SystemStatsService.swift */,
 				C711FF0D53387D16F50C5EA6 /* UpdaterService.swift */,
 				8C693AF419763177AE1CEA0F /* UserDefaultsClient.swift */,
 				E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */,
@@ -1046,6 +1049,7 @@
 				8F5D3C9118D51569A13CB473 /* SurfaceContainerView.swift in Sources */,
 				64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */,
 				75BECE7D63EF981C344D4902 /* SurfaceView.swift in Sources */,
+				33B0CCD680CE4BAC31407678 /* SystemStatsService.swift in Sources */,
 				B8DCB316773E208FABEDA9D7 /* UpdaterService.swift in Sources */,
 				A8F1A82072120476BAEC2D52 /* UserDefaultsClient.swift in Sources */,
 				B167B81282ADF716B21B1679 /* VibrancyView.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		B7D2BF4B62D8D6DB71C707B5 /* RecursiveFSWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD3F55DB0088089F62AFBFA /* RecursiveFSWatcherTests.swift */; };
 		B8B5B666D5CC24071420A966 /* StoragePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45141531B99E3E1B79620ECA /* StoragePanel.swift */; };
 		B8DCB316773E208FABEDA9D7 /* UpdaterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C711FF0D53387D16F50C5EA6 /* UpdaterService.swift */; };
+		BAEEBBBC67C9969D0553D084 /* ChromeIndicatorRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0461B8E2ED8F50BA8AF0DF /* ChromeIndicatorRefreshTests.swift */; };
 		BF19A66EC95FA4FB46CA400D /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F228193206574DB257C8B3FB /* AppKit.framework */; };
 		C052FE23BF089795BB04E10E /* RenamePaneSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191592BF0EBCEC22DF9F5745 /* RenamePaneSheet.swift */; };
 		C0DDF7284D01523225E5EEE7 /* GhosttyConfigClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47FF7FB9A9C29221EAD089E /* GhosttyConfigClient.swift */; };
@@ -216,6 +217,7 @@
 		09D2D521EEDB4FE47843C382 /* SyncInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncInputTests.swift; sourceTree = "<group>"; };
 		0C975C89EC3EAA135F52A7AD /* WorkspaceDropTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDropTarget.swift; sourceTree = "<group>"; };
 		0E79DA6455C6FF3D2124CBA9 /* GraftService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraftService.swift; sourceTree = "<group>"; };
+		0F0461B8E2ED8F50BA8AF0DF /* ChromeIndicatorRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeIndicatorRefreshTests.swift; sourceTree = "<group>"; };
 		110ABCD54BF803110E5F5060 /* GraftInspectorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraftInspectorButton.swift; sourceTree = "<group>"; };
 		110D5179A9834B4AB19B705B /* StatusBarPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarPopoverView.swift; sourceTree = "<group>"; };
 		11C5539104EFEFA5CCB936F1 /* GroupIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupIcon.swift; sourceTree = "<group>"; };
@@ -490,6 +492,7 @@
 				A2554566AF4F790EB30637E3 /* AgentLifecycleTests.swift */,
 				D6B83DC43AEA38B4929307FA /* AppReducerTests.swift */,
 				ADBC4A3F4B30336A12D32DF4 /* AutoDetectRepoTests.swift */,
+				0F0461B8E2ED8F50BA8AF0DF /* ChromeIndicatorRefreshTests.swift */,
 				3EF0C410566DD2211C2A5EE9 /* ChromeStyleThemeTests.swift */,
 				89FC5F004277851CEA0CFF3F /* CommandPaletteTests.swift */,
 				309F641591BB580429299666 /* ConfigParserTests.swift */,
@@ -922,6 +925,7 @@
 				840B487024194CA181EE42F8 /* AgentLifecycleTests.swift in Sources */,
 				B5EDCEE4998F1F0B6F844814 /* AppReducerTests.swift in Sources */,
 				DC11308E0E92225F551CF162 /* AutoDetectRepoTests.swift in Sources */,
+				BAEEBBBC67C9969D0553D084 /* ChromeIndicatorRefreshTests.swift in Sources */,
 				ABDC80C6FF2934417FFC931B /* ChromeStyleThemeTests.swift in Sources */,
 				FD494AFC9E74F4C5D7E125B8 /* CommandPaletteTests.swift in Sources */,
 				A1937931A23F2D0EB8472737 /* ConfigParserTests.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		ECA2C078504EB9BF0E04B343 /* GhosttyConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AD7A8D7E6592B90FBB7D24 /* GhosttyConfig.swift */; };
 		ECB2D027885F6AAC05BFBA22 /* GraftInspectorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110ABCD54BF803110E5F5060 /* GraftInspectorButton.swift */; };
 		ECC9AA8342DF3710795427C7 /* SyncInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D2D521EEDB4FE47843C382 /* SyncInputTests.swift */; };
+		ECD2ACA49EA1B7F669422FD2 /* SystemStatGauge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D96732EDE4F0D4A4511372D /* SystemStatGauge.swift */; };
 		ED79F70009D8C2A4A1A742F8 /* ResizeDimensionsOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6F950849E47A0BCC6DEAB5 /* ResizeDimensionsOverlay.swift */; };
 		EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */; };
 		EDF35E86B633BB1E8C3DE844 /* WindowSpacesBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */; };
@@ -226,6 +227,7 @@
 		1C625959E287CE9896D5BA4D /* RepoRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoRegistryTests.swift; sourceTree = "<group>"; };
 		1CB2BCC7EBF45A4E50F314F2 /* DiffPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneView.swift; sourceTree = "<group>"; };
 		1D792DEC74448D403CE1A96D /* RingBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBuffer.swift; sourceTree = "<group>"; };
+		1D96732EDE4F0D4A4511372D /* SystemStatGauge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatGauge.swift; sourceTree = "<group>"; };
 		1E7D450881FC7318F58CB78F /* MarkdownHTMLRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownHTMLRenderer.swift; sourceTree = "<group>"; };
 		1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		1F71D541343DA67CDCADA821 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
@@ -746,6 +748,7 @@
 				09102B6ADEAB463454E7F15E /* StatusBarController.swift */,
 				110D5179A9834B4AB19B705B /* StatusBarPopoverView.swift */,
 				E730EF15502C9C30B7ACCAF7 /* StatusBarView.swift */,
+				1D96732EDE4F0D4A4511372D /* SystemStatGauge.swift */,
 			);
 			path = StatusBar;
 			sourceTree = "<group>";
@@ -1049,6 +1052,7 @@
 				8F5D3C9118D51569A13CB473 /* SurfaceContainerView.swift in Sources */,
 				64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */,
 				75BECE7D63EF981C344D4902 /* SurfaceView.swift in Sources */,
+				ECD2ACA49EA1B7F669422FD2 /* SystemStatGauge.swift in Sources */,
 				33B0CCD680CE4BAC31407678 /* SystemStatsService.swift in Sources */,
 				B8DCB316773E208FABEDA9D7 /* UpdaterService.swift in Sources */,
 				A8F1A82072120476BAEC2D52 /* UserDefaultsClient.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		8E99D6024CA5451216D39602 /* PaneHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB94DA665D3B322A44251454 /* PaneHeaderView.swift */; };
 		8F5D3C9118D51569A13CB473 /* SurfaceContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018EF0FBACD529C982B7811D /* SurfaceContainerView.swift */; };
 		9443792BCB5BEA5B06312F00 /* RecursiveFSWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140051AE1CBF1087B5F289F7 /* RecursiveFSWatcher.swift */; };
+		95D51269B050D359AC3E91D8 /* LabelMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3FCA7A9AA41A0B3A67A8C7 /* LabelMigrationTests.swift */; };
 		9D8356F03AF69469528218D5 /* FocusNotifyingTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AC82B39AC5EEEC6A787B4D4 /* FocusNotifyingTextView.swift */; };
 		9E48EBF9E92828BAF42C0932 /* LabelPresetsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D01D7C0300DB8B0987C7F58 /* LabelPresetsSettingsView.swift */; };
 		A0056823B88DEBC5006159A2 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE42A23C94DA8DA930C61E3 /* NotificationService.swift */; };
@@ -252,6 +253,7 @@
 		3879BA745F8737CA5872F80D /* DatabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseService.swift; sourceTree = "<group>"; };
 		396BAB6F7BCAE4EEF2ADEFAF /* DiffHTMLRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffHTMLRendererTests.swift; sourceTree = "<group>"; };
 		39D6C6671997547A9F95AD39 /* LabelPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelPresetTests.swift; sourceTree = "<group>"; };
+		3A3FCA7A9AA41A0B3A67A8C7 /* LabelMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelMigrationTests.swift; sourceTree = "<group>"; };
 		3B2687F4D886D153C83D8A60 /* WorkspaceGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroup.swift; sourceTree = "<group>"; };
 		3B4FA41668CB28EB0FFA7911 /* MarkdownFindScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFindScript.swift; sourceTree = "<group>"; };
 		3DD93535314E9897122ED638 /* GraftCLIReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraftCLIReplyTests.swift; sourceTree = "<group>"; };
@@ -496,6 +498,7 @@
 				EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */,
 				95D0AA21761E50EFDA70A0E9 /* InspectPayloadSanitiserTests.swift */,
 				5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */,
+				3A3FCA7A9AA41A0B3A67A8C7 /* LabelMigrationTests.swift */,
 				39D6C6671997547A9F95AD39 /* LabelPresetTests.swift */,
 				4CCB57D9C4E2AC2014127FC8 /* MarkdownCheckboxRenderingTests.swift */,
 				200EB2588E40ABB7C51E24E6 /* MarkdownHTMLRendererTests.swift */,
@@ -924,6 +927,7 @@
 				EDD3C2388FB932FCF46F3444 /* HelpDataTests.swift in Sources */,
 				2CD77355541CE17C3427C610 /* InspectPayloadSanitiserTests.swift in Sources */,
 				B701F36FA68D43170D591F40 /* KeyBindingTests.swift in Sources */,
+				95D51269B050D359AC3E91D8 /* LabelMigrationTests.swift in Sources */,
 				CF6DEC598C1A3508555E8EB3 /* LabelPresetTests.swift in Sources */,
 				0D23E37D86270E1BAADFF549 /* MarkdownCheckboxRenderingTests.swift in Sources */,
 				EA22F9720B68648A78D237E3 /* MarkdownHTMLRendererTests.swift in Sources */,

--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		741144CE5AC7DEC20A18A89D /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70E36C00A55A87562F4AC1D /* CommandPaletteView.swift */; };
 		759B67A4E8D35868EC6E2295 /* AppActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D46DA7C3A37F67FBBBEAC7 /* AppActivation.swift */; };
 		75BECE7D63EF981C344D4902 /* SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CA6C20BB3882E02348ADF4 /* SurfaceView.swift */; };
+		76A3D9E4C48429C694A1896A /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730EF15502C9C30B7ACCAF7 /* StatusBarView.swift */; };
 		76FC0D784C9823F0B870C6C5 /* GitHeadWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B88C15DF87E94A115F9FD7 /* GitHeadWatcherTests.swift */; };
 		77C780C65EFA8114C681638B /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 8B14B7BF7BD4FCD61EBB97A9 /* ComposableArchitecture */; };
 		77CF808E3AF2C06BD12D11C0 /* SplitDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DED98594372C8E34542A5C2 /* SplitDividerView.swift */; };
@@ -107,6 +108,7 @@
 		A0056823B88DEBC5006159A2 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE42A23C94DA8DA930C61E3 /* NotificationService.swift */; };
 		A0749EBDDCE764238315879A /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9DA0C4B28F4E3DAF4CF1EB0 /* IOKit.framework */; };
 		A094A49881297881F9791F0A /* PaneSendKeyReplyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452A1B196F8438AD7A7DAC0A /* PaneSendKeyReplyTests.swift */; };
+		A100881CAD4946DC855B50A6 /* WindowTitleBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EE3D8224F44E30912F703D /* WindowTitleBar.swift */; };
 		A15BBD1CFDB5E52E44B7ED59 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = A7AC116A099F0911E230E51F /* Markdown */; };
 		A1937931A23F2D0EB8472737 /* ConfigParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309F641591BB580429299666 /* ConfigParserTests.swift */; };
 		A33EF4059D3F3479ED5C9EE2 /* WorkspaceGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2687F4D886D153C83D8A60 /* WorkspaceGroup.swift */; };
@@ -138,9 +140,11 @@
 		C14C8EEDD9146F537341D02E /* SocketParsingOutsideNexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 150E85D36973D18EFF0C764C /* SocketParsingOutsideNexTests.swift */; };
 		C1FC2BD79FF0D9DC86910028 /* WebPaneInspectorScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BAD220346CCE551765FCD9 /* WebPaneInspectorScript.swift */; };
 		C276E6F9F7B46ED43FF491D5 /* NexApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3714AA1F15C85762BF36B1FE /* NexApp.swift */; };
+		C35AD7E358BD4B5B0EABF5E9 /* ChromeTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483277A20C203022712FB04D /* ChromeTheme.swift */; };
 		CCBCDD690DA8A082B0C3D1EF /* StatusBarPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110D5179A9834B4AB19B705B /* StatusBarPopoverView.swift */; };
 		CF6DEC598C1A3508555E8EB3 /* LabelPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D6C6671997547A9F95AD39 /* LabelPresetTests.swift */; };
 		D0B97CB294CE96D259C08960 /* GraftCLIReplyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD93535314E9897122ED638 /* GraftCLIReplyTests.swift */; };
+		D5E5F5395113992874C7D4D7 /* RootChromeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6762B22A5CA7CC5867025DA2 /* RootChromeView.swift */; };
 		D9A2EC37D7FABEAFE48E109A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB65E3CCBB3A287C413A6015 /* Foundation.framework */; };
 		DA4AC555E9C3FC84061F2FB9 /* PaneFocusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD9BCE4ABC267C7E34EAF09 /* PaneFocusView.swift */; };
 		DBBD0CD88C3B7EF588D5CB04 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0153509BA13BB205C40DE2D5 /* GitService.swift */; };
@@ -253,6 +257,7 @@
 		45141531B99E3E1B79620ECA /* StoragePanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoragePanel.swift; sourceTree = "<group>"; };
 		452A1B196F8438AD7A7DAC0A /* PaneSendKeyReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneSendKeyReplyTests.swift; sourceTree = "<group>"; };
 		45DFA60F59651234F0F59BE9 /* WebPaneChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneChrome.swift; sourceTree = "<group>"; };
+		483277A20C203022712FB04D /* ChromeTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeTheme.swift; sourceTree = "<group>"; };
 		4CCB57D9C4E2AC2014127FC8 /* MarkdownCheckboxRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCheckboxRenderingTests.swift; sourceTree = "<group>"; };
 		4DA17E3004A004E6B4DDDBF6 /* PersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceTests.swift; sourceTree = "<group>"; };
 		4F0D3AB3067CDBF5A490F532 /* NewWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceSheet.swift; sourceTree = "<group>"; };
@@ -263,6 +268,7 @@
 		5AC82B39AC5EEEC6A787B4D4 /* FocusNotifyingTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusNotifyingTextView.swift; sourceTree = "<group>"; };
 		5F60DBD29A7E964E6F18A28F /* KeyBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingTests.swift; sourceTree = "<group>"; };
 		61D6AE6635332105A3C18A03 /* VibrancyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VibrancyView.swift; sourceTree = "<group>"; };
+		6762B22A5CA7CC5867025DA2 /* RootChromeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootChromeView.swift; sourceTree = "<group>"; };
 		67E67BC5275DEF2EED8D21D2 /* RenameWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameWorkspaceSheet.swift; sourceTree = "<group>"; };
 		684EF74D8EC3F295B22944AB /* WorkspaceLabelViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLabelViews.swift; sourceTree = "<group>"; };
 		6B4B95F852C737F18989F8FA /* WorkspaceColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceColor.swift; sourceTree = "<group>"; };
@@ -331,6 +337,7 @@
 		CFDE8815715F4B6A37D353E8 /* MarkdownCodeCopyScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeCopyScript.swift; sourceTree = "<group>"; };
 		CFE42A23C94DA8DA930C61E3 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		D0CED7EFE254E4491327CAE0 /* EditorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorService.swift; sourceTree = "<group>"; };
+		D2EE3D8224F44E30912F703D /* WindowTitleBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowTitleBar.swift; sourceTree = "<group>"; };
 		D6B83DC43AEA38B4929307FA /* AppReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReducerTests.swift; sourceTree = "<group>"; };
 		D70E36C00A55A87562F4AC1D /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
 		D7BB09519FE46ECBB397354C /* WebPaneActuator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneActuator.swift; sourceTree = "<group>"; };
@@ -350,6 +357,7 @@
 		E52ED6952E87B8F73B2450D7 /* WebTabNewFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebTabNewFocusTests.swift; sourceTree = "<group>"; };
 		E5859C5B2E1850D1262AFE4B /* Nex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Nex.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5A4C5D8F4C099C65A7EA890 /* ScratchpadEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadEditorView.swift; sourceTree = "<group>"; };
+		E730EF15502C9C30B7ACCAF7 /* StatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarView.swift; sourceTree = "<group>"; };
 		E99FA58E4E44ADAD17A788E2 /* WindowSpacesBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowSpacesBinding.swift; sourceTree = "<group>"; };
 		E9F7D5571F89D43BC6C76928 /* WorkspaceGroupSocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupSocketTests.swift; sourceTree = "<group>"; };
 		EA085FC1EE7D90E88FEF33CB /* HelpDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpDataTests.swift; sourceTree = "<group>"; };
@@ -454,6 +462,15 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		4241F8B9346761ADDAF4D0C5 /* Chrome */ = {
+			isa = PBXGroup;
+			children = (
+				6762B22A5CA7CC5867025DA2 /* RootChromeView.swift */,
+				D2EE3D8224F44E30912F703D /* WindowTitleBar.swift */,
+			);
+			path = Chrome;
+			sourceTree = "<group>";
+		};
 		47374755237A71FC9547ADD5 /* NexTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -549,11 +566,13 @@
 				F1A8D5B3446F6056F443CDB8 /* Nex.entitlements */,
 				3714AA1F15C85762BF36B1FE /* NexApp.swift */,
 				B504C980131A9A777767EEB1 /* QuitGate.swift */,
+				4241F8B9346761ADDAF4D0C5 /* Chrome */,
 				477C757108CEE52846121B1E /* Commands */,
 				5F485357D29F2C092501D735 /* Features */,
 				4FF05F1CABA6C0F391FCBFCF /* Ghostty */,
 				37906607D9F29897C19CCC22 /* Models */,
 				6B9A3E1F3B72D1A26F249A1C /* Services */,
+				F095B23294C4398DA905D114 /* Theme */,
 			);
 			path = Nex;
 			sourceTree = "<group>";
@@ -723,6 +742,7 @@
 			children = (
 				09102B6ADEAB463454E7F15E /* StatusBarController.swift */,
 				110D5179A9834B4AB19B705B /* StatusBarPopoverView.swift */,
+				E730EF15502C9C30B7ACCAF7 /* StatusBarView.swift */,
 			);
 			path = StatusBar;
 			sourceTree = "<group>";
@@ -733,6 +753,14 @@
 				84D4EC6AC4CDFB5377057239 /* HelpView.swift */,
 			);
 			path = Help;
+			sourceTree = "<group>";
+		};
+		F095B23294C4398DA905D114 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				483277A20C203022712FB04D /* ChromeTheme.swift */,
+			);
+			path = Theme;
 			sourceTree = "<group>";
 		};
 		F09BE06FAA330721302E5EE2 /* CommandPalette */ = {
@@ -938,6 +966,7 @@
 				EC6971D2E311C8903C373778 /* AppReducer.swift in Sources */,
 				EFDCA64CD227A833D2801893 /* CLIInstallService.swift in Sources */,
 				B23A46CD372F9E16C2C1D716 /* CheckForUpdatesView.swift in Sources */,
+				C35AD7E358BD4B5B0EABF5E9 /* ChromeTheme.swift in Sources */,
 				B221D950378165611A0DF932 /* ClipboardImageHelper.swift in Sources */,
 				3C74513CA9D5FD60E672B477 /* CommandPaletteItem.swift in Sources */,
 				741144CE5AC7DEC20A18A89D /* CommandPaletteView.swift in Sources */,
@@ -1003,6 +1032,7 @@
 				40D01E98BD9BE2397CFC1080 /* RepoRegistryView.swift in Sources */,
 				ED79F70009D8C2A4A1A742F8 /* ResizeDimensionsOverlay.swift in Sources */,
 				5A9607BD6AD03E15B0124B88 /* RingBuffer.swift in Sources */,
+				D5E5F5395113992874C7D4D7 /* RootChromeView.swift in Sources */,
 				FB45777E3BD181F04B322F93 /* ScratchpadEditorView.swift in Sources */,
 				29C636F17D2FEF2D5E0BE55D /* SettingsFeature.swift in Sources */,
 				E31F1B84CF270603EF2B93E0 /* SettingsView.swift in Sources */,
@@ -1011,6 +1041,7 @@
 				77CF808E3AF2C06BD12D11C0 /* SplitDividerView.swift in Sources */,
 				066D1D15DCA5E39EC770E77C /* StatusBarController.swift in Sources */,
 				CCBCDD690DA8A082B0C3D1EF /* StatusBarPopoverView.swift in Sources */,
+				76A3D9E4C48429C694A1896A /* StatusBarView.swift in Sources */,
 				B8B5B666D5CC24071420A966 /* StoragePanel.swift in Sources */,
 				8F5D3C9118D51569A13CB473 /* SurfaceContainerView.swift in Sources */,
 				64D34691D60DD597D0882047 /* SurfaceManager.swift in Sources */,
@@ -1031,6 +1062,7 @@
 				A8626EC08DC12588F912E1EF /* WebPaneStore.swift in Sources */,
 				2F440D3EB93B6C127A1FF003 /* WebPaneView.swift in Sources */,
 				EDF35E86B633BB1E8C3DE844 /* WindowSpacesBinding.swift in Sources */,
+				A100881CAD4946DC855B50A6 /* WindowTitleBar.swift in Sources */,
 				4AF9CB9A4E7CE871FBE1A6F2 /* WorkspaceColor.swift in Sources */,
 				B4846A1AC5C67E51AFA9C846 /* WorkspaceDropTarget.swift in Sources */,
 				E62618BAC6927017CC4ECC44 /* WorkspaceFeature.swift in Sources */,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -612,6 +612,7 @@ struct AppReducer {
         case setFocusFollowsMouseDelay(Int)
         case setTCPPort(Int)
         case tcpPortStartFailed(Int)
+        case restartSocketServer
 
         // Global Hotkey
         case setGlobalHotkey(KeyTrigger?)
@@ -4429,6 +4430,18 @@ struct AppReducer {
                         value: "\(delay)",
                         inFile: path
                     )
+                }
+
+            case .restartSocketServer:
+                // Tear down and rebind the Unix socket (clears /tmp/nex.sock
+                // and any wedged client FDs); bring TCP back if configured.
+                // onMessage is a singleton property, so it survives the cycle.
+                return .run { [tcpPort = state.tcpPort] _ in
+                    socketServer.stop()
+                    socketServer.start()
+                    if tcpPort > 0 {
+                        _ = socketServer.startTCP(port: tcpPort)
+                    }
                 }
 
             case .setTCPPort(let port):

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -3975,7 +3975,13 @@ struct AppReducer {
                     // to status / stop / quit-flush.
                     return .merge(
                         .send(.createWorkspace(name: "Default")),
-                        .send(.graft(.onAppLaunched(parentRepoRoots: [])))
+                        .send(.graft(.onAppLaunched(parentRepoRoots: []))),
+                        // A fresh install has no legacy free-form labels to
+                        // migrate. Mark the one-shot label→preset migration done
+                        // now so a later launch (workspaces no longer empty)
+                        // doesn't run it against the user's *new* labels and
+                        // resurrect any preset they deleted in the meantime.
+                        .run { _ in userDefaults.setBool(true, LabelPresetsStorage.migratedKey) }
                     )
                 }
                 state.workspaces = workspaces
@@ -4167,6 +4173,18 @@ struct AppReducer {
             case .workspaces:
                 // Child workspace actions — persist after mutations
                 return .send(.persistState)
+
+            // Chrome appearance / colour / theme changes recolour the agent
+            // status dots. In-app SwiftUI surfaces re-read them from the chrome
+            // environment automatically, but the AppKit menu-bar icon + popover
+            // are pushed their colours imperatively in `updateExternalIndicators`
+            // — so re-push when the chrome theme changes, otherwise the menu-bar
+            // dot keeps a stale colour until the next agent-status change. This
+            // MUST sit above the catch-all `case .settings:` below, which would
+            // otherwise shadow it (first-match-wins) and return `.none`.
+            case .settings(.setChromeAppearance), .settings(.setChromeColor),
+                 .settings(.resetChromeColors), .settings(.applyStyleTheme):
+                return .send(.updateExternalIndicators)
 
             case .settings:
                 return .none
@@ -6314,15 +6332,6 @@ struct AppReducer {
                 )))
 
             // MARK: - External Indicators
-
-            // The in-app SwiftUI surfaces re-read the status colours from the
-            // chrome environment automatically, but the AppKit menu-bar icon +
-            // popover are pushed their colours imperatively in
-            // `updateExternalIndicators` — so re-push when the chrome theme
-            // changes, otherwise the menu-bar dot keeps a stale colour until the
-            // next agent-status change.
-            case .settings(.setChromeAppearance), .settings(.setChromeColor), .settings(.resetChromeColors):
-                return .send(.updateExternalIndicators)
 
             case .updateExternalIndicators:
                 var totalWaiting = 0

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -4,6 +4,15 @@ import Foundation
 import SwiftUI
 import WebKit
 
+/// A finished agent run, captured when its waiting-for-input state is cleared.
+/// Backs the footer's "done" hover detail. Session-scoped; not persisted.
+struct CompletedAgent: Equatable {
+    let workspaceName: String
+    let workspaceColor: WorkspaceColor
+    let paneTitle: String
+    let completedAt: Date
+}
+
 @Reducer
 struct AppReducer {
     @ObservableState
@@ -34,6 +43,10 @@ struct AppReducer {
         /// cleared this session (an acknowledged finished turn). Drives the
         /// status bar's "N done". Session-scoped, intentionally not persisted.
         var completedAgentCount: Int = 0
+        /// Recent finished agents (newest first, capped), captured at the same
+        /// moment `completedAgentCount` increments — backs the "done" hover
+        /// detail. Session-scoped, not persisted.
+        var completedAgents: [CompletedAgent] = []
         var keybindings: KeyBindingMap = .defaults
         var focusFollowsMouse: Bool = false
         var focusFollowsMouseDelay: Int = 100
@@ -3097,6 +3110,17 @@ struct AppReducer {
             if case let .workspaces(.element(id: wsID, action: .clearPaneStatus(paneID))) = action,
                state.workspaces[id: wsID]?.panes[id: paneID]?.status == .waitingForInput {
                 state.completedAgentCount += 1
+                if let workspace = state.workspaces[id: wsID], let pane = workspace.panes[id: paneID] {
+                    state.completedAgents.insert(CompletedAgent(
+                        workspaceName: workspace.name,
+                        workspaceColor: workspace.color,
+                        paneTitle: pane.title ?? pane.label ?? "Shell",
+                        completedAt: Date()
+                    ), at: 0)
+                    if state.completedAgents.count > 30 {
+                        state.completedAgents.removeLast(state.completedAgents.count - 30)
+                    }
+                }
             }
             return .none
         }

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -20,6 +20,7 @@ struct AppReducer {
         var groupDeleteConfirmation: GroupDeleteConfirmation?
         var groupBulkCreatePrompt: GroupBulkCreatePrompt?
         var groupCustomEmojiPrompt: GroupCustomEmojiPrompt?
+        var workspaceCustomEmojiPrompt: WorkspaceCustomEmojiPrompt?
         var selectedWorkspaceIDs: Set<UUID> = []
         var lastSelectionAnchor: UUID?
         var bulkDeleteConfirmationIDs: [UUID]?
@@ -28,6 +29,10 @@ struct AppReducer {
         var repoRegistry: IdentifiedArrayOf<Repo> = []
         var gitStatuses: [UUID: RepoGitStatus] = [:]
         var isInspectorVisible: Bool = false
+        /// Running tally of agent runs whose waiting-for-input state was
+        /// cleared this session (an acknowledged finished turn). Drives the
+        /// status bar's "N done". Session-scoped, intentionally not persisted.
+        var completedAgentCount: Int = 0
         var keybindings: KeyBindingMap = .defaults
         var focusFollowsMouse: Bool = false
         var focusFollowsMouseDelay: Int = 100
@@ -115,6 +120,25 @@ struct AppReducer {
                 }
             }
             return ActivitySummary(agentCount: agentCount, workspaceCount: workspaceCount)
+        }
+
+        /// Cross-workspace agent counts for the bottom status bar. Reading
+        /// this inside a tracked view registers a dependency on `workspaces`
+        /// + `completedAgentCount`, so the footer re-bodies on any status
+        /// change (Release-safe when read from a distinct child view).
+        var chromeStatusSummary: ChromeStatusSummary {
+            var summary = ChromeStatusSummary()
+            for workspace in workspaces {
+                for pane in workspace.panes {
+                    switch pane.status {
+                    case .running: summary.running += 1
+                    case .waitingForInput: summary.waiting += 1
+                    case .idle: break
+                    }
+                }
+            }
+            summary.done = completedAgentCount
+            return summary
         }
 
         /// Sidebar entry that the active workspace occupies, used as an
@@ -387,6 +411,10 @@ struct AppReducer {
         case requestGroupCustomEmoji(UUID)
         case cancelGroupCustomEmoji
         case confirmGroupCustomEmoji(String)
+        case setWorkspaceIcon(id: UUID, icon: GroupIcon?)
+        case requestWorkspaceCustomEmoji(UUID)
+        case cancelWorkspaceCustomEmoji
+        case confirmWorkspaceCustomEmoji(String)
         case deleteGroup(id: UUID, cascade: Bool)
         case moveWorkspaceToGroup(workspaceID: UUID, groupID: UUID?, index: Int? = nil)
         case beginRenameGroup(UUID)
@@ -3047,6 +3075,18 @@ struct AppReducer {
     }
 
     var body: some ReducerOf<Self> {
+        // Declared BEFORE the main reducer's `.forEach` so it runs while the
+        // pane is still `.waitingForInput` — the child `clearPaneStatus`
+        // handler (which flips it to `.idle`) runs first within the
+        // `.forEach`, so reading the status from the parent interception
+        // below would always see `.idle`. A leading reducer sidesteps that.
+        Reduce { state, action in
+            if case let .workspaces(.element(id: wsID, action: .clearPaneStatus(paneID))) = action,
+               state.workspaces[id: wsID]?.panes[id: paneID]?.status == .waitingForInput {
+                state.completedAgentCount += 1
+            }
+            return .none
+        }
         Reduce { state, action in
             switch action {
             case .appLaunched:
@@ -3658,6 +3698,38 @@ struct AppReducer {
                 state.groupCustomEmojiPrompt = nil
                 guard state.groups[id: prompt.groupID] != nil else { return .none }
                 state.groups[id: prompt.groupID]?.icon = .emoji(String(firstGrapheme))
+                return .send(.persistState)
+
+            case .setWorkspaceIcon(let id, let icon):
+                guard state.workspaces[id: id] != nil else { return .none }
+                state.workspaces[id: id]?.icon = icon
+                return .send(.persistState)
+
+            case .requestWorkspaceCustomEmoji(let id):
+                guard let workspace = state.workspaces[id: id] else { return .none }
+                state.workspaceCustomEmojiPrompt = WorkspaceCustomEmojiPrompt(
+                    workspaceID: id,
+                    workspaceName: workspace.name
+                )
+                return .none
+
+            case .cancelWorkspaceCustomEmoji:
+                state.workspaceCustomEmojiPrompt = nil
+                return .none
+
+            case .confirmWorkspaceCustomEmoji(let emoji):
+                // Same server-side "1 emoji grapheme" guard as the group path.
+                let trimmed = emoji.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard let prompt = state.workspaceCustomEmojiPrompt,
+                      let firstGrapheme = trimmed.first,
+                      firstGrapheme.isGraphemeEmoji
+                else {
+                    state.workspaceCustomEmojiPrompt = nil
+                    return .none
+                }
+                state.workspaceCustomEmojiPrompt = nil
+                guard state.workspaces[id: prompt.workspaceID] != nil else { return .none }
+                state.workspaces[id: prompt.workspaceID]?.icon = .emoji(String(firstGrapheme))
                 return .send(.persistState)
 
             case .deleteGroup(let id, let cascade):

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -62,6 +62,13 @@ struct AppReducer {
         /// text matches a preset name.
         var labelPresets: [LabelPreset] = []
 
+        /// One-time label→preset migration runs once both the workspaces and
+        /// the (UserDefaults) presets have loaded — they load concurrently, so
+        /// each completion sets its flag and triggers the migration when both
+        /// are ready.
+        var didRestoreWorkspaces = false
+        var didLoadLabelPresets = false
+
         /// Color for a workspace label string, or nil when no preset
         /// matches (chip renders in the neutral free-form style). Match is
         /// exact and case-sensitive, mirroring how `addLabel` stores
@@ -554,6 +561,10 @@ struct AppReducer {
         // MARK: - Label presets
 
         case labelPresetsLoaded([LabelPreset])
+        /// Back-fill a preset (default colour) for every existing workspace
+        /// label that predates the presets feature, so they survive being
+        /// unapplied. Runs once both workspaces + presets have loaded.
+        case migrateLabelsToPresets
         /// Add a preset. Name is normalized (trim/clamp); empty or a
         /// case-sensitive duplicate name is ignored.
         case addLabelPreset(name: String, color: LabelColor)
@@ -3984,6 +3995,7 @@ struct AppReducer {
                 state.groups = groups
                 state.activeWorkspaceID = activeID ?? workspaces.first?.id
                 state.repoRegistry = repoRegistry
+                state.didRestoreWorkspaces = true
 
                 // Use persisted topLevelOrder if present; otherwise synthesize
                 // from the flat workspaces list (legacy DBs predate groups).
@@ -4071,6 +4083,7 @@ struct AppReducer {
                         },
                         .send(.refreshGitStatus),
                         .send(.startGitStatusTimer),
+                        .send(.migrateLabelsToPresets),
                         .send(.graft(.onAppLaunched(parentRepoRoots: parentRepoRoots)))
                     ] + watcherSeeds
                 )
@@ -4297,7 +4310,24 @@ struct AppReducer {
 
             case .labelPresetsLoaded(let list):
                 state.labelPresets = list
-                return .none
+                state.didLoadLabelPresets = true
+                return .send(.migrateLabelsToPresets)
+
+            case .migrateLabelsToPresets:
+                // Only once both halves have loaded (they load concurrently).
+                guard state.didRestoreWorkspaces, state.didLoadLabelPresets else { return .none }
+                var seen = Set(state.labelPresets.map(\.name))
+                var added: [LabelPreset] = []
+                for workspace in state.workspaces {
+                    for label in workspace.labels where !seen.contains(label) {
+                        seen.insert(label)
+                        // Default colour; the user can recolour it in Settings.
+                        added.append(LabelPreset(name: label, color: .named(.gray)))
+                    }
+                }
+                guard !added.isEmpty else { return .none }
+                state.labelPresets.append(contentsOf: added)
+                return persistLabelPresets(state.labelPresets)
 
             case .addLabelPreset(let name, let color):
                 let normalized = WorkspaceFeature.normalizeLabel(name)

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ComposableArchitecture
 import Foundation
+import SwiftUI
 import WebKit
 
 @Reducer
@@ -6321,6 +6322,15 @@ struct AppReducer {
 
             // MARK: - External Indicators
 
+            // The in-app SwiftUI surfaces re-read the status colours from the
+            // chrome environment automatically, but the AppKit menu-bar icon +
+            // popover are pushed their colours imperatively in
+            // `updateExternalIndicators` — so re-push when the chrome theme
+            // changes, otherwise the menu-bar dot keeps a stale colour until the
+            // next agent-status change.
+            case .settings(.setChromeAppearance), .settings(.setChromeColor), .settings(.resetChromeColors):
+                return .send(.updateExternalIndicators)
+
             case .updateExternalIndicators:
                 var totalWaiting = 0
                 var totalRunning = 0
@@ -6359,12 +6369,26 @@ struct AppReducer {
                 let finalWaiting = totalWaiting
                 let finalRunning = totalRunning
                 let finalItems = statusItems
+                let appearance = state.settings.chromeAppearance
+                let colorOverrides = state.settings.chromeColorOverrides
                 return .run { _ in
                     await MainActor.run {
+                        // Resolve the chrome status colours so the menu-bar icon
+                        // + popover match the in-app status colours. The menu bar
+                        // sits in the OS appearance, so resolve against it.
+                        let scheme: ColorScheme = NSApp.effectiveAppearance
+                            .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? .dark : .light
+                        let theme = ChromeTheme.resolve(
+                            appearance: appearance,
+                            system: scheme,
+                            overrides: colorOverrides
+                        )
                         controller.update(
                             waitingCount: finalWaiting,
                             runningCount: finalRunning,
-                            items: finalItems
+                            items: finalItems,
+                            waitingColor: theme.statusWaiting,
+                            runningColor: theme.statusRunning
                         )
                         if finalWaiting > 0 {
                             NSApp.dockTile.badgeLabel = "\(finalWaiting)"

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -4317,6 +4317,13 @@ struct AppReducer {
             case .migrateLabelsToPresets:
                 // Only once both halves have loaded (they load concurrently).
                 guard state.didRestoreWorkspaces, state.didLoadLabelPresets else { return .none }
+                // One-shot: a back-fill that ran every launch would resurrect a
+                // preset the user later deletes (its label can still be applied
+                // to a workspace), reverting their delete + custom colour.
+                guard !userDefaults.boolForKey(LabelPresetsStorage.migratedKey) else { return .none }
+                let markMigrated = Effect<Action>.run { _ in
+                    userDefaults.setBool(true, LabelPresetsStorage.migratedKey)
+                }
                 var seen = Set(state.labelPresets.map(\.name))
                 var added: [LabelPreset] = []
                 for workspace in state.workspaces {
@@ -4326,9 +4333,9 @@ struct AppReducer {
                         added.append(LabelPreset(name: label, color: .named(.gray)))
                     }
                 }
-                guard !added.isEmpty else { return .none }
+                guard !added.isEmpty else { return markMigrated }
                 state.labelPresets.append(contentsOf: added)
-                return persistLabelPresets(state.labelPresets)
+                return .merge(persistLabelPresets(state.labelPresets), markMigrated)
 
             case .addLabelPreset(let name, let color):
                 let normalized = WorkspaceFeature.normalizeLabel(name)

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -4,15 +4,6 @@ import Foundation
 import SwiftUI
 import WebKit
 
-/// A finished agent run, captured when its waiting-for-input state is cleared.
-/// Backs the footer's "done" hover detail. Session-scoped; not persisted.
-struct CompletedAgent: Equatable {
-    let workspaceName: String
-    let workspaceColor: WorkspaceColor
-    let paneTitle: String
-    let completedAt: Date
-}
-
 @Reducer
 struct AppReducer {
     @ObservableState
@@ -39,14 +30,6 @@ struct AppReducer {
         var repoRegistry: IdentifiedArrayOf<Repo> = []
         var gitStatuses: [UUID: RepoGitStatus] = [:]
         var isInspectorVisible: Bool = false
-        /// Running tally of agent runs whose waiting-for-input state was
-        /// cleared this session (an acknowledged finished turn). Drives the
-        /// status bar's "N done". Session-scoped, intentionally not persisted.
-        var completedAgentCount: Int = 0
-        /// Recent finished agents (newest first, capped), captured at the same
-        /// moment `completedAgentCount` increments — backs the "done" hover
-        /// detail. Session-scoped, not persisted.
-        var completedAgents: [CompletedAgent] = []
         var keybindings: KeyBindingMap = .defaults
         var focusFollowsMouse: Bool = false
         var focusFollowsMouseDelay: Int = 100
@@ -144,9 +127,9 @@ struct AppReducer {
         }
 
         /// Cross-workspace agent counts for the bottom status bar. Reading
-        /// this inside a tracked view registers a dependency on `workspaces`
-        /// + `completedAgentCount`, so the footer re-bodies on any status
-        /// change (Release-safe when read from a distinct child view).
+        /// this inside a tracked view registers a dependency on `workspaces`,
+        /// so the footer re-bodies on any status change (Release-safe when
+        /// read from a distinct child view).
         var chromeStatusSummary: ChromeStatusSummary {
             var summary = ChromeStatusSummary()
             for workspace in workspaces {
@@ -154,11 +137,13 @@ struct AppReducer {
                     switch pane.status {
                     case .running: summary.running += 1
                     case .waitingForInput: summary.waiting += 1
-                    case .idle: break
+                    case .idle:
+                        // An attached-but-idle agent session is "inactive"
+                        // (a resumable agent that isn't running or waiting).
+                        if pane.agentSessionID != nil { summary.inactive += 1 }
                     }
                 }
             }
-            summary.done = completedAgentCount
             return summary
         }
 
@@ -3101,29 +3086,6 @@ struct AppReducer {
     }
 
     var body: some ReducerOf<Self> {
-        // Declared BEFORE the main reducer's `.forEach` so it runs while the
-        // pane is still `.waitingForInput` — the child `clearPaneStatus`
-        // handler (which flips it to `.idle`) runs first within the
-        // `.forEach`, so reading the status from the parent interception
-        // below would always see `.idle`. A leading reducer sidesteps that.
-        Reduce { state, action in
-            if case let .workspaces(.element(id: wsID, action: .clearPaneStatus(paneID))) = action,
-               state.workspaces[id: wsID]?.panes[id: paneID]?.status == .waitingForInput {
-                state.completedAgentCount += 1
-                if let workspace = state.workspaces[id: wsID], let pane = workspace.panes[id: paneID] {
-                    state.completedAgents.insert(CompletedAgent(
-                        workspaceName: workspace.name,
-                        workspaceColor: workspace.color,
-                        paneTitle: pane.title ?? pane.label ?? "Shell",
-                        completedAt: Date()
-                    ), at: 0)
-                    if state.completedAgents.count > 30 {
-                        state.completedAgents.removeLast(state.completedAgents.count - 30)
-                    }
-                }
-            }
-            return .none
-        }
         Reduce { state, action in
             switch action {
             case .appLaunched:

--- a/Nex/Chrome/RootChromeView.swift
+++ b/Nex/Chrome/RootChromeView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ComposableArchitecture
 import SwiftUI
 
@@ -53,11 +54,26 @@ struct RootChromeView: View {
 struct ChromeThemed<Content: View>: View {
     let store: StoreOf<AppReducer>
     @ViewBuilder var content: Content
-    @Environment(\.colorScheme) private var systemScheme
+    // The true OS scheme, read from `NSApp.effectiveAppearance` and kept live —
+    // NOT `@Environment(\.colorScheme)`, which reflects this window's forced
+    // override and so can't tell us what "System" should resolve to.
+    @StateObject private var systemAppearance = SystemAppearanceModel()
 
     var body: some View {
         WithPerceptionTracking {
             let appearance = store.settings.chromeAppearance
+            let systemScheme = systemAppearance.colorScheme
+            // Always resolve to a CONCRETE scheme. `.preferredColorScheme(nil)`
+            // (the old `.system` path) does not reliably revert a window that was
+            // previously forced to .light/.dark — that left the surfaces resolving
+            // light while text/native chrome followed the dark window. Forcing a
+            // concrete scheme makes every transition concrete→concrete (reliable),
+            // and `systemAppearance` keeps `.system` following the OS live.
+            let effective: ColorScheme = switch appearance {
+            case .system: systemScheme
+            case .light: .light
+            case .dark: .dark
+            }
             let theme = ChromeTheme.resolve(
                 appearance: appearance,
                 system: systemScheme,
@@ -72,8 +88,38 @@ struct ChromeThemed<Content: View>: View {
                     groupFill: store.settings.sidebarGroupFillOpacity,
                     groupStroke: store.settings.sidebarGroupStrokeOpacity
                 ))
-                .preferredColorScheme(appearance.explicitScheme)
+                .preferredColorScheme(effective)
                 .tint(theme.accent)
         }
+    }
+}
+
+/// Publishes the true system colour scheme from `NSApp.effectiveAppearance`,
+/// independent of any window's `.preferredColorScheme` override. Drives the
+/// `.system` chrome preference: we force this concrete scheme rather than
+/// `.preferredColorScheme(nil)` (which doesn't reliably revert a previously
+/// forced window), and re-publish when the OS flips light/dark so `.system`
+/// stays live (e.g. the auto day/night schedule).
+@MainActor
+final class SystemAppearanceModel: ObservableObject {
+    @Published private(set) var colorScheme: ColorScheme
+    private var observation: NSKeyValueObservation?
+
+    init() {
+        colorScheme = SystemAppearanceModel.current()
+        // NSKeyValueObservation invalidates itself on deinit, so no manual
+        // teardown is needed.
+        observation = NSApp.observe(\.effectiveAppearance, options: [.new]) { [weak self] _, _ in
+            Task { @MainActor in self?.refresh() }
+        }
+    }
+
+    private func refresh() {
+        let scheme = SystemAppearanceModel.current()
+        if colorScheme != scheme { colorScheme = scheme }
+    }
+
+    private static func current() -> ColorScheme {
+        NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? .dark : .light
     }
 }

--- a/Nex/Chrome/RootChromeView.swift
+++ b/Nex/Chrome/RootChromeView.swift
@@ -21,8 +21,11 @@ struct RootChromeView: View {
 
     var body: some View {
         WithPerceptionTracking {
-            let appearance = store.settings.chromeAppearance
-            let theme = appearance.theme(system: systemScheme)
+            let theme = ChromeTheme.resolve(
+                appearance: store.settings.chromeAppearance,
+                system: systemScheme,
+                overrides: store.settings.chromeColorOverrides
+            )
             ChromeThemed(store: store) {
                 ContentView(store: store)
                     .background {
@@ -55,7 +58,11 @@ struct ChromeThemed<Content: View>: View {
     var body: some View {
         WithPerceptionTracking {
             let appearance = store.settings.chromeAppearance
-            let theme = appearance.theme(system: systemScheme)
+            let theme = ChromeTheme.resolve(
+                appearance: appearance,
+                system: systemScheme,
+                overrides: store.settings.chromeColorOverrides
+            )
             content
                 .environment(\.chromeTheme, theme)
                 .preferredColorScheme(appearance.explicitScheme)

--- a/Nex/Chrome/RootChromeView.swift
+++ b/Nex/Chrome/RootChromeView.swift
@@ -54,9 +54,9 @@ struct RootChromeView: View {
 struct ChromeThemed<Content: View>: View {
     let store: StoreOf<AppReducer>
     @ViewBuilder var content: Content
-    // The true OS scheme, read from `NSApp.effectiveAppearance` and kept live —
-    // NOT `@Environment(\.colorScheme)`, which reflects this window's forced
-    // override and so can't tell us what "System" should resolve to.
+    /// The true OS scheme, read from `NSApp.effectiveAppearance` and kept live —
+    /// NOT `@Environment(\.colorScheme)`, which reflects this window's forced
+    /// override and so can't tell us what "System" should resolve to.
     @StateObject private var systemAppearance = SystemAppearanceModel()
 
     var body: some View {

--- a/Nex/Chrome/RootChromeView.swift
+++ b/Nex/Chrome/RootChromeView.swift
@@ -66,6 +66,12 @@ struct ChromeThemed<Content: View>: View {
             content
                 .environment(\.chromeTheme, theme)
                 .environment(\.sidebarColorIntensity, store.settings.sidebarColorIntensity)
+                .environment(\.sidebarFillStroke, SidebarFillStroke(
+                    avatarFill: store.settings.sidebarAvatarFillOpacity,
+                    avatarStroke: store.settings.sidebarAvatarStrokeOpacity,
+                    groupFill: store.settings.sidebarGroupFillOpacity,
+                    groupStroke: store.settings.sidebarGroupStrokeOpacity
+                ))
                 .preferredColorScheme(appearance.explicitScheme)
                 .tint(theme.accent)
         }

--- a/Nex/Chrome/RootChromeView.swift
+++ b/Nex/Chrome/RootChromeView.swift
@@ -65,6 +65,7 @@ struct ChromeThemed<Content: View>: View {
             )
             content
                 .environment(\.chromeTheme, theme)
+                .environment(\.sidebarColorIntensity, store.settings.sidebarColorIntensity)
                 .preferredColorScheme(appearance.explicitScheme)
                 .tint(theme.accent)
         }

--- a/Nex/Chrome/RootChromeView.swift
+++ b/Nex/Chrome/RootChromeView.swift
@@ -1,0 +1,65 @@
+import ComposableArchitecture
+import SwiftUI
+
+/// App-root wrapper that resolves the warm `ChromeTheme` from the user's
+/// `chromeAppearance` preference + the system colour scheme and injects it
+/// into the environment for the whole window.
+///
+/// This is a deliberately small, distinct child view: `WithPerceptionTracking`
+/// is a no-op in Release builds, so the theme would never re-resolve on a
+/// preference change if this read lived inside `ContentView`'s large body.
+/// Isolating it here guarantees the sun/moon toggle actually repaints the
+/// chrome in Release. `ContentView(store:)` sits at a stable type+position,
+/// so re-creating this wrapper on a preference change preserves the pane-grid
+/// (terminal surface) subtree identity untouched.
+struct RootChromeView: View {
+    let store: StoreOf<AppReducer>
+    /// The window's resolved scheme. Only consulted in the `.system` branch
+    /// (where we don't force a scheme), so the read-then-override can't loop.
+    @Environment(\.colorScheme) private var systemScheme
+    @Environment(\.ghosttyConfig) private var ghosttyConfig
+
+    var body: some View {
+        WithPerceptionTracking {
+            let appearance = store.settings.chromeAppearance
+            let theme = appearance.theme(system: systemScheme)
+            ChromeThemed(store: store) {
+                ContentView(store: store)
+                    .background {
+                        // Only paint the opaque chrome backdrop when the
+                        // terminal is fully opaque. With `background-opacity < 1`
+                        // the window is non-opaque (see NexApp) so transparent
+                        // shell surfaces can see through to the desktop — an
+                        // opaque backdrop here would defeat that.
+                        if ghosttyConfig.backgroundOpacity >= 1 {
+                            theme.windowBackground.ignoresSafeArea()
+                        }
+                    }
+            }
+        }
+    }
+}
+
+/// Resolves the chrome palette from the appearance preference + system scheme
+/// and injects it (theme + preferredColorScheme + tint) for any subtree.
+///
+/// Shared by `RootChromeView` (the main window) and the `Settings` scene so
+/// both honour the appearance preference. Like `RootChromeView`, the work
+/// lives inside `WithPerceptionTracking` in this small, distinct child view so
+/// a preference change actually re-resolves the theme in Release builds.
+struct ChromeThemed<Content: View>: View {
+    let store: StoreOf<AppReducer>
+    @ViewBuilder var content: Content
+    @Environment(\.colorScheme) private var systemScheme
+
+    var body: some View {
+        WithPerceptionTracking {
+            let appearance = store.settings.chromeAppearance
+            let theme = appearance.theme(system: systemScheme)
+            content
+                .environment(\.chromeTheme, theme)
+                .preferredColorScheme(appearance.explicitScheme)
+                .tint(theme.accent)
+        }
+    }
+}

--- a/Nex/Chrome/WindowTitleBar.swift
+++ b/Nex/Chrome/WindowTitleBar.swift
@@ -33,7 +33,10 @@ struct WindowTitleBar: View {
                 trailingControls
             }
             .frame(maxWidth: .infinity)
-            .frame(height: 38)
+            // 32pt centres the title bar on the macOS traffic lights' fixed
+            // vertical position (~16pt from the window top), so they sit
+            // vertically centred in the bar.
+            .frame(height: 32)
             .overlay(alignment: .bottom) {
                 theme.divider.frame(height: 1)
             }

--- a/Nex/Chrome/WindowTitleBar.swift
+++ b/Nex/Chrome/WindowTitleBar.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 /// Custom in-content window title bar shown under the hidden native
 /// titlebar (`.windowStyle(.hiddenTitleBar)`). Centres the active
-/// workspace identity (status dot · name · pane count · branch). Traffic
+/// workspace identity (status dot · name · pane count). Traffic
 /// lights float over its leading edge; window dragging is handled by the
 /// `WindowDragRegion`.
 ///
@@ -77,24 +77,14 @@ struct WindowTitleBar: View {
                 Text("\(workspace.panes.count) pane\(workspace.panes.count == 1 ? "" : "s")")
                     .foregroundStyle(theme.textTertiary)
             }
-
-            if let branch = activeBranch(workspace) {
-                separator
-                HStack(spacing: 3) {
-                    Image(systemName: "arrow.triangle.branch")
-                        .font(.system(size: 9))
-                    Text(branch)
-                }
-                .foregroundStyle(theme.textTertiary)
-            }
         }
         .font(.system(size: 12))
         .lineLimit(1)
         .truncationMode(.tail)
         // Asymmetric insets: clear the traffic lights on the left (80) and
         // reserve room for the trailing controls on the right (86) so a long
-        // name + branch truncates instead of overlapping the menu / sidebar
-        // buttons on a narrow window.
+        // name truncates instead of overlapping the menu / sidebar buttons on a
+        // narrow window.
         .padding(.leading, 80)
         .padding(.trailing, 86)
     }
@@ -112,18 +102,6 @@ struct WindowTitleBar: View {
             return theme.statusRunning
         }
         return workspace.color.color
-    }
-
-    /// Branch of the focused pane, falling back to the first pane that has
-    /// one (so the title bar still shows a branch when focus is on a
-    /// non-shell pane).
-    private func activeBranch(_ workspace: WorkspaceFeature.State?) -> String? {
-        guard let workspace else { return nil }
-        if let focusedID = workspace.focusedPaneID,
-           let branch = workspace.panes[id: focusedID]?.gitBranch {
-            return branch
-        }
-        return workspace.panes.compactMap(\.gitBranch).first
     }
 }
 

--- a/Nex/Chrome/WindowTitleBar.swift
+++ b/Nex/Chrome/WindowTitleBar.swift
@@ -94,6 +94,9 @@ struct WindowTitleBar: View {
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
+            // borderlessButton tints its label with the accent; force it to the
+            // neutral text colour so the ••• matches the other title-bar controls.
+            .tint(theme.textSecondary)
             .foregroundStyle(theme.textSecondary)
 
             Button { store.send(.toggleSidebar) } label: {

--- a/Nex/Chrome/WindowTitleBar.swift
+++ b/Nex/Chrome/WindowTitleBar.swift
@@ -1,0 +1,160 @@
+import AppKit
+import ComposableArchitecture
+import SwiftUI
+
+/// Custom in-content window title bar shown under the hidden native
+/// titlebar (`.windowStyle(.hiddenTitleBar)`). Centres the active
+/// workspace identity (status dot · name · pane count · branch) and
+/// hosts the right-hand chrome controls. Traffic lights float over its
+/// leading edge; window dragging is preserved via
+/// `isMovableByWindowBackground` set on the window.
+///
+/// A distinct child view with its own `WithPerceptionTracking` so it
+/// re-renders in Release builds when the active workspace / pane state
+/// changes (the outer `WithPerceptionTracking` is a no-op there).
+struct WindowTitleBar: View {
+    let store: StoreOf<AppReducer>
+    @Environment(\.chromeTheme) private var theme
+
+    var body: some View {
+        WithPerceptionTracking {
+            let workspace = store.activeWorkspace
+            ZStack {
+                // Match the bottom status bar's background (sidebar/footer
+                // tone). `WindowDragRegion` is a real layer in front of the
+                // colour but behind the title content, so empty parts of the
+                // bar drag the window (via `performDrag`) — scoped to the bar
+                // so it doesn't make the sidebar a drag handle the way
+                // `isMovableByWindowBackground` did.
+                theme.footerBackground
+                WindowDragRegion()
+                identityCluster(workspace)
+                trailingControls
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 38)
+            .overlay(alignment: .bottom) {
+                theme.divider.frame(height: 1)
+            }
+        }
+    }
+
+    private func identityCluster(_ workspace: WorkspaceFeature.State?) -> some View {
+        HStack(spacing: 7) {
+            Circle()
+                .fill(dotColor(workspace))
+                .frame(width: 7, height: 7)
+
+            Text(workspace?.name ?? "Nex")
+                .fontWeight(.semibold)
+                .foregroundStyle(theme.textPrimary)
+
+            if let workspace {
+                separator
+                Text("\(workspace.panes.count) pane\(workspace.panes.count == 1 ? "" : "s")")
+                    .foregroundStyle(theme.textTertiary)
+            }
+
+            if let branch = activeBranch(workspace) {
+                separator
+                HStack(spacing: 3) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .font(.system(size: 9))
+                    Text(branch)
+                }
+                .foregroundStyle(theme.textTertiary)
+            }
+        }
+        .font(.system(size: 12))
+        .lineLimit(1)
+        .truncationMode(.tail)
+        // Asymmetric insets: clear the traffic lights on the left (80) and
+        // reserve room for the trailing controls on the right (110) so a long
+        // name + branch truncates instead of overlapping the record / menu /
+        // sidebar buttons on a narrow window.
+        .padding(.leading, 80)
+        .padding(.trailing, 110)
+    }
+
+    private var trailingControls: some View {
+        HStack(spacing: 14) {
+            Spacer()
+
+            // Record is a visual stub (no capture backend yet).
+            Image(systemName: "record.circle")
+                .foregroundStyle(theme.textTertiary)
+                .help("Recording — coming soon")
+
+            Menu {
+                Button("New Workspace") { store.send(.showNewWorkspaceSheet()) }
+                Button(store.isInspectorVisible ? "Hide Inspector" : "Show Inspector") {
+                    store.send(.toggleInspector)
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .foregroundStyle(theme.textSecondary)
+
+            Button { store.send(.toggleSidebar) } label: {
+                Image(systemName: "sidebar.left")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(theme.textSecondary)
+            .help("Toggle sidebar")
+        }
+        .font(.system(size: 13))
+        .padding(.trailing, 14)
+    }
+
+    private var separator: some View {
+        Text("·").foregroundStyle(theme.textTertiary)
+    }
+
+    private func dotColor(_ workspace: WorkspaceFeature.State?) -> Color {
+        guard let workspace else { return theme.textTertiary }
+        if workspace.panes.contains(where: { $0.status == .waitingForInput }) {
+            return theme.statusWaiting
+        }
+        if workspace.panes.contains(where: { $0.status == .running }) {
+            return theme.statusRunning
+        }
+        return workspace.color.color
+    }
+
+    /// Branch of the focused pane, falling back to the first pane that has
+    /// one (so the title bar still shows a branch when focus is on a
+    /// non-shell pane).
+    private func activeBranch(_ workspace: WorkspaceFeature.State?) -> String? {
+        guard let workspace else { return nil }
+        if let focusedID = workspace.focusedPaneID,
+           let branch = workspace.panes[id: focusedID]?.gitBranch {
+            return branch
+        }
+        return workspace.panes.compactMap(\.gitBranch).first
+    }
+}
+
+/// A transparent, hit-testable backing view that lets the window be dragged
+/// from the non-interactive parts of the custom title bar. Scoped to the
+/// title bar (not the whole window) so it doesn't hijack sidebar drag-to-
+/// reorder the way `NSWindow.isMovableByWindowBackground` did. Interactive
+/// SwiftUI controls layered in front (the buttons) keep their own handling.
+private struct WindowDragRegion: NSViewRepresentable {
+    func makeNSView(context _: Context) -> NSView {
+        DragView()
+    }
+
+    func updateNSView(_: NSView, context _: Context) {}
+
+    private final class DragView: NSView {
+        /// `mouseDownCanMoveWindow` is unreliable for a SwiftUI-embedded view,
+        /// so initiate the drag explicitly. `performDrag` also handles the
+        /// double-click-to-zoom/minimise titlebar conventions.
+        override func mouseDown(with event: NSEvent) {
+            window?.performDrag(with: event)
+        }
+    }
+}

--- a/Nex/Chrome/WindowTitleBar.swift
+++ b/Nex/Chrome/WindowTitleBar.swift
@@ -4,10 +4,17 @@ import SwiftUI
 
 /// Custom in-content window title bar shown under the hidden native
 /// titlebar (`.windowStyle(.hiddenTitleBar)`). Centres the active
-/// workspace identity (status dot · name · pane count · branch) and
-/// hosts the right-hand chrome controls. Traffic lights float over its
-/// leading edge; window dragging is preserved via
-/// `isMovableByWindowBackground` set on the window.
+/// workspace identity (status dot · name · pane count · branch). Traffic
+/// lights float over its leading edge; window dragging is handled by the
+/// `WindowDragRegion`.
+///
+/// This bar is drawn as *content* under the transparent native titlebar
+/// (via `ignoresSafeArea`), so the macOS titlebar owns mouse events in the
+/// top strip and any interactive control placed here would be unclickable.
+/// The identity + background are non-interactive, so that's fine; the
+/// right-hand chrome controls (••• menu, sidebar toggle) instead live in a
+/// native trailing titlebar accessory (`TitlebarTrailingControls`, installed
+/// in `NexApp`) which the titlebar *does* route clicks to.
 ///
 /// A distinct child view with its own `WithPerceptionTracking` so it
 /// re-renders in Release builds when the active workspace / pane state
@@ -15,6 +22,9 @@ import SwiftUI
 struct WindowTitleBar: View {
     let store: StoreOf<AppReducer>
     @Environment(\.chromeTheme) private var theme
+    // Owned here (an in-scene view) so the titlebar-accessory ••• menu — which
+    // is outside the SwiftUI scene and can't reach `openSettings` itself — can
+    // relay through `nexOpenSettings`.
     @Environment(\.openSettings) private var openSettings
 
     var body: some View {
@@ -22,15 +32,15 @@ struct WindowTitleBar: View {
             let workspace = store.activeWorkspace
             ZStack {
                 // Match the bottom status bar's background (sidebar/footer
-                // tone). `WindowDragRegion` is a real layer in front of the
-                // colour but behind the title content, so empty parts of the
-                // bar drag the window (via `performDrag`) — scoped to the bar
-                // so it doesn't make the sidebar a drag handle the way
-                // `isMovableByWindowBackground` did.
+                // tone). `WindowDragRegion` lets empty parts of the bar drag
+                // the window (via `performDrag`) — scoped to the bar so it
+                // doesn't make the sidebar a drag handle the way
+                // `isMovableByWindowBackground` did. The interactive controls
+                // are a native titlebar accessory (see the type doc), not
+                // content here, so the drag region can span the full width.
                 theme.footerBackground
                 WindowDragRegion()
                 identityCluster(workspace)
-                trailingControls
             }
             .frame(maxWidth: .infinity)
             // 32pt centres the title bar on the macOS traffic lights' fixed
@@ -39,6 +49,15 @@ struct WindowTitleBar: View {
             .frame(height: 32)
             .overlay(alignment: .bottom) {
                 theme.divider.frame(height: 1)
+            }
+            // Installs the trailing controls as a native titlebar accessory on
+            // the *actual* hosting window (resolved via the view's `.window`),
+            // which `NSApp.windows.first` at app-setup time can't reliably do.
+            .background(TitlebarControlsInstaller(store: store))
+            // The accessory's ••• menu posts this; relay it to the scene's
+            // Settings action (which the accessory itself can't reach).
+            .onReceive(NotificationCenter.default.publisher(for: .nexOpenSettings)) { _ in
+                openSettings()
             }
         }
     }
@@ -78,39 +97,6 @@ struct WindowTitleBar: View {
         // buttons on a narrow window.
         .padding(.leading, 80)
         .padding(.trailing, 86)
-    }
-
-    private var trailingControls: some View {
-        HStack(spacing: 14) {
-            Spacer()
-
-            Menu {
-                Button("Settings…") { openSettings() }
-                Button(store.isInspectorVisible ? "Hide Inspector" : "Show Inspector") {
-                    store.send(.toggleInspector)
-                }
-                Divider()
-                Button("Restart Socket Server") { store.send(.restartSocketServer) }
-            } label: {
-                Image(systemName: "ellipsis")
-            }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
-            // borderlessButton tints its label with the accent; force it to the
-            // neutral text colour so the ••• matches the other title-bar controls.
-            .tint(theme.textSecondary)
-            .foregroundStyle(theme.textSecondary)
-
-            Button { store.send(.toggleSidebar) } label: {
-                Image(systemName: "sidebar.left")
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(theme.textSecondary)
-            .help("Toggle sidebar")
-        }
-        .font(.system(size: 13))
-        .padding(.trailing, 14)
     }
 
     private var separator: some View {
@@ -161,4 +147,115 @@ private struct WindowDragRegion: NSViewRepresentable {
             window?.performDrag(with: event)
         }
     }
+}
+
+/// The right-hand chrome controls (••• menu + sidebar toggle). Installed as a
+/// native *trailing titlebar accessory* (see `installTitlebarTrailingControls`)
+/// rather than drawn inside `WindowTitleBar`: content drawn under the
+/// transparent native titlebar is click-shadowed (the titlebar owns mouse
+/// events in the top strip), so these would be dead. A titlebar accessory is
+/// the supported way to put clickable controls up there. Resolves the chrome
+/// theme inline because the accessory lives outside the window's SwiftUI
+/// environment.
+struct TitlebarTrailingControls: View {
+    let store: StoreOf<AppReducer>
+    @Environment(\.colorScheme) private var systemScheme
+
+    var body: some View {
+        WithPerceptionTracking {
+            let theme = ChromeTheme.resolve(
+                appearance: store.settings.chromeAppearance,
+                system: systemScheme,
+                overrides: store.settings.chromeColorOverrides
+            )
+            HStack(spacing: 14) {
+                Menu {
+                    Button("Settings…") { openSettings() }
+                    Button(store.isInspectorVisible ? "Hide Inspector" : "Show Inspector") {
+                        store.send(.toggleInspector)
+                    }
+                    Divider()
+                    Button("Restart Socket Server") { store.send(.restartSocketServer) }
+                } label: {
+                    Image(systemName: "ellipsis")
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                // borderlessButton tints its label with the accent; force it to
+                // the neutral text colour so ••• matches the sidebar toggle.
+                .tint(theme.textSecondary)
+                .foregroundStyle(theme.textSecondary)
+
+                Button { store.send(.toggleSidebar) } label: {
+                    Image(systemName: "sidebar.left")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(theme.textSecondary)
+                .help("Toggle sidebar")
+            }
+            .font(.system(size: 13))
+            .padding(.horizontal, 12)
+        }
+    }
+
+    /// Settings is its own SwiftUI scene; the accessory is outside that scene's
+    /// environment, so `@Environment(\.openSettings)` is unavailable and the
+    /// `showSettingsWindow:` responder action doesn't reach it from here. Relay
+    /// to an in-scene listener (`WindowTitleBar`) that owns `openSettings`.
+    private func openSettings() {
+        NotificationCenter.default.post(name: .nexOpenSettings, object: nil)
+    }
+}
+
+extension Notification.Name {
+    /// Posted by the titlebar-accessory ••• menu (outside the SwiftUI scene) to
+    /// ask an in-scene view to invoke the scene's `openSettings` action.
+    static let nexOpenSettings = Notification.Name("nex.openSettings")
+}
+
+/// Resolves the real hosting `NSWindow` (via `view.window`, which
+/// `NSApp.windows.first` at app-setup time can't be trusted to return) and
+/// installs the trailing titlebar accessory once it's available. Lives as a
+/// zero-size background in `WindowTitleBar`.
+private struct TitlebarControlsInstaller: NSViewRepresentable {
+    let store: StoreOf<AppReducer>
+
+    func makeNSView(context _: Context) -> NSView {
+        let probe = NSView(frame: .zero)
+        install(from: probe)
+        return probe
+    }
+
+    func updateNSView(_ nsView: NSView, context _: Context) {
+        install(from: nsView)
+    }
+
+    private func install(from probe: NSView) {
+        // The window isn't attached during make/update; defer to the next
+        // runloop tick when `probe.window` is set.
+        DispatchQueue.main.async {
+            guard let window = probe.window else { return }
+            installTitlebarTrailingControls(in: window, store: store)
+        }
+    }
+}
+
+/// Install `TitlebarTrailingControls` as a trailing titlebar accessory on the
+/// window. Idempotent: the installer's make/update both call in, so we must not
+/// stack duplicate accessories.
+@MainActor
+func installTitlebarTrailingControls(in window: NSWindow, store: StoreOf<AppReducer>) {
+    let id = NSUserInterfaceItemIdentifier("nex.titlebar.trailing")
+    if window.titlebarAccessoryViewControllers.contains(where: { $0.view.identifier == id }) {
+        return
+    }
+    let hosting = NSHostingView(rootView: TitlebarTrailingControls(store: store))
+    hosting.identifier = id
+    // Give the accessory an explicit size so it isn't laid out at zero width.
+    hosting.frame = NSRect(x: 0, y: 0, width: hosting.fittingSize.width, height: 28)
+    let controller = NSTitlebarAccessoryViewController()
+    controller.layoutAttribute = .trailing
+    controller.view = hosting
+    window.addTitlebarAccessoryViewController(controller)
 }

--- a/Nex/Chrome/WindowTitleBar.swift
+++ b/Nex/Chrome/WindowTitleBar.swift
@@ -22,9 +22,9 @@ import SwiftUI
 struct WindowTitleBar: View {
     let store: StoreOf<AppReducer>
     @Environment(\.chromeTheme) private var theme
-    // Owned here (an in-scene view) so the titlebar-accessory ••• menu — which
-    // is outside the SwiftUI scene and can't reach `openSettings` itself — can
-    // relay through `nexOpenSettings`.
+    /// Owned here (an in-scene view) so the titlebar-accessory ••• menu — which
+    /// is outside the SwiftUI scene and can't reach `openSettings` itself — can
+    /// relay through `nexOpenSettings`.
     @Environment(\.openSettings) private var openSettings
 
     var body: some View {

--- a/Nex/Chrome/WindowTitleBar.swift
+++ b/Nex/Chrome/WindowTitleBar.swift
@@ -69,21 +69,16 @@ struct WindowTitleBar: View {
         .lineLimit(1)
         .truncationMode(.tail)
         // Asymmetric insets: clear the traffic lights on the left (80) and
-        // reserve room for the trailing controls on the right (110) so a long
-        // name + branch truncates instead of overlapping the record / menu /
-        // sidebar buttons on a narrow window.
+        // reserve room for the trailing controls on the right (86) so a long
+        // name + branch truncates instead of overlapping the menu / sidebar
+        // buttons on a narrow window.
         .padding(.leading, 80)
-        .padding(.trailing, 110)
+        .padding(.trailing, 86)
     }
 
     private var trailingControls: some View {
         HStack(spacing: 14) {
             Spacer()
-
-            // Record is a visual stub (no capture backend yet).
-            Image(systemName: "record.circle")
-                .foregroundStyle(theme.textTertiary)
-                .help("Recording — coming soon")
 
             Menu {
                 Button("New Workspace") { store.send(.showNewWorkspaceSheet()) }

--- a/Nex/Chrome/WindowTitleBar.swift
+++ b/Nex/Chrome/WindowTitleBar.swift
@@ -15,6 +15,7 @@ import SwiftUI
 struct WindowTitleBar: View {
     let store: StoreOf<AppReducer>
     @Environment(\.chromeTheme) private var theme
+    @Environment(\.openSettings) private var openSettings
 
     var body: some View {
         WithPerceptionTracking {
@@ -81,10 +82,12 @@ struct WindowTitleBar: View {
             Spacer()
 
             Menu {
-                Button("New Workspace") { store.send(.showNewWorkspaceSheet()) }
+                Button("Settings…") { openSettings() }
                 Button(store.isInspectorVisible ? "Hide Inspector" : "Show Inspector") {
                     store.send(.toggleInspector)
                 }
+                Divider()
+                Button("Restart Socket Server") { store.send(.restartSocketServer) }
             } label: {
                 Image(systemName: "ellipsis")
             }

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -7,559 +7,571 @@ struct ContentView: View {
     let store: StoreOf<AppReducer>
     @Environment(\.surfaceManager) private var surfaceManager
     @Environment(\.socketServer) private var socketServer
+    @Environment(\.chromeTheme) private var chromeTheme
     @State private var sidebarWidth: CGFloat = 220
     @State private var statusClearTask: Task<Void, Never>?
 
     var body: some View {
         WithPerceptionTracking {
-            HStack(spacing: 0) {
-                if store.isSidebarVisible {
-                    WorkspaceListView(store: store)
-                        .frame(width: sidebarWidth)
-                        .background(Color(nsColor: .controlBackgroundColor))
+            VStack(spacing: 0) {
+                WindowTitleBar(store: store)
 
-                    sidebarResizeHandle
-                }
+                HStack(spacing: 0) {
+                    if store.isSidebarVisible {
+                        WorkspaceListView(store: store)
+                            .frame(width: sidebarWidth)
+                            .background(chromeTheme.sidebarBackground)
 
-                if let activeID = store.activeWorkspaceID,
-                   let workspace = store.workspaces[id: activeID] {
-                    PaneGridView(
-                        layout: workspace.layout,
-                        panes: workspace.panes,
-                        focusedPaneID: workspace.focusedPaneID,
-                        onCreatePane: {
-                            store.send(.workspaces(.element(id: activeID, action: .createPane())))
-                        },
-                        onSplitPane: { paneID, direction in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .splitPane(direction: direction, sourcePaneID: paneID)
-                            )))
-                        },
-                        onClosePane: { paneID in
-                            store.send(.workspaces(.element(id: activeID, action: .closePane(paneID))))
-                        },
-                        onFocusPane: { paneID in
-                            store.send(.workspaces(.element(id: activeID, action: .focusPane(paneID))))
-                        },
-                        isZoomed: workspace.zoomedPaneID != nil && workspace.panes.count > 1,
-                        onToggleZoom: {
-                            store.send(.workspaces(.element(id: activeID, action: .toggleZoomPane)))
-                        },
-                        onToggleMarkdownEdit: { paneID in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .toggleMarkdownEdit(paneID)
-                            )))
-                        },
-                        onScratchpadContentChanged: { paneID, content in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .scratchpadContentChanged(paneID: paneID, content: content)
-                            )))
-                        },
-                        onUpdateRatio: { splitPath, ratio in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .updateSplitRatio(splitPath: splitPath, ratio: ratio)
-                            )))
-                        },
-                        onMovePane: { paneID, targetPaneID, zone in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .movePane(paneID: paneID, targetPaneID: targetPaneID, zone: zone)
-                            )))
-                        },
-                        searchingPaneID: workspace.searchingPaneID,
-                        searchNeedle: workspace.searchNeedle,
-                        searchTotal: workspace.searchTotal,
-                        searchSelected: workspace.searchSelected,
-                        onSearchNeedleChanged: { needle in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .searchNeedleChanged(needle)
-                            )))
-                        },
-                        onSearchNavigateNext: {
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .searchNavigateNext
-                            )))
-                        },
-                        onSearchNavigatePrevious: {
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .searchNavigatePrevious
-                            )))
-                        },
-                        onSearchClose: {
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .searchClose
-                            )))
-                        },
-                        focusFollowsMouse: store.focusFollowsMouse,
-                        focusFollowsMouseDelay: store.focusFollowsMouseDelay,
-                        otherWorkspaces: store.workspaces
-                            .filter { $0.id != activeID }
-                            .map { (id: $0.id, name: $0.name) },
-                        onRenamePane: { paneID in
-                            store.send(.setRenamingPaneID(paneID))
-                        },
-                        onMovePaneToWorkspace: { paneID, targetWSID in
-                            store.send(.socketMessage(
-                                .paneMoveToWorkspace(
-                                    paneID: paneID,
-                                    toWorkspace: targetWSID.uuidString,
-                                    create: false
-                                ),
-                                reply: nil
-                            ))
-                        },
-                        isSyncInputActive: workspace.isSyncInputActive,
-                        syncInputExcluded: workspace.syncInputExcluded,
-                        onToggleSyncExcluded: { paneID in
-                            let excluded = workspace.syncInputExcluded.contains(paneID)
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .setSyncInputExcluded(paneID: paneID, excluded: !excluded)
-                            )))
-                        },
-                        webPanes: workspace.webPanes,
-                        webPaneURLFocusToken: store.webPaneURLFocusTokens,
-                        onWebNavigate: { paneID, url in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .webPaneNavigate(paneID: paneID, url: url)
-                            )))
-                        },
-                        onWebBack: { paneID in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .webPaneBack(paneID: paneID)
-                            )))
-                        },
-                        onWebForward: { paneID in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .webPaneForward(paneID: paneID)
-                            )))
-                        },
-                        onWebReload: { paneID in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .webPaneReload(paneID: paneID, hard: false)
-                            )))
-                        },
-                        onWebTabSelect: { paneID, tabID in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .webPaneTabSelect(paneID: paneID, tabID: tabID)
-                            )))
-                        },
-                        onWebTabClose: { paneID, tabID in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .webPaneTabClose(paneID: paneID, tabID: tabID)
-                            )))
-                        },
-                        onWebTabNew: { paneID in
-                            store.send(.webPaneOpenNewTab(paneID: paneID, url: nil))
-                        },
-                        onWebTogglePickup: { paneID in
-                            store.send(.webBatchInspectToggle(paneID: paneID))
-                        },
-                        onWebBatchItemCommentChanged: { paneID, itemID, comment in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .webBatchItemCommentChanged(
+                        sidebarResizeHandle
+                    }
+
+                    if let activeID = store.activeWorkspaceID,
+                       let workspace = store.workspaces[id: activeID] {
+                        PaneGridView(
+                            layout: workspace.layout,
+                            panes: workspace.panes,
+                            focusedPaneID: workspace.focusedPaneID,
+                            onCreatePane: {
+                                store.send(.workspaces(.element(id: activeID, action: .createPane())))
+                            },
+                            onSplitPane: { paneID, direction in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .splitPane(direction: direction, sourcePaneID: paneID)
+                                )))
+                            },
+                            onClosePane: { paneID in
+                                store.send(.workspaces(.element(id: activeID, action: .closePane(paneID))))
+                            },
+                            onFocusPane: { paneID in
+                                store.send(.workspaces(.element(id: activeID, action: .focusPane(paneID))))
+                            },
+                            isZoomed: workspace.zoomedPaneID != nil && workspace.panes.count > 1,
+                            onToggleZoom: {
+                                store.send(.workspaces(.element(id: activeID, action: .toggleZoomPane)))
+                            },
+                            onToggleMarkdownEdit: { paneID in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .toggleMarkdownEdit(paneID)
+                                )))
+                            },
+                            onScratchpadContentChanged: { paneID, content in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .scratchpadContentChanged(paneID: paneID, content: content)
+                                )))
+                            },
+                            onUpdateRatio: { splitPath, ratio in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .updateSplitRatio(splitPath: splitPath, ratio: ratio)
+                                )))
+                            },
+                            onMovePane: { paneID, targetPaneID, zone in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .movePane(paneID: paneID, targetPaneID: targetPaneID, zone: zone)
+                                )))
+                            },
+                            searchingPaneID: workspace.searchingPaneID,
+                            searchNeedle: workspace.searchNeedle,
+                            searchTotal: workspace.searchTotal,
+                            searchSelected: workspace.searchSelected,
+                            onSearchNeedleChanged: { needle in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .searchNeedleChanged(needle)
+                                )))
+                            },
+                            onSearchNavigateNext: {
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .searchNavigateNext
+                                )))
+                            },
+                            onSearchNavigatePrevious: {
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .searchNavigatePrevious
+                                )))
+                            },
+                            onSearchClose: {
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .searchClose
+                                )))
+                            },
+                            focusFollowsMouse: store.focusFollowsMouse,
+                            focusFollowsMouseDelay: store.focusFollowsMouseDelay,
+                            otherWorkspaces: store.workspaces
+                                .filter { $0.id != activeID }
+                                .map { (id: $0.id, name: $0.name) },
+                            onRenamePane: { paneID in
+                                store.send(.setRenamingPaneID(paneID))
+                            },
+                            onMovePaneToWorkspace: { paneID, targetWSID in
+                                store.send(.socketMessage(
+                                    .paneMoveToWorkspace(
+                                        paneID: paneID,
+                                        toWorkspace: targetWSID.uuidString,
+                                        create: false
+                                    ),
+                                    reply: nil
+                                ))
+                            },
+                            isSyncInputActive: workspace.isSyncInputActive,
+                            syncInputExcluded: workspace.syncInputExcluded,
+                            onToggleSyncExcluded: { paneID in
+                                let excluded = workspace.syncInputExcluded.contains(paneID)
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .setSyncInputExcluded(paneID: paneID, excluded: !excluded)
+                                )))
+                            },
+                            webPanes: workspace.webPanes,
+                            webPaneURLFocusToken: store.webPaneURLFocusTokens,
+                            onWebNavigate: { paneID, url in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .webPaneNavigate(paneID: paneID, url: url)
+                                )))
+                            },
+                            onWebBack: { paneID in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .webPaneBack(paneID: paneID)
+                                )))
+                            },
+                            onWebForward: { paneID in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .webPaneForward(paneID: paneID)
+                                )))
+                            },
+                            onWebReload: { paneID in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .webPaneReload(paneID: paneID, hard: false)
+                                )))
+                            },
+                            onWebTabSelect: { paneID, tabID in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .webPaneTabSelect(paneID: paneID, tabID: tabID)
+                                )))
+                            },
+                            onWebTabClose: { paneID, tabID in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .webPaneTabClose(paneID: paneID, tabID: tabID)
+                                )))
+                            },
+                            onWebTabNew: { paneID in
+                                store.send(.webPaneOpenNewTab(paneID: paneID, url: nil))
+                            },
+                            onWebTogglePickup: { paneID in
+                                store.send(.webBatchInspectToggle(paneID: paneID))
+                            },
+                            onWebBatchItemCommentChanged: { paneID, itemID, comment in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .webBatchItemCommentChanged(
+                                        paneID: paneID, itemID: itemID, comment: comment
+                                    )
+                                )))
+                                // Push to the page popover too so it
+                                // mirrors the panel edit when shown for
+                                // the same item (no-op if its textarea
+                                // currently holds keyboard focus).
+                                store.send(.pushBatchCommentToPage(
                                     paneID: paneID, itemID: itemID, comment: comment
+                                ))
+                            },
+                            onWebBatchItemRemoved: { paneID, itemID in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .webBatchItemRemoved(paneID: paneID, itemID: itemID)
+                                )))
+                                store.send(.syncBatchMarkers(paneID: paneID))
+                            },
+                            onWebBatchRowTapped: { paneID, itemID in
+                                store.send(.webBatchFocusItem(
+                                    paneID: paneID, itemID: itemID, origin: .panel
+                                ))
+                            },
+                            onWebBatchSend: { paneID, sendTo in
+                                store.send(.webBatchInspectSend(paneID: paneID, sendTo: sendTo))
+                            },
+                            onWebBatchCancel: { paneID in
+                                store.send(.webBatchInspectCancel(paneID: paneID))
+                            },
+                            onWebTogglePrivate: { paneID in
+                                store.send(.webPaneSetPrivate(paneID: paneID, enabled: nil))
+                            },
+                            favourites: store.favourites,
+                            onToggleFavourite: { url, title in
+                                store.send(.toggleFavourite(url: url, title: title))
+                            },
+                            onOpenFavourite: { paneID, url in
+                                store.send(.workspaces(.element(
+                                    id: activeID,
+                                    action: .webPaneNavigate(paneID: paneID, url: url)
+                                )))
+                            }
+                        )
+                    } else {
+                        VStack(spacing: 8) {
+                            Image(systemName: "terminal")
+                                .font(.system(size: 48))
+                                .foregroundStyle(.quaternary)
+                            Text("No workspace selected")
+                                .foregroundStyle(.secondary)
+                            Button("Create Workspace") {
+                                store.send(.showNewWorkspaceSheet())
+                            }
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+
+                    if store.isInspectorVisible {
+                        WorkspaceInspectorView(store: store)
+                    }
+                }
+                .environment(
+                    \.sidebarTextEditingActive,
+                    store.renamingGroupID != nil || store.renamingWorkspaceID != nil
+                )
+                .overlay {
+                    if store.isCommandPaletteVisible {
+                        Color.black.opacity(0.001)
+                            .ignoresSafeArea()
+                            .onTapGesture {
+                                store.send(.dismissCommandPalette)
+                            }
+                            .overlay(alignment: .top) {
+                                CommandPaletteView(
+                                    query: store.commandPaletteQuery,
+                                    items: store.commandPaletteItems,
+                                    selectedIndex: store.commandPaletteSelectedIndex,
+                                    onQueryChanged: { store.send(.commandPaletteQueryChanged($0)) },
+                                    onSelectIndex: { store.send(.commandPaletteSelectIndex($0)) },
+                                    onSelectNext: { store.send(.commandPaletteSelectNext) },
+                                    onSelectPrevious: { store.send(.commandPaletteSelectPrevious) },
+                                    onConfirm: { store.send(.commandPaletteConfirm) },
+                                    onDismiss: { store.send(.dismissCommandPalette) }
                                 )
-                            )))
-                            // Push to the page popover too so it
-                            // mirrors the panel edit when shown for
-                            // the same item (no-op if its textarea
-                            // currently holds keyboard focus).
-                            store.send(.pushBatchCommentToPage(
-                                paneID: paneID, itemID: itemID, comment: comment
-                            ))
-                        },
-                        onWebBatchItemRemoved: { paneID, itemID in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .webBatchItemRemoved(paneID: paneID, itemID: itemID)
-                            )))
-                            store.send(.syncBatchMarkers(paneID: paneID))
-                        },
-                        onWebBatchRowTapped: { paneID, itemID in
-                            store.send(.webBatchFocusItem(
-                                paneID: paneID, itemID: itemID, origin: .panel
-                            ))
-                        },
-                        onWebBatchSend: { paneID, sendTo in
-                            store.send(.webBatchInspectSend(paneID: paneID, sendTo: sendTo))
-                        },
-                        onWebBatchCancel: { paneID in
-                            store.send(.webBatchInspectCancel(paneID: paneID))
-                        },
-                        onWebTogglePrivate: { paneID in
-                            store.send(.webPaneSetPrivate(paneID: paneID, enabled: nil))
-                        },
-                        favourites: store.favourites,
-                        onToggleFavourite: { url, title in
-                            store.send(.toggleFavourite(url: url, title: title))
-                        },
-                        onOpenFavourite: { paneID, url in
-                            store.send(.workspaces(.element(
-                                id: activeID,
-                                action: .webPaneNavigate(paneID: paneID, url: url)
-                            )))
-                        }
-                    )
-                } else {
-                    VStack(spacing: 8) {
-                        Image(systemName: "terminal")
-                            .font(.system(size: 48))
-                            .foregroundStyle(.quaternary)
-                        Text("No workspace selected")
-                            .foregroundStyle(.secondary)
-                        Button("Create Workspace") {
-                            store.send(.showNewWorkspaceSheet())
-                        }
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
-
-                if store.isInspectorVisible {
-                    WorkspaceInspectorView(store: store)
-                }
-            }
-            .environment(
-                \.sidebarTextEditingActive,
-                store.renamingGroupID != nil || store.renamingWorkspaceID != nil
-            )
-            .overlay {
-                if store.isCommandPaletteVisible {
-                    Color.black.opacity(0.001)
-                        .ignoresSafeArea()
-                        .onTapGesture {
-                            store.send(.dismissCommandPalette)
-                        }
-                        .overlay(alignment: .top) {
-                            CommandPaletteView(
-                                query: store.commandPaletteQuery,
-                                items: store.commandPaletteItems,
-                                selectedIndex: store.commandPaletteSelectedIndex,
-                                onQueryChanged: { store.send(.commandPaletteQueryChanged($0)) },
-                                onSelectIndex: { store.send(.commandPaletteSelectIndex($0)) },
-                                onSelectNext: { store.send(.commandPaletteSelectNext) },
-                                onSelectPrevious: { store.send(.commandPaletteSelectPrevious) },
-                                onConfirm: { store.send(.commandPaletteConfirm) },
-                                onDismiss: { store.send(.dismissCommandPalette) }
-                            )
-                            .padding(.top, 40)
-                        }
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                }
-            }
-            .animation(.easeOut(duration: 0.15), value: store.isCommandPaletteVisible)
-            .animation(.default, value: store.isSidebarVisible)
-            .animation(.default, value: store.isInspectorVisible)
-            .sheet(isPresented: Binding(
-                get: { store.isNewWorkspaceSheetPresented },
-                set: { if !$0 { store.send(.dismissNewWorkspaceSheet) } }
-            )) {
-                NewWorkspaceSheet(store: store)
-            }
-            .sheet(isPresented: Binding(
-                get: { store.renamingWorkspaceID != nil },
-                set: { if !$0 { store.send(.setRenamingWorkspaceID(nil)) } }
-            )) {
-                if let id = store.renamingWorkspaceID,
-                   let ws = store.workspaces[id: id] {
-                    RenameWorkspaceSheet(
-                        currentName: ws.name,
-                        onRename: { newName in
-                            store.send(.workspaces(.element(id: id, action: .rename(newName))))
-                            store.send(.setRenamingWorkspaceID(nil))
-                        },
-                        onDismiss: {
-                            store.send(.setRenamingWorkspaceID(nil))
-                        }
-                    )
-                }
-            }
-            .sheet(isPresented: Binding(
-                get: { store.renamingPaneID != nil },
-                set: { if !$0 { store.send(.setRenamingPaneID(nil)) } }
-            )) {
-                if let paneID = store.renamingPaneID,
-                   let pane = store.workspaces.flatMap(\.panes).first(where: { $0.id == paneID }) {
-                    RenamePaneSheet(
-                        currentName: pane.label ?? "",
-                        onRename: { newName in
-                            store.send(.socketMessage(
-                                .paneName(paneID: paneID, target: nil, workspace: nil, name: newName),
-                                reply: nil
-                            ))
-                            store.send(.setRenamingPaneID(nil))
-                        },
-                        onDismiss: {
-                            store.send(.setRenamingPaneID(nil))
-                        }
-                    )
-                }
-            }
-            .onReceive(NotificationCenter.default.publisher(for: QuitGate.confirmQuitChangedNotification)) { _ in
-                store.send(.settings(.refreshConfirmQuitWhenActive))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: SurfaceView.paneFocusedNotification)) { notification in
-                guard let paneID = notification.userInfo?["paneID"] as? UUID,
-                      let activeID = store.activeWorkspaceID,
-                      let workspace = store.workspaces[id: activeID],
-                      workspace.panes[id: paneID] != nil else { return }
-                if workspace.focusedPaneID != paneID {
-                    store.send(.workspaces(.element(id: activeID, action: .focusPane(paneID))))
-                }
-                scheduleClearStatus(paneID: paneID, workspaceID: activeID)
-            }
-            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-                NSApp.dockTile.badgeLabel = nil
-                store.send(.updateExternalIndicators)
-                guard let activeID = store.activeWorkspaceID,
-                      let workspace = store.workspaces[id: activeID],
-                      let focusedID = workspace.focusedPaneID else { return }
-                scheduleClearStatus(paneID: focusedID, workspaceID: activeID)
-            }
-            .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.surfaceTitleNotification)) { notification in
-                guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
-                      let title = notification.userInfo?["title"] as? String,
-                      let paneID = surfaceManager.paneID(for: surface) else { return }
-                // Route through AppReducer for cross-workspace support
-                store.send(.surfaceTitleChanged(paneID: paneID, title: title))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.stateDidChangeNotification)) { notification in
-                // WKWebView KVO fired for url/title — push the new
-                // values into the workspace reducer so persistence,
-                // close/reopen snapshots, pane titles, and the CLI
-                // `nex web url` reply stay in sync with what the
-                // user actually has on screen (link clicks, back/
-                // forward, redirects, etc.).
-                guard let info = notification.userInfo,
-                      let paneID = info["paneID"] as? UUID,
-                      let tabID = info["tabID"] as? UUID else { return }
-                let url = (info["url"] as? String) ?? ""
-                let title = (info["title"] as? String) ?? ""
-                guard let workspace = store.workspaces.first(where: {
-                    $0.webPanes[paneID] != nil
-                }) else { return }
-                store.send(.workspaces(.element(
-                    id: workspace.id,
-                    action: .webPaneStateChanged(
-                        paneID: paneID, tabID: tabID, url: url, title: title
-                    )
-                )))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.consoleLineNotification)) { notification in
-                // Console capture: every wrapped console.* call and
-                // every window error fires here. Push into the pane's
-                // ring buffer so `nex web console` can drain it.
-                guard let info = notification.userInfo,
-                      let paneID = info["paneID"] as? UUID,
-                      let tabID = info["tabID"] as? UUID,
-                      let levelRaw = info["level"] as? String,
-                      let level = ConsoleLine.Level(rawValue: levelRaw) else { return }
-                let message = (info["message"] as? String) ?? ""
-                let url = (info["url"] as? String) ?? ""
-                let lineNumber = info["lineNumber"] as? Int
-                let columnNumber = info["columnNumber"] as? Int
-                guard let workspace = store.workspaces.first(where: {
-                    $0.webPanes[paneID] != nil
-                }) else { return }
-                let line = ConsoleLine(
-                    tabID: tabID,
-                    level: level,
-                    message: message,
-                    url: url,
-                    lineNumber: lineNumber,
-                    columnNumber: columnNumber,
-                    capturedAt: Date()
-                )
-                store.send(.workspaces(.element(
-                    id: workspace.id,
-                    action: .webConsoleLineReceived(paneID: paneID, line: line)
-                )))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchMarkerClickedNotification)) { notification in
-                // User clicked a numbered badge on the page — focus
-                // the matching row in the side panel. Skip the
-                // page-side highlight (the badge was just under their
-                // cursor; re-pulsing it would be redundant).
-                guard let info = notification.userInfo,
-                      let paneID = info["paneID"] as? UUID,
-                      let itemID = info["itemID"] as? UUID else { return }
-                store.send(.webBatchFocusItem(
-                    paneID: paneID, itemID: itemID, origin: .page
-                ))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchCommentEditedNotification)) { notification in
-                // User edited the comment in the page popover.
-                // Push it into state via the usual workspace action,
-                // skipping the panel→page sync (origin == .page) so
-                // we don't bounce the value back into JS and clobber
-                // the textarea cursor.
-                guard let info = notification.userInfo,
-                      let paneID = info["paneID"] as? UUID,
-                      let itemID = info["itemID"] as? UUID,
-                      let comment = info["comment"] as? String,
-                      let workspace = store.workspaces.first(where: {
-                          $0.webPanes[paneID] != nil
-                      }) else { return }
-                store.send(.workspaces(.element(
-                    id: workspace.id,
-                    action: .webBatchItemCommentChanged(
-                        paneID: paneID, itemID: itemID, comment: comment
-                    )
-                )))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchPopoverDismissedNotification)) { notification in
-                // Done / Esc in the page popover. Clear focus so
-                // the popover and focus ring hide; user can pick
-                // the next element.
-                guard let info = notification.userInfo,
-                      let paneID = info["paneID"] as? UUID else { return }
-                store.send(.webBatchDismissPopover(paneID: paneID))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchItemRemovedFromPopoverNotification)) { notification in
-                // Remove button in the page popover — same effect as
-                // the panel's ❌, plus a marker re-sync so the badge
-                // disappears.
-                guard let info = notification.userInfo,
-                      let paneID = info["paneID"] as? UUID,
-                      let itemID = info["itemID"] as? UUID,
-                      let workspace = store.workspaces.first(where: {
-                          $0.webPanes[paneID] != nil
-                      }) else { return }
-                store.send(.workspaces(.element(
-                    id: workspace.id,
-                    action: .webBatchItemRemoved(paneID: paneID, itemID: itemID)
-                )))
-                store.send(.syncBatchMarkers(paneID: paneID))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.inspectResultNotification)) { notification in
-                // Picker delivered a click — sanitise the raw dict
-                // here so it crosses into the reducer as a typed,
-                // Equatable struct (Action enums must be Equatable).
-                guard let info = notification.userInfo,
-                      let paneID = info["paneID"] as? UUID,
-                      let tabID = info["tabID"] as? UUID,
-                      let payload = info["payload"] as? [String: Any],
-                      let result = InspectPayloadSanitiser.decode(payload, tabID: tabID)
-                else { return }
-                store.send(.webInspectPayloadReceived(
-                    paneID: paneID, result: result
-                ))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.surfacePwdNotification)) { notification in
-                guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
-                      let pwd = notification.userInfo?["pwd"] as? String,
-                      let paneID = surfaceManager.paneID(for: surface) else { return }
-                // Route through AppReducer for cross-workspace support
-                store.send(.surfaceDirectoryChanged(paneID: paneID, directory: pwd))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.desktopNotification)) { notification in
-                guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
-                      let title = notification.userInfo?["title"] as? String,
-                      let body = notification.userInfo?["body"] as? String,
-                      let paneID = surfaceManager.paneID(for: surface) else { return }
-                store.send(.desktopNotification(paneID: paneID, title: title, body: body))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.surfaceCloseNotification)) { notification in
-                // Two posting sites use this notification:
-                //   1) close_surface_cb — posts paneID (it has direct access to SurfaceView's userdata)
-                //   2) SHOW_CHILD_EXITED action — posts the raw ghostty_surface_t
-                //      and we look up the paneID via SurfaceManager.
-                let paneID: UUID? = {
-                    if let direct = notification.userInfo?["paneID"] as? UUID { return direct }
-                    guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t else { return nil }
-                    return surfaceManager.paneID(for: surface)
-                }()
-                guard let paneID else { return }
-                store.send(.surfaceProcessExited(paneID: paneID))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.openFileNotification)) { notification in
-                guard let path = notification.userInfo?["path"] as? String else { return }
-                let paneID: UUID? = {
-                    guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t else { return nil }
-                    return surfaceManager.paneID(for: surface)
-                }()
-                store.send(.openFileAtPath(path, fromPaneID: paneID))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.searchStartNotification)) { notification in
-                guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
-                      let needle = notification.userInfo?["needle"] as? String,
-                      let paneID = surfaceManager.paneID(for: surface) else { return }
-                store.send(.ghosttySearchStarted(paneID: paneID, needle: needle))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.searchEndNotification)) { notification in
-                guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
-                      let paneID = surfaceManager.paneID(for: surface) else { return }
-                store.send(.ghosttySearchEnded(paneID: paneID))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.searchTotalNotification)) { notification in
-                guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
-                      let total = notification.userInfo?["total"] as? Int,
-                      let paneID = surfaceManager.paneID(for: surface) else { return }
-                store.send(.searchTotalUpdated(paneID: paneID, total: total))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.searchSelectedNotification)) { notification in
-                guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
-                      let selected = notification.userInfo?["selected"] as? Int,
-                      let paneID = surfaceManager.paneID(for: surface) else { return }
-                store.send(.searchSelectedUpdated(paneID: paneID, selected: selected))
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .markdownFindResult)) { notification in
-                guard let paneID = notification.userInfo?["paneID"] as? UUID,
-                      let total = notification.userInfo?["total"] as? Int,
-                      let current = notification.userInfo?["current"] as? Int else { return }
-                store.send(.searchTotalUpdated(paneID: paneID, total: total))
-                // current is -1 when there are no matches; only forward a real index.
-                if current >= 0 {
-                    store.send(.searchSelectedUpdated(paneID: paneID, selected: current))
-                }
-            }
-            .onAppear {
-                // The xcodebuild test host instantiates ContentView; skip the
-                // socket listener so `xcodebuild test` never touches
-                // /tmp/nex.sock or binds a TCP port.
-                guard !NexApp.isTestMode else { return }
-
-                // Start socket server and wire messages to AppReducer
-                socketServer.onMessage = { message, reply in
-                    Task { @MainActor in
-                        store.send(.socketMessage(message, reply: reply))
+                                .padding(.top, 40)
+                            }
+                            .transition(.move(edge: .top).combined(with: .opacity))
                     }
                 }
-                socketServer.start()
-
-                // Start TCP listener if configured (for dev containers / SSH tunnels)
-                let config = ConfigParser.parseGeneralSettings(
-                    fromFile: KeybindingService.configPath
-                )
-                if config.tcpPort > 0 {
-                    socketServer.startTCP(port: config.tcpPort)
+                .animation(.easeOut(duration: 0.15), value: store.isCommandPaletteVisible)
+                .animation(.default, value: store.isSidebarVisible)
+                .animation(.default, value: store.isInspectorVisible)
+                .sheet(isPresented: Binding(
+                    get: { store.isNewWorkspaceSheetPresented },
+                    set: { if !$0 { store.send(.dismissNewWorkspaceSheet) } }
+                )) {
+                    NewWorkspaceSheet(store: store)
                 }
-            }
-            .onDrop(of: [UTType.fileURL], isTargeted: nil) { providers in
-                guard let provider = providers.first else { return false }
-                _ = provider.loadObject(ofClass: URL.self) { url, _ in
-                    guard let url, url.pathExtension.lowercased() == "md" else { return }
-                    Task { @MainActor in
-                        store.send(.openFileAtPath(url.path, fromPaneID: nil))
+                .sheet(isPresented: Binding(
+                    get: { store.renamingWorkspaceID != nil },
+                    set: { if !$0 { store.send(.setRenamingWorkspaceID(nil)) } }
+                )) {
+                    if let id = store.renamingWorkspaceID,
+                       let ws = store.workspaces[id: id] {
+                        RenameWorkspaceSheet(
+                            currentName: ws.name,
+                            onRename: { newName in
+                                store.send(.workspaces(.element(id: id, action: .rename(newName))))
+                                store.send(.setRenamingWorkspaceID(nil))
+                            },
+                            onDismiss: {
+                                store.send(.setRenamingWorkspaceID(nil))
+                            }
+                        )
                     }
                 }
-                return true
+                .sheet(isPresented: Binding(
+                    get: { store.renamingPaneID != nil },
+                    set: { if !$0 { store.send(.setRenamingPaneID(nil)) } }
+                )) {
+                    if let paneID = store.renamingPaneID,
+                       let pane = store.workspaces.flatMap(\.panes).first(where: { $0.id == paneID }) {
+                        RenamePaneSheet(
+                            currentName: pane.label ?? "",
+                            onRename: { newName in
+                                store.send(.socketMessage(
+                                    .paneName(paneID: paneID, target: nil, workspace: nil, name: newName),
+                                    reply: nil
+                                ))
+                                store.send(.setRenamingPaneID(nil))
+                            },
+                            onDismiss: {
+                                store.send(.setRenamingPaneID(nil))
+                            }
+                        )
+                    }
+                }
+                .onReceive(NotificationCenter.default.publisher(for: QuitGate.confirmQuitChangedNotification)) { _ in
+                    store.send(.settings(.refreshConfirmQuitWhenActive))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: SurfaceView.paneFocusedNotification)) { notification in
+                    guard let paneID = notification.userInfo?["paneID"] as? UUID,
+                          let activeID = store.activeWorkspaceID,
+                          let workspace = store.workspaces[id: activeID],
+                          workspace.panes[id: paneID] != nil else { return }
+                    if workspace.focusedPaneID != paneID {
+                        store.send(.workspaces(.element(id: activeID, action: .focusPane(paneID))))
+                    }
+                    scheduleClearStatus(paneID: paneID, workspaceID: activeID)
+                }
+                .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                    NSApp.dockTile.badgeLabel = nil
+                    store.send(.updateExternalIndicators)
+                    guard let activeID = store.activeWorkspaceID,
+                          let workspace = store.workspaces[id: activeID],
+                          let focusedID = workspace.focusedPaneID else { return }
+                    scheduleClearStatus(paneID: focusedID, workspaceID: activeID)
+                }
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.surfaceTitleNotification)) { notification in
+                    guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
+                          let title = notification.userInfo?["title"] as? String,
+                          let paneID = surfaceManager.paneID(for: surface) else { return }
+                    // Route through AppReducer for cross-workspace support
+                    store.send(.surfaceTitleChanged(paneID: paneID, title: title))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.stateDidChangeNotification)) { notification in
+                    // WKWebView KVO fired for url/title — push the new
+                    // values into the workspace reducer so persistence,
+                    // close/reopen snapshots, pane titles, and the CLI
+                    // `nex web url` reply stay in sync with what the
+                    // user actually has on screen (link clicks, back/
+                    // forward, redirects, etc.).
+                    guard let info = notification.userInfo,
+                          let paneID = info["paneID"] as? UUID,
+                          let tabID = info["tabID"] as? UUID else { return }
+                    let url = (info["url"] as? String) ?? ""
+                    let title = (info["title"] as? String) ?? ""
+                    guard let workspace = store.workspaces.first(where: {
+                        $0.webPanes[paneID] != nil
+                    }) else { return }
+                    store.send(.workspaces(.element(
+                        id: workspace.id,
+                        action: .webPaneStateChanged(
+                            paneID: paneID, tabID: tabID, url: url, title: title
+                        )
+                    )))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.consoleLineNotification)) { notification in
+                    // Console capture: every wrapped console.* call and
+                    // every window error fires here. Push into the pane's
+                    // ring buffer so `nex web console` can drain it.
+                    guard let info = notification.userInfo,
+                          let paneID = info["paneID"] as? UUID,
+                          let tabID = info["tabID"] as? UUID,
+                          let levelRaw = info["level"] as? String,
+                          let level = ConsoleLine.Level(rawValue: levelRaw) else { return }
+                    let message = (info["message"] as? String) ?? ""
+                    let url = (info["url"] as? String) ?? ""
+                    let lineNumber = info["lineNumber"] as? Int
+                    let columnNumber = info["columnNumber"] as? Int
+                    guard let workspace = store.workspaces.first(where: {
+                        $0.webPanes[paneID] != nil
+                    }) else { return }
+                    let line = ConsoleLine(
+                        tabID: tabID,
+                        level: level,
+                        message: message,
+                        url: url,
+                        lineNumber: lineNumber,
+                        columnNumber: columnNumber,
+                        capturedAt: Date()
+                    )
+                    store.send(.workspaces(.element(
+                        id: workspace.id,
+                        action: .webConsoleLineReceived(paneID: paneID, line: line)
+                    )))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchMarkerClickedNotification)) { notification in
+                    // User clicked a numbered badge on the page — focus
+                    // the matching row in the side panel. Skip the
+                    // page-side highlight (the badge was just under their
+                    // cursor; re-pulsing it would be redundant).
+                    guard let info = notification.userInfo,
+                          let paneID = info["paneID"] as? UUID,
+                          let itemID = info["itemID"] as? UUID else { return }
+                    store.send(.webBatchFocusItem(
+                        paneID: paneID, itemID: itemID, origin: .page
+                    ))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchCommentEditedNotification)) { notification in
+                    // User edited the comment in the page popover.
+                    // Push it into state via the usual workspace action,
+                    // skipping the panel→page sync (origin == .page) so
+                    // we don't bounce the value back into JS and clobber
+                    // the textarea cursor.
+                    guard let info = notification.userInfo,
+                          let paneID = info["paneID"] as? UUID,
+                          let itemID = info["itemID"] as? UUID,
+                          let comment = info["comment"] as? String,
+                          let workspace = store.workspaces.first(where: {
+                              $0.webPanes[paneID] != nil
+                          }) else { return }
+                    store.send(.workspaces(.element(
+                        id: workspace.id,
+                        action: .webBatchItemCommentChanged(
+                            paneID: paneID, itemID: itemID, comment: comment
+                        )
+                    )))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchPopoverDismissedNotification)) { notification in
+                    // Done / Esc in the page popover. Clear focus so
+                    // the popover and focus ring hide; user can pick
+                    // the next element.
+                    guard let info = notification.userInfo,
+                          let paneID = info["paneID"] as? UUID else { return }
+                    store.send(.webBatchDismissPopover(paneID: paneID))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.batchItemRemovedFromPopoverNotification)) { notification in
+                    // Remove button in the page popover — same effect as
+                    // the panel's ❌, plus a marker re-sync so the badge
+                    // disappears.
+                    guard let info = notification.userInfo,
+                          let paneID = info["paneID"] as? UUID,
+                          let itemID = info["itemID"] as? UUID,
+                          let workspace = store.workspaces.first(where: {
+                              $0.webPanes[paneID] != nil
+                          }) else { return }
+                    store.send(.workspaces(.element(
+                        id: workspace.id,
+                        action: .webBatchItemRemoved(paneID: paneID, itemID: itemID)
+                    )))
+                    store.send(.syncBatchMarkers(paneID: paneID))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.inspectResultNotification)) { notification in
+                    // Picker delivered a click — sanitise the raw dict
+                    // here so it crosses into the reducer as a typed,
+                    // Equatable struct (Action enums must be Equatable).
+                    guard let info = notification.userInfo,
+                          let paneID = info["paneID"] as? UUID,
+                          let tabID = info["tabID"] as? UUID,
+                          let payload = info["payload"] as? [String: Any],
+                          let result = InspectPayloadSanitiser.decode(payload, tabID: tabID)
+                    else { return }
+                    store.send(.webInspectPayloadReceived(
+                        paneID: paneID, result: result
+                    ))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.surfacePwdNotification)) { notification in
+                    guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
+                          let pwd = notification.userInfo?["pwd"] as? String,
+                          let paneID = surfaceManager.paneID(for: surface) else { return }
+                    // Route through AppReducer for cross-workspace support
+                    store.send(.surfaceDirectoryChanged(paneID: paneID, directory: pwd))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.desktopNotification)) { notification in
+                    guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
+                          let title = notification.userInfo?["title"] as? String,
+                          let body = notification.userInfo?["body"] as? String,
+                          let paneID = surfaceManager.paneID(for: surface) else { return }
+                    store.send(.desktopNotification(paneID: paneID, title: title, body: body))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.surfaceCloseNotification)) { notification in
+                    // Two posting sites use this notification:
+                    //   1) close_surface_cb — posts paneID (it has direct access to SurfaceView's userdata)
+                    //   2) SHOW_CHILD_EXITED action — posts the raw ghostty_surface_t
+                    //      and we look up the paneID via SurfaceManager.
+                    let paneID: UUID? = {
+                        if let direct = notification.userInfo?["paneID"] as? UUID { return direct }
+                        guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t else { return nil }
+                        return surfaceManager.paneID(for: surface)
+                    }()
+                    guard let paneID else { return }
+                    store.send(.surfaceProcessExited(paneID: paneID))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.openFileNotification)) { notification in
+                    guard let path = notification.userInfo?["path"] as? String else { return }
+                    let paneID: UUID? = {
+                        guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t else { return nil }
+                        return surfaceManager.paneID(for: surface)
+                    }()
+                    store.send(.openFileAtPath(path, fromPaneID: paneID))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.searchStartNotification)) { notification in
+                    guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
+                          let needle = notification.userInfo?["needle"] as? String,
+                          let paneID = surfaceManager.paneID(for: surface) else { return }
+                    store.send(.ghosttySearchStarted(paneID: paneID, needle: needle))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.searchEndNotification)) { notification in
+                    guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
+                          let paneID = surfaceManager.paneID(for: surface) else { return }
+                    store.send(.ghosttySearchEnded(paneID: paneID))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.searchTotalNotification)) { notification in
+                    guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
+                          let total = notification.userInfo?["total"] as? Int,
+                          let paneID = surfaceManager.paneID(for: surface) else { return }
+                    store.send(.searchTotalUpdated(paneID: paneID, total: total))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyApp.searchSelectedNotification)) { notification in
+                    guard let surface = notification.userInfo?["surface"] as? ghostty_surface_t,
+                          let selected = notification.userInfo?["selected"] as? Int,
+                          let paneID = surfaceManager.paneID(for: surface) else { return }
+                    store.send(.searchSelectedUpdated(paneID: paneID, selected: selected))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: .markdownFindResult)) { notification in
+                    guard let paneID = notification.userInfo?["paneID"] as? UUID,
+                          let total = notification.userInfo?["total"] as? Int,
+                          let current = notification.userInfo?["current"] as? Int else { return }
+                    store.send(.searchTotalUpdated(paneID: paneID, total: total))
+                    // current is -1 when there are no matches; only forward a real index.
+                    if current >= 0 {
+                        store.send(.searchSelectedUpdated(paneID: paneID, selected: current))
+                    }
+                }
+                .onAppear {
+                    // The xcodebuild test host instantiates ContentView; skip the
+                    // socket listener so `xcodebuild test` never touches
+                    // /tmp/nex.sock or binds a TCP port.
+                    guard !NexApp.isTestMode else { return }
+
+                    // Start socket server and wire messages to AppReducer
+                    socketServer.onMessage = { message, reply in
+                        Task { @MainActor in
+                            store.send(.socketMessage(message, reply: reply))
+                        }
+                    }
+                    socketServer.start()
+
+                    // Start TCP listener if configured (for dev containers / SSH tunnels)
+                    let config = ConfigParser.parseGeneralSettings(
+                        fromFile: KeybindingService.configPath
+                    )
+                    if config.tcpPort > 0 {
+                        socketServer.startTCP(port: config.tcpPort)
+                    }
+                }
+                .onDrop(of: [UTType.fileURL], isTargeted: nil) { providers in
+                    guard let provider = providers.first else { return false }
+                    _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                        guard let url, url.pathExtension.lowercased() == "md" else { return }
+                        Task { @MainActor in
+                            store.send(.openFileAtPath(url.path, fromPaneID: nil))
+                        }
+                    }
+                    return true
+                }
+
+                StatusBarView(store: store)
             }
+            // Draw the custom title bar up into the hidden-titlebar region so
+            // it shares the traffic-light row instead of sitting below it
+            // (which doubled the chrome height). The title bar already insets
+            // its content past the traffic lights horizontally.
+            .ignoresSafeArea(.container, edges: .top)
         }
     }
 

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -21,6 +21,11 @@ struct ContentView: View {
                         WorkspaceListView(store: store)
                             .frame(width: sidebarWidth)
                             .background(chromeTheme.sidebarBackground)
+                            // Same 1px divider as the "New Workspace" footer bar,
+                            // on the trailing edge to split the sidebar from the panes.
+                            .overlay(alignment: .trailing) {
+                                chromeTheme.divider.frame(width: 1)
+                            }
 
                         sidebarResizeHandle
                     }

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -238,6 +238,9 @@ struct ContentView: View {
                         WorkspaceInspectorView(store: store)
                     }
                 }
+                // Clip the content row to its own bounds so full-height pane
+                // dividers can't draw up into the title bar above it.
+                .clipped()
                 .environment(
                     \.sidebarTextEditingActive,
                     store.renamingGroupID != nil || store.renamingWorkspaceID != nil

--- a/Nex/Features/CommandPalette/CommandPaletteView.swift
+++ b/Nex/Features/CommandPalette/CommandPaletteView.swift
@@ -11,6 +11,7 @@ struct CommandPaletteView: View {
     let onConfirm: () -> Void
     let onDismiss: () -> Void
 
+    @Environment(\.chromeTheme) private var chromeTheme
     @FocusState private var isFieldFocused: Bool
     @State private var localQuery: String = ""
     @State private var scrollToSelection = false
@@ -81,8 +82,7 @@ struct CommandPaletteView: View {
             }
         }
         .frame(width: 440)
-        .background(.ultraThinMaterial)
-        .background(Color(nsColor: .windowBackgroundColor).opacity(0.85))
+        .background(chromeTheme.surfaceBackground)
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .shadow(color: .black.opacity(0.25), radius: 12, y: 4)
         .onAppear {

--- a/Nex/Features/DiffPane/DiffHTMLRenderer.swift
+++ b/Nex/Features/DiffPane/DiffHTMLRenderer.swift
@@ -278,6 +278,12 @@ enum DiffHTMLRenderer {
             overflow-x: hidden;
         }
         .dark body { color: #e6edf3; }
+        /* Thin scrollbar matching the sidebar's overlay scroller. */
+        ::-webkit-scrollbar { width: 8px; height: 8px; }
+        ::-webkit-scrollbar-track { background: transparent; }
+        ::-webkit-scrollbar-thumb { background: rgba(128, 128, 128, 0.4); border-radius: 4px; }
+        ::-webkit-scrollbar-thumb:hover { background: rgba(128, 128, 128, 0.6); }
+        ::-webkit-scrollbar-corner { background: transparent; }
         .diff {
             padding-bottom: 8px;
         }

--- a/Nex/Features/DiffPane/DiffHTMLRenderer.swift
+++ b/Nex/Features/DiffPane/DiffHTMLRenderer.swift
@@ -229,12 +229,12 @@ enum DiffHTMLRenderer {
         return luminance < 0.5
     }
 
-    private static func cssBackground(color: NSColor, opacity: Double) -> String {
-        let rgb = color.usingColorSpace(.sRGB) ?? color
-        let r = Int(rgb.redComponent * 255)
-        let g = Int(rgb.greenComponent * 255)
-        let b = Int(rgb.blueComponent * 255)
-        return "background-color: rgba(\(r), \(g), \(b), \(opacity));"
+    private static func cssBackground(color _: NSColor, opacity _: Double) -> String {
+        // Transparent: the pane body's SwiftUI background is the single
+        // ghostty-coloured surface behind this (transparent) web view, matching
+        // the terminal exactly and going transparent at 0% opacity. The colour
+        // is still used by the caller to pick the light/dark text theme.
+        "background-color: transparent;"
     }
 
     private static func wrapInHTMLDocument(

--- a/Nex/Features/DiffPane/DiffPaneView.swift
+++ b/Nex/Features/DiffPane/DiffPaneView.swift
@@ -71,6 +71,10 @@ struct DiffPaneView: NSViewRepresentable {
         let tokenBumped = coord.lastRefreshToken != refreshToken
         let focusGained = isFocused && !coord.lastIsFocused
         let fontChanged = coord.fontSize != fontSize
+        // Compare before overwriting: the background is baked into the HTML/CSS,
+        // so an appearance change needs a re-render to match the terminal live.
+        let bgChanged = coord.backgroundColor != backgroundColor
+            || coord.backgroundOpacity != backgroundOpacity
 
         coord.repoPath = repoPath
         coord.targetPath = targetPath
@@ -81,7 +85,7 @@ struct DiffPaneView: NSViewRepresentable {
         if pathChanged || tokenBumped || focusGained {
             coord.lastRefreshToken = refreshToken
             coord.loadDiff()
-        } else if fontChanged {
+        } else if fontChanged || bgChanged {
             coord.renderCurrent()
         }
 

--- a/Nex/Features/MarkdownPane/LineNumberRulerView.swift
+++ b/Nex/Features/MarkdownPane/LineNumberRulerView.swift
@@ -7,6 +7,12 @@ final class LineNumberRulerView: NSRulerView {
     private let textPadding: CGFloat = 4
     private let minimumThickness: CGFloat = 36
 
+    /// Gutter fill + line-number colour. When `gutterBackgroundColor` is set the
+    /// gutter is painted with it (the pane-header chrome colour) instead of
+    /// letting the transparent editor surface show through.
+    var gutterBackgroundColor: NSColor? { didSet { needsDisplay = true } }
+    var gutterTextColor: NSColor? { didSet { needsDisplay = true } }
+
     /// Cached newline offsets for O(1) line-number lookup during scroll.
     /// Index i holds the string index of the start of line i+1.
     private var lineStarts: [Int] = [0]
@@ -80,6 +86,11 @@ final class LineNumberRulerView: NSRulerView {
     // MARK: - Drawing
 
     override func drawHashMarksAndLabels(in _: NSRect) {
+        if let gutterBackgroundColor {
+            gutterBackgroundColor.setFill()
+            bounds.fill()
+        }
+
         guard let textView = clientView as? NSTextView,
               let layoutManager = textView.layoutManager,
               let textContainer = textView.textContainer else { return }
@@ -89,7 +100,7 @@ final class LineNumberRulerView: NSRulerView {
 
         let attrs: [NSAttributedString.Key: Any] = [
             .font: lineNumberFont,
-            .foregroundColor: NSColor.secondaryLabelColor
+            .foregroundColor: gutterTextColor ?? NSColor.secondaryLabelColor
         ]
 
         let string = textView.string as NSString

--- a/Nex/Features/MarkdownPane/MarkdownEditorView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownEditorView.swift
@@ -26,9 +26,10 @@ struct MarkdownEditorView: NSViewRepresentable {
         textView.isAutomaticTextReplacementEnabled = false
         textView.usesFindBar = true
         textView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        textView.textColor = NSColor.textColor
+        let fg = Self.foreground(for: backgroundColor)
+        textView.textColor = fg
         textView.backgroundColor = backgroundColor.withAlphaComponent(backgroundOpacity)
-        textView.insertionPointColor = NSColor.textColor
+        textView.insertionPointColor = fg
         textView.textContainerInset = NSSize(width: 8, height: 8)
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
@@ -79,6 +80,18 @@ struct MarkdownEditorView: NSViewRepresentable {
             context.coordinator.filePath = filePath
             context.coordinator.loadFile()
         }
+        // Re-apply the terminal background (+ contrasting text) live on an
+        // appearance change.
+        if let textView = context.coordinator.textView {
+            let bg = backgroundColor.withAlphaComponent(backgroundOpacity)
+            if textView.backgroundColor != bg {
+                textView.backgroundColor = bg
+                context.coordinator.scrollView?.backgroundColor = bg
+                let fg = Self.foreground(for: backgroundColor)
+                textView.textColor = fg
+                textView.insertionPointColor = fg
+            }
+        }
         // Only claim on a real false→true transition so re-renders caused
         // by unrelated state changes (e.g., the user typing in the command
         // palette's TextField) don't yank first responder back.
@@ -106,6 +119,17 @@ struct MarkdownEditorView: NSViewRepresentable {
     private func releaseFirstResponderIfHeld(_ textView: NSTextView) {
         guard let window = textView.window, window.firstResponder === textView else { return }
         window.makeFirstResponder(nil)
+    }
+
+    /// Readable text colour for the given background: light text on a dark
+    /// background, dark text on a light one (luminance-based, mirroring the
+    /// scratchpad editor and the markdown/diff HTML renderers).
+    private static func foreground(for background: NSColor) -> NSColor {
+        let rgb = background.usingColorSpace(.deviceRGB) ?? background
+        let luminance = 0.299 * rgb.redComponent + 0.587 * rgb.greenComponent + 0.114 * rgb.blueComponent
+        return luminance < 0.5
+            ? NSColor(white: 0.90, alpha: 1)
+            : NSColor(white: 0.12, alpha: 1)
     }
 
     // MARK: - Coordinator

--- a/Nex/Features/MarkdownPane/MarkdownEditorView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownEditorView.swift
@@ -44,6 +44,8 @@ struct MarkdownEditorView: NSViewRepresentable {
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
         scrollView.drawsBackground = false
+        // Thin overlay scroller, matching the sidebar.
+        scrollView.scrollerStyle = .overlay
 
         // Line number gutter — pane-header chrome colour (see ScratchpadEditorView).
         scrollView.rulersVisible = true

--- a/Nex/Features/MarkdownPane/MarkdownEditorView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownEditorView.swift
@@ -8,6 +8,7 @@ struct MarkdownEditorView: NSViewRepresentable {
     var backgroundColor: NSColor = .textBackgroundColor
     var backgroundOpacity: Double = 1.0
     @Environment(\.sidebarTextEditingActive) private var sidebarTextEditingActive
+    @Environment(\.chromeTheme) private var chromeTheme
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -44,9 +45,11 @@ struct MarkdownEditorView: NSViewRepresentable {
         scrollView.hasHorizontalScroller = false
         scrollView.drawsBackground = false
 
-        // Line number gutter
+        // Line number gutter — pane-header chrome colour (see ScratchpadEditorView).
         scrollView.rulersVisible = true
         let rulerView = LineNumberRulerView(textView: textView)
+        rulerView.gutterBackgroundColor = NSColor(chromeTheme.headerBackground)
+        rulerView.gutterTextColor = NSColor(chromeTheme.textTertiary)
         scrollView.verticalRulerView = rulerView
 
         context.coordinator.textView = textView
@@ -90,6 +93,9 @@ struct MarkdownEditorView: NSViewRepresentable {
                 textView.insertionPointColor = fg
             }
         }
+        // Keep the gutter on the pane-header chrome colour across appearance changes.
+        context.coordinator.rulerView?.gutterBackgroundColor = NSColor(chromeTheme.headerBackground)
+        context.coordinator.rulerView?.gutterTextColor = NSColor(chromeTheme.textTertiary)
         // Only claim on a real false→true transition so re-renders caused
         // by unrelated state changes (e.g., the user typing in the command
         // palette's TextField) don't yank first responder back.

--- a/Nex/Features/MarkdownPane/MarkdownEditorView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownEditorView.swift
@@ -28,7 +28,9 @@ struct MarkdownEditorView: NSViewRepresentable {
         textView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
         let fg = Self.foreground(for: backgroundColor)
         textView.textColor = fg
-        textView.backgroundColor = backgroundColor.withAlphaComponent(backgroundOpacity)
+        // Transparent content: the pane body's SwiftUI background is the single
+        // ghostty-coloured surface (see ScratchpadEditorView).
+        textView.drawsBackground = false
         textView.insertionPointColor = fg
         textView.textContainerInset = NSSize(width: 8, height: 8)
         textView.isVerticallyResizable = true
@@ -40,8 +42,7 @@ struct MarkdownEditorView: NSViewRepresentable {
         scrollView.documentView = textView
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
-        scrollView.drawsBackground = true
-        scrollView.backgroundColor = backgroundColor.withAlphaComponent(backgroundOpacity)
+        scrollView.drawsBackground = false
 
         // Line number gutter
         scrollView.rulersVisible = true
@@ -80,14 +81,11 @@ struct MarkdownEditorView: NSViewRepresentable {
             context.coordinator.filePath = filePath
             context.coordinator.loadFile()
         }
-        // Re-apply the terminal background (+ contrasting text) live on an
-        // appearance change.
+        // Keep the text colour contrasting with the (terminal) background on an
+        // appearance change; the surface is the pane body's SwiftUI background.
         if let textView = context.coordinator.textView {
-            let bg = backgroundColor.withAlphaComponent(backgroundOpacity)
-            if textView.backgroundColor != bg {
-                textView.backgroundColor = bg
-                context.coordinator.scrollView?.backgroundColor = bg
-                let fg = Self.foreground(for: backgroundColor)
+            let fg = Self.foreground(for: backgroundColor)
+            if textView.textColor != fg {
                 textView.textColor = fg
                 textView.insertionPointColor = fg
             }

--- a/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
+++ b/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
@@ -303,6 +303,12 @@ enum MarkdownRenderer {
             \(backgroundCSS)
         }
         .dark body { color: #e6edf3; }
+        /* Thin scrollbar matching the sidebar's overlay scroller. */
+        ::-webkit-scrollbar { width: 8px; height: 8px; }
+        ::-webkit-scrollbar-track { background: transparent; }
+        ::-webkit-scrollbar-thumb { background: rgba(128, 128, 128, 0.4); border-radius: 4px; }
+        ::-webkit-scrollbar-thumb:hover { background: rgba(128, 128, 128, 0.6); }
+        ::-webkit-scrollbar-corner { background: transparent; }
         h1, h2, h3, h4, h5, h6 {
             margin-top: 1.5em;
             margin-bottom: 0.5em;

--- a/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
+++ b/Nex/Features/MarkdownPane/MarkdownHTMLRenderer.swift
@@ -253,12 +253,14 @@ enum MarkdownRenderer {
         return luminance < 0.5
     }
 
-    private static func cssBackground(color: NSColor, opacity: Double) -> String {
-        let rgb = color.usingColorSpace(.sRGB) ?? color
-        let r = Int(rgb.redComponent * 255)
-        let g = Int(rgb.greenComponent * 255)
-        let b = Int(rgb.blueComponent * 255)
-        return "background-color: rgba(\(r), \(g), \(b), \(opacity));"
+    private static func cssBackground(color _: NSColor, opacity _: Double) -> String {
+        // Transparent: the pane body's SwiftUI background is the single
+        // ghostty-coloured surface behind this (transparent) web view, so the
+        // markdown matches the terminal exactly and goes transparent at 0%
+        // opacity rather than painting a second opaque layer of its own. The
+        // background colour is still used by the caller to pick the light/dark
+        // text theme.
+        "background-color: transparent;"
     }
 
     private static func wrapInHTMLDocument(

--- a/Nex/Features/MarkdownPane/MarkdownPaneView.swift
+++ b/Nex/Features/MarkdownPane/MarkdownPaneView.swift
@@ -98,6 +98,13 @@ struct MarkdownPaneView: NSViewRepresentable {
         } else if context.coordinator.fontSize != fontSize {
             context.coordinator.fontSize = fontSize
             context.coordinator.renderCurrentContent()
+        } else if context.coordinator.backgroundColor != backgroundColor
+            || context.coordinator.backgroundOpacity != backgroundOpacity {
+            // Appearance changed — the background is baked into the HTML/CSS,
+            // so re-render to match the terminal's new background live.
+            context.coordinator.backgroundColor = backgroundColor
+            context.coordinator.backgroundOpacity = backgroundOpacity
+            context.coordinator.renderCurrentContent()
         }
         // Only claim on a real false→true transition so re-renders caused
         // by unrelated state changes (e.g., the user typing in the command

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -336,8 +336,10 @@ struct PaneGridView: View {
         }
         .overlay {
             if pane.id == focusedPaneID {
+                // Full highlight around the focused pane (header + body), in the
+                // dedicated pane-focus colour (separate from the sidebar accent).
                 Rectangle()
-                    .strokeBorder(Color.accentColor.opacity(0.4), lineWidth: 1)
+                    .strokeBorder(chromeTheme.paneFocus, lineWidth: 2)
             }
         }
         .overlay {

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -72,6 +72,7 @@ struct PaneGridView: View {
     var onOpenFavourite: ((UUID, String) -> Void)?
 
     @Environment(\.ghosttyConfig) private var ghosttyConfig
+    @Environment(\.chromeTheme) private var chromeTheme
     @Environment(\.surfaceManager) private var surfaceManager
 
     @State private var dragSourcePaneID: UUID?
@@ -326,6 +327,8 @@ struct PaneGridView: View {
             }
         }
         .background {
+            // Non-terminal pane bodies share the terminal panes' Ghostty
+            // background so content panes blend with the terminal theme.
             if pane.type == .markdown || pane.type == .scratchpad || pane.type == .diff || pane.type == .web {
                 Color(nsColor: ghosttyConfig.backgroundColor)
                     .opacity(ghosttyConfig.backgroundOpacity)
@@ -458,6 +461,8 @@ struct PaneGridView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: ghosttyConfig.backgroundColor))
+        // The "No panes" placeholder fills an empty grid (no pane bodies),
+        // so it reads as a window gap → chrome windowBackground.
+        .background(chromeTheme.windowBackground)
     }
 }

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -36,6 +36,7 @@ struct PaneHeaderView: View {
     var onToggleSyncExcluded: (() -> Void)?
 
     @State private var isDragging = false
+    @Environment(\.chromeTheme) private var theme
 
     var body: some View {
         HStack(spacing: 4) {
@@ -82,7 +83,7 @@ struct PaneHeaderView: View {
 
             Text(displayPath)
                 .font(.system(size: 11, design: .monospaced))
-                .foregroundStyle(isFocused ? .primary : .secondary)
+                .foregroundStyle(isFocused ? theme.textPrimary : theme.textSecondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
 
@@ -144,6 +145,10 @@ struct PaneHeaderView: View {
             }
 
             Spacer()
+
+            if pane.type == .shell, pane.agentSessionID != nil {
+                agentBadge
+            }
 
             if let branch = pane.gitBranch {
                 HStack(spacing: 2) {
@@ -256,30 +261,61 @@ struct PaneHeaderView: View {
                     onDragEnded?()
                 }
         )
-        .background {
-            ZStack {
-                Color(nsColor: .windowBackgroundColor)
-                if isFocused {
-                    Color.accentColor.opacity(0.15)
-                }
-            }
-        }
+        // Keep the header at the flat header tone (no focus tint), so it
+        // renders exactly the spec'd colour; focus is shown by the accent
+        // underline below.
+        .background(theme.headerBackground)
         .overlay(alignment: .bottom) {
+            theme.divider.frame(height: 1)
             if isFocused {
-                Color.accentColor.opacity(0.6)
+                theme.selectionStroke.opacity(0.7)
                     .frame(height: 2)
             }
+        }
+    }
+
+    /// Right-aligned agent badge: amber `claude · mm:ss` while running,
+    /// blue `awaiting input` while waiting. Hidden when idle. Only shown
+    /// for shell panes that have an attached agent session.
+    @ViewBuilder
+    private var agentBadge: some View {
+        switch pane.status {
+        case .running:
+            HStack(spacing: 3) {
+                Text("claude")
+                if let started = pane.agentStartedAt {
+                    Text("·")
+                    TimelineView(.periodic(from: .now, by: 1)) { context in
+                        Text(chromeElapsedLabel(from: started, to: context.date))
+                            .monospacedDigit()
+                    }
+                }
+            }
+            .font(.system(size: 10, design: .monospaced))
+            .foregroundStyle(theme.activeAgent)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(theme.activeAgent.opacity(0.14), in: RoundedRectangle(cornerRadius: 3))
+        case .waitingForInput:
+            Text("awaiting input")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(theme.statusWaiting)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(theme.statusWaiting.opacity(0.14), in: RoundedRectangle(cornerRadius: 3))
+        case .idle:
+            EmptyView()
         }
     }
 
     private var statusDotColor: Color {
         switch pane.status {
         case .running:
-            .green
+            theme.statusRunning
         case .waitingForInput:
-            .blue
+            theme.statusWaiting
         case .idle:
-            isFocused ? Color.secondary.opacity(0.5) : Color.secondary.opacity(0.3)
+            isFocused ? theme.textTertiary : theme.textTertiary.opacity(0.5)
         }
     }
 
@@ -389,12 +425,7 @@ struct PaneHeaderView: View {
                 : (target as NSString).lastPathComponent
             return "diff: \(scope)"
         }
-        let path = pane.title ?? pane.workingDirectory
-        if let home = ProcessInfo.processInfo.environment["HOME"],
-           path.hasPrefix(home) {
-            return "~" + path.dropFirst(home.count)
-        }
-        return path
+        return chromeHomeAbbreviated(pane.title ?? pane.workingDirectory)
     }
 }
 

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -261,16 +261,12 @@ struct PaneHeaderView: View {
                     onDragEnded?()
                 }
         )
-        // Keep the header at the flat header tone (no focus tint), so it
-        // renders exactly the spec'd colour; focus is shown by the accent
-        // underline below.
+        // Flat header tone with just the structural divider; focus is shown by
+        // the full pane-focus border (drawn around the whole pane in
+        // PaneGridView), not a header underline.
         .background(theme.headerBackground)
         .overlay(alignment: .bottom) {
             theme.divider.frame(height: 1)
-            if isFocused {
-                theme.selectionStroke.opacity(0.7)
-                    .frame(height: 2)
-            }
         }
     }
 

--- a/Nex/Features/PaneGrid/PaneSearchOverlay.swift
+++ b/Nex/Features/PaneGrid/PaneSearchOverlay.swift
@@ -11,6 +11,7 @@ struct PaneSearchOverlay: View {
     let onNavigatePrevious: () -> Void
     let onClose: () -> Void
 
+    @Environment(\.chromeTheme) private var chromeTheme
     @FocusState private var isFieldFocused: Bool
     @State private var localNeedle: String = ""
 
@@ -75,8 +76,7 @@ struct PaneSearchOverlay: View {
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 4)
-        .background(.ultraThinMaterial)
-        .background(Color(nsColor: .windowBackgroundColor).opacity(0.85))
+        .background(chromeTheme.headerBackground)
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
         .onAppear {

--- a/Nex/Features/PaneGrid/RenamePaneSheet.swift
+++ b/Nex/Features/PaneGrid/RenamePaneSheet.swift
@@ -8,6 +8,7 @@ struct RenamePaneSheet: View {
     let onDismiss: () -> Void
 
     @State private var text: String = ""
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         VStack(spacing: 16) {
@@ -28,6 +29,7 @@ struct RenamePaneSheet: View {
         }
         .padding()
         .frame(width: 320)
+        .background(chromeTheme.surfaceBackground)
         .onAppear { text = currentName }
     }
 

--- a/Nex/Features/PaneGrid/ResizeDimensionsOverlay.swift
+++ b/Nex/Features/PaneGrid/ResizeDimensionsOverlay.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct ResizeDimensionsOverlay: View {
     let text: String
 
+    @Environment(\.chromeTheme) private var chromeTheme
+
     var body: some View {
         Text(text)
             .font(.system(size: 13, weight: .medium, design: .monospaced))
@@ -12,8 +14,7 @@ struct ResizeDimensionsOverlay: View {
             .foregroundStyle(.primary)
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
-            .background(.ultraThinMaterial)
-            .background(Color(nsColor: .windowBackgroundColor).opacity(0.7))
+            .background(chromeTheme.headerBackground)
             .clipShape(RoundedRectangle(cornerRadius: 6))
             .shadow(color: .black.opacity(0.25), radius: 4, y: 2)
             .allowsHitTesting(false)

--- a/Nex/Features/PaneGrid/SplitDividerView.swift
+++ b/Nex/Features/PaneGrid/SplitDividerView.swift
@@ -7,6 +7,7 @@ struct SplitDividerView: View {
     let onDrag: (Double) -> Void
     var onDragStateChanged: ((Bool) -> Void)?
 
+    @Environment(\.chromeTheme) private var chromeTheme
     @State private var isDragging = false
 
     private var isHorizontal: Bool {
@@ -15,7 +16,7 @@ struct SplitDividerView: View {
 
     var body: some View {
         Rectangle()
-            .fill(Color(nsColor: .windowBackgroundColor))
+            .fill(chromeTheme.divider)
             .overlay(isDragging ? Color.accentColor.opacity(0.5) : Color.secondary.opacity(0.2))
             .frame(
                 width: isHorizontal ? 4 : nil,

--- a/Nex/Features/PaneGrid/SplitDividerView.swift
+++ b/Nex/Features/PaneGrid/SplitDividerView.swift
@@ -19,8 +19,8 @@ struct SplitDividerView: View {
             .fill(chromeTheme.divider)
             .overlay(isDragging ? Color.accentColor.opacity(0.5) : Color.secondary.opacity(0.2))
             .frame(
-                width: isHorizontal ? 4 : nil,
-                height: isHorizontal ? nil : 4
+                width: isHorizontal ? PaneLayout.dividerThickness : nil,
+                height: isHorizontal ? nil : PaneLayout.dividerThickness
             )
             .contentShape(Rectangle().inset(by: -4))
             .onHover { hovering in

--- a/Nex/Features/RepoRegistry/RepoPickerView.swift
+++ b/Nex/Features/RepoRegistry/RepoPickerView.swift
@@ -55,6 +55,7 @@ struct RepoPickerView: View {
     /// Last interacted-with row. Drives keyboard nav and shift-click ranges.
     @State private var anchorRepoID: UUID?
     @FocusState private var focusedField: Field?
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         VStack(spacing: 12) {
@@ -98,6 +99,7 @@ struct RepoPickerView: View {
         }
         .padding(16)
         .frame(width: 360, height: 340)
+        .background(chromeTheme.surfaceBackground)
         .onAppear {
             DispatchQueue.main.async {
                 focusedField = .search

--- a/Nex/Features/RepoRegistry/RepoRegistryView.swift
+++ b/Nex/Features/RepoRegistry/RepoRegistryView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct RepoRegistryView: View {
     let store: StoreOf<AppReducer>
     @State private var searchText = ""
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         WithPerceptionTracking {
@@ -50,8 +51,10 @@ struct RepoRegistryView: View {
                         }
                     }
                     .listStyle(.inset)
+                    .scrollContentBackground(.hidden)
                 }
             }
+            .background(chromeTheme.surfaceBackground)
         }
     }
 

--- a/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
+++ b/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
@@ -29,9 +29,13 @@ struct ScratchpadEditorView: NSViewRepresentable {
         textView.isAutomaticTextReplacementEnabled = false
         textView.usesFindBar = true
         textView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        textView.textColor = NSColor.textColor
+        // Text colour tracks the (terminal) background's luminance, not the
+        // chrome appearance — otherwise a light chrome over a dark terminal
+        // background renders unreadable black-on-dark text.
+        let fg = Self.foreground(for: backgroundColor)
+        textView.textColor = fg
         textView.backgroundColor = backgroundColor.withAlphaComponent(backgroundOpacity)
-        textView.insertionPointColor = NSColor.textColor
+        textView.insertionPointColor = fg
         textView.textContainerInset = NSSize(width: 8, height: 8)
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
@@ -79,6 +83,15 @@ struct ScratchpadEditorView: NSViewRepresentable {
 
     func updateNSView(_: PaneFocusView, context: Context) {
         guard let textView = context.coordinator.textView else { return }
+        // Keep colours in sync if the (terminal) background changes.
+        let fg = Self.foreground(for: backgroundColor)
+        let bg = backgroundColor.withAlphaComponent(backgroundOpacity)
+        if textView.backgroundColor != bg { textView.backgroundColor = bg }
+        if textView.textColor != fg {
+            textView.textColor = fg
+            textView.insertionPointColor = fg
+        }
+        context.coordinator.scrollView?.backgroundColor = bg
         // Only claim on a real false→true transition so re-renders caused
         // by unrelated state changes (e.g., the user typing in the command
         // palette's TextField) don't yank first responder back.
@@ -104,6 +117,17 @@ struct ScratchpadEditorView: NSViewRepresentable {
     private func releaseFirstResponderIfHeld(_ textView: NSTextView) {
         guard let window = textView.window, window.firstResponder === textView else { return }
         window.makeFirstResponder(nil)
+    }
+
+    /// Readable foreground for a given background: light text on a dark
+    /// background, dark text on a light one (luminance-based, mirroring the
+    /// markdown/diff HTML renderers).
+    private static func foreground(for background: NSColor) -> NSColor {
+        let rgb = background.usingColorSpace(.deviceRGB) ?? background
+        let luminance = 0.299 * rgb.redComponent + 0.587 * rgb.greenComponent + 0.114 * rgb.blueComponent
+        return luminance < 0.5
+            ? NSColor(white: 0.90, alpha: 1)
+            : NSColor(white: 0.12, alpha: 1)
     }
 
     // MARK: - Coordinator

--- a/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
+++ b/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
@@ -11,6 +11,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
     var backgroundColor: NSColor = .textBackgroundColor
     var backgroundOpacity: Double = 1.0
     @Environment(\.sidebarTextEditingActive) private var sidebarTextEditingActive
+    @Environment(\.chromeTheme) private var chromeTheme
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -52,9 +53,12 @@ struct ScratchpadEditorView: NSViewRepresentable {
         scrollView.hasHorizontalScroller = false
         scrollView.drawsBackground = false
 
-        // Line number gutter
+        // Line number gutter — uses the pane-header chrome colour so the gutter
+        // reads as chrome, distinct from the terminal-coloured editor body.
         scrollView.rulersVisible = true
         let rulerView = LineNumberRulerView(textView: textView)
+        rulerView.gutterBackgroundColor = NSColor(chromeTheme.headerBackground)
+        rulerView.gutterTextColor = NSColor(chromeTheme.textTertiary)
         scrollView.verticalRulerView = rulerView
 
         context.coordinator.textView = textView
@@ -93,6 +97,9 @@ struct ScratchpadEditorView: NSViewRepresentable {
             textView.textColor = fg
             textView.insertionPointColor = fg
         }
+        // Keep the gutter on the pane-header chrome colour across appearance changes.
+        context.coordinator.rulerView?.gutterBackgroundColor = NSColor(chromeTheme.headerBackground)
+        context.coordinator.rulerView?.gutterTextColor = NSColor(chromeTheme.textTertiary)
         // Only claim on a real false→true transition so re-renders caused
         // by unrelated state changes (e.g., the user typing in the command
         // palette's TextField) don't yank first responder back.

--- a/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
+++ b/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
@@ -34,7 +34,11 @@ struct ScratchpadEditorView: NSViewRepresentable {
         // background renders unreadable black-on-dark text.
         let fg = Self.foreground(for: backgroundColor)
         textView.textColor = fg
-        textView.backgroundColor = backgroundColor.withAlphaComponent(backgroundOpacity)
+        // Transparent content: the pane body's SwiftUI background is the single
+        // ghostty-coloured surface (matches the terminal exactly and goes fully
+        // transparent at 0% opacity), instead of the text view + scroll view
+        // each painting their own opaque layer beneath it.
+        textView.drawsBackground = false
         textView.insertionPointColor = fg
         textView.textContainerInset = NSSize(width: 8, height: 8)
         textView.isVerticallyResizable = true
@@ -46,8 +50,7 @@ struct ScratchpadEditorView: NSViewRepresentable {
         scrollView.documentView = textView
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
-        scrollView.drawsBackground = true
-        scrollView.backgroundColor = backgroundColor.withAlphaComponent(backgroundOpacity)
+        scrollView.drawsBackground = false
 
         // Line number gutter
         scrollView.rulersVisible = true
@@ -83,15 +86,13 @@ struct ScratchpadEditorView: NSViewRepresentable {
 
     func updateNSView(_: PaneFocusView, context: Context) {
         guard let textView = context.coordinator.textView else { return }
-        // Keep colours in sync if the (terminal) background changes.
+        // Keep the text colour in sync if the (terminal) background changes;
+        // the surface itself is the pane body's SwiftUI background.
         let fg = Self.foreground(for: backgroundColor)
-        let bg = backgroundColor.withAlphaComponent(backgroundOpacity)
-        if textView.backgroundColor != bg { textView.backgroundColor = bg }
         if textView.textColor != fg {
             textView.textColor = fg
             textView.insertionPointColor = fg
         }
-        context.coordinator.scrollView?.backgroundColor = bg
         // Only claim on a real false→true transition so re-renders caused
         // by unrelated state changes (e.g., the user typing in the command
         // palette's TextField) don't yank first responder back.

--- a/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
+++ b/Nex/Features/ScratchpadPane/ScratchpadEditorView.swift
@@ -52,6 +52,8 @@ struct ScratchpadEditorView: NSViewRepresentable {
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
         scrollView.drawsBackground = false
+        // Thin overlay scroller, matching the sidebar.
+        scrollView.scrollerStyle = .overlay
 
         // Line number gutter — uses the pane-header chrome colour so the gutter
         // reads as chrome, distinct from the terminal-coloured editor body.

--- a/Nex/Features/Settings/KeybindingsSettingsView.swift
+++ b/Nex/Features/Settings/KeybindingsSettingsView.swift
@@ -7,6 +7,7 @@ struct KeybindingsSettingsView: View {
     let store: StoreOf<AppReducer>
     @State private var recordingAction: NexAction?
     @State private var recordingGlobal: Bool = false
+    @Environment(\.chromeTheme) private var chromeTheme
 
     private static let categoryOrder = [
         "Pane Management", "Navigation", "Workspaces", "View", "Files", "Search"
@@ -55,6 +56,7 @@ struct KeybindingsSettingsView: View {
                     }
                 }
                 .listStyle(.inset(alternatesRowBackgrounds: true))
+                .scrollContentBackground(.hidden)
 
                 Divider()
 
@@ -69,6 +71,7 @@ struct KeybindingsSettingsView: View {
                 }
                 .padding(12)
             }
+            .background(chromeTheme.surfaceBackground)
             .sheet(item: recordingActionBinding) { action in
                 KeyRecorderSheet(
                     action: action,
@@ -221,6 +224,7 @@ private struct GlobalKeyRecorderSheet: View {
     let onComplete: (KeyTrigger?) -> Void
 
     @State private var conflictMessage: String?
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         VStack(spacing: 16) {
@@ -267,6 +271,7 @@ private struct GlobalKeyRecorderSheet: View {
         }
         .padding(24)
         .frame(width: 380)
+        .background(chromeTheme.surfaceBackground)
     }
 }
 
@@ -282,6 +287,7 @@ private struct KeyRecorderSheet: View {
     let onComplete: (KeyTrigger?) -> Void
 
     @State private var conflictMessage: String?
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         VStack(spacing: 16) {
@@ -327,6 +333,7 @@ private struct KeyRecorderSheet: View {
         }
         .padding(24)
         .frame(width: 340)
+        .background(chromeTheme.surfaceBackground)
     }
 }
 

--- a/Nex/Features/Settings/LabelPresetsSettingsView.swift
+++ b/Nex/Features/Settings/LabelPresetsSettingsView.swift
@@ -17,6 +17,7 @@ private enum LabelCol {
 struct LabelPresetsSettingsView: View {
     let store: StoreOf<AppReducer>
 
+    @Environment(\.chromeTheme) private var chromeTheme
     @State private var newName = ""
     @State private var newColor: LabelColor = .named(.blue)
     @State private var newTextColor: LabelColor?
@@ -71,9 +72,11 @@ struct LabelPresetsSettingsView: View {
                         }
                     }
                     .listStyle(.inset(alternatesRowBackgrounds: true))
+                    .scrollContentBackground(.hidden)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(chromeTheme.surfaceBackground)
         }
     }
 

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -34,6 +34,9 @@ struct SettingsFeature {
         var newGroupPlacement: SidebarPlacement = .endOfList
         var newWorkspacePlacement: SidebarPlacement = .endOfList
         var confirmQuitWhenActive: Bool = true
+        /// Warm app-chrome palette preference. Drives the sidebar / title bar /
+        /// status bar appearance independently of the Ghostty terminal theme.
+        var chromeAppearance: ChromeAppearance = .system
 
         /// The resolved absolute worktree base path. Expands ~ and substitutes
         /// the `<repo>` placeholder:
@@ -63,6 +66,7 @@ struct SettingsFeature {
         case setNewGroupPlacement(SidebarPlacement)
         case setNewWorkspacePlacement(SidebarPlacement)
         case setConfirmQuitWhenActive(Bool)
+        case setChromeAppearance(ChromeAppearance)
         case refreshConfirmQuitWhenActive
         case selectTheme(NexTheme?)
         case applyAppearance(opacity: Double, r: Double, g: Double, b: Double, theme: NexTheme?)
@@ -83,6 +87,7 @@ struct SettingsFeature {
     static let defaultsKeyNewGroupPlacement = "settings.newGroupPlacement"
     static let defaultsKeyNewWorkspacePlacement = "settings.newWorkspacePlacement"
     static let defaultsKeyConfirmQuitWhenActive = QuitGateDefaults.confirmQuit
+    static let defaultsKeyChromeAppearance = "settings.chromeAppearance"
 
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.userDefaults) var userDefaults
@@ -116,6 +121,10 @@ struct SettingsFeature {
                 }
                 if userDefaults.hasKey(Self.defaultsKeyConfirmQuitWhenActive) {
                     state.confirmQuitWhenActive = userDefaults.boolForKey(Self.defaultsKeyConfirmQuitWhenActive)
+                }
+                if let raw = userDefaults.stringForKey(Self.defaultsKeyChromeAppearance),
+                   let appearance = ChromeAppearance(rawValue: raw) {
+                    state.chromeAppearance = appearance
                 }
                 if userDefaults.boolForKey(Self.defaultsKeyHasCustomColor) {
                     state.backgroundColorR = userDefaults.doubleForKey(Self.defaultsKeyColorR)
@@ -199,6 +208,14 @@ struct SettingsFeature {
             case .setConfirmQuitWhenActive(let enabled):
                 state.confirmQuitWhenActive = enabled
                 userDefaults.setBool(enabled, Self.defaultsKeyConfirmQuitWhenActive)
+                return .none
+
+            case .setChromeAppearance(let appearance):
+                // Chrome-only: persist and let RootChromeView re-resolve the
+                // palette. Deliberately decoupled from `.applyAppearance` —
+                // this must NOT rebuild the ghostty terminal config.
+                state.chromeAppearance = appearance
+                userDefaults.setString(appearance.rawValue, Self.defaultsKeyChromeAppearance)
                 return .none
 
             case .refreshConfirmQuitWhenActive:

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -52,6 +52,8 @@ struct SettingsFeature {
         var sparklineColorHex: String = ""
         /// Inline sparkline width in points.
         var sparklineWidth: Double = 28
+        /// Sparkline render style (`SparklineStyle` rawValue: line / dots).
+        var sparklineStyle: String = "line"
         /// Warm app-chrome palette preference. Drives the sidebar / title bar /
         /// status bar appearance independently of the Ghostty terminal theme.
         var chromeAppearance: ChromeAppearance = .system
@@ -101,6 +103,7 @@ struct SettingsFeature {
         case setShowSystemStatGraphs(Bool)
         case setSparklineColor(String)
         case setSparklineWidth(Double)
+        case setSparklineStyle(String)
         case setChromeAppearance(ChromeAppearance)
         case setChromeColor(key: String, hex: String?)
         case resetChromeColors
@@ -131,6 +134,7 @@ struct SettingsFeature {
     static let defaultsKeyShowSystemStatGraphs = "settings.showSystemStatGraphs"
     static let defaultsKeySparklineColor = "settings.sparklineColor"
     static let defaultsKeySparklineWidth = "settings.sparklineWidth"
+    static let defaultsKeySparklineStyle = "settings.sparklineStyle"
     static let defaultsKeyChromeAppearance = "settings.chromeAppearance"
     static let defaultsKeyChromeColors = "settings.chromeColors"
     static let defaultsKeySidebarColorIntensity = "settings.sidebarColorIntensity"
@@ -186,6 +190,9 @@ struct SettingsFeature {
                 }
                 if userDefaults.hasKey(Self.defaultsKeySparklineWidth) {
                     state.sparklineWidth = userDefaults.doubleForKey(Self.defaultsKeySparklineWidth)
+                }
+                if let style = userDefaults.stringForKey(Self.defaultsKeySparklineStyle), !style.isEmpty {
+                    state.sparklineStyle = style
                 }
                 if let raw = userDefaults.stringForKey(Self.defaultsKeyChromeAppearance),
                    let appearance = ChromeAppearance(rawValue: raw) {
@@ -325,6 +332,11 @@ struct SettingsFeature {
             case .setSparklineWidth(let width):
                 state.sparklineWidth = width
                 userDefaults.setDouble(width, Self.defaultsKeySparklineWidth)
+                return .none
+
+            case .setSparklineStyle(let style):
+                state.sparklineStyle = style
+                userDefaults.setString(style, Self.defaultsKeySparklineStyle)
                 return .none
 
             case .setChromeAppearance(let appearance):

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -42,6 +42,8 @@ struct SettingsFeature {
         var newGroupPlacement: SidebarPlacement = .endOfList
         var newWorkspacePlacement: SidebarPlacement = .endOfList
         var confirmQuitWhenActive: Bool = true
+        /// Show CPU / memory / load in the bottom status bar.
+        var showSystemStats: Bool = true
         /// Warm app-chrome palette preference. Drives the sidebar / title bar /
         /// status bar appearance independently of the Ghostty terminal theme.
         var chromeAppearance: ChromeAppearance = .system
@@ -86,6 +88,7 @@ struct SettingsFeature {
         case setNewGroupPlacement(SidebarPlacement)
         case setNewWorkspacePlacement(SidebarPlacement)
         case setConfirmQuitWhenActive(Bool)
+        case setShowSystemStats(Bool)
         case setChromeAppearance(ChromeAppearance)
         case setChromeColor(key: String, hex: String?)
         case resetChromeColors
@@ -111,6 +114,7 @@ struct SettingsFeature {
     static let defaultsKeyNewGroupPlacement = "settings.newGroupPlacement"
     static let defaultsKeyNewWorkspacePlacement = "settings.newWorkspacePlacement"
     static let defaultsKeyConfirmQuitWhenActive = QuitGateDefaults.confirmQuit
+    static let defaultsKeyShowSystemStats = "settings.showSystemStats"
     static let defaultsKeyChromeAppearance = "settings.chromeAppearance"
     static let defaultsKeyChromeColors = "settings.chromeColors"
     static let defaultsKeySidebarColorIntensity = "settings.sidebarColorIntensity"
@@ -151,6 +155,9 @@ struct SettingsFeature {
                 }
                 if userDefaults.hasKey(Self.defaultsKeyConfirmQuitWhenActive) {
                     state.confirmQuitWhenActive = userDefaults.boolForKey(Self.defaultsKeyConfirmQuitWhenActive)
+                }
+                if userDefaults.hasKey(Self.defaultsKeyShowSystemStats) {
+                    state.showSystemStats = userDefaults.boolForKey(Self.defaultsKeyShowSystemStats)
                 }
                 if let raw = userDefaults.stringForKey(Self.defaultsKeyChromeAppearance),
                    let appearance = ChromeAppearance(rawValue: raw) {
@@ -258,6 +265,11 @@ struct SettingsFeature {
             case .setConfirmQuitWhenActive(let enabled):
                 state.confirmQuitWhenActive = enabled
                 userDefaults.setBool(enabled, Self.defaultsKeyConfirmQuitWhenActive)
+                return .none
+
+            case .setShowSystemStats(let enabled):
+                state.showSystemStats = enabled
+                userDefaults.setBool(enabled, Self.defaultsKeyShowSystemStats)
                 return .none
 
             case .setChromeAppearance(let appearance):

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -37,6 +37,9 @@ struct SettingsFeature {
         /// Warm app-chrome palette preference. Drives the sidebar / title bar /
         /// status bar appearance independently of the Ghostty terminal theme.
         var chromeAppearance: ChromeAppearance = .system
+        /// Per-appearance chrome colour overrides. Keyed `"<light|dark>:<key>"`
+        /// (see `ChromeColorKey`) → `"RRGGBB"`. Empty = use the presets.
+        var chromeColorOverrides: [String: String] = [:]
 
         /// The resolved absolute worktree base path. Expands ~ and substitutes
         /// the `<repo>` placeholder:
@@ -67,6 +70,8 @@ struct SettingsFeature {
         case setNewWorkspacePlacement(SidebarPlacement)
         case setConfirmQuitWhenActive(Bool)
         case setChromeAppearance(ChromeAppearance)
+        case setChromeColor(key: String, hex: String?)
+        case resetChromeColors
         case refreshConfirmQuitWhenActive
         case selectTheme(NexTheme?)
         case applyAppearance(opacity: Double, r: Double, g: Double, b: Double, theme: NexTheme?)
@@ -88,6 +93,7 @@ struct SettingsFeature {
     static let defaultsKeyNewWorkspacePlacement = "settings.newWorkspacePlacement"
     static let defaultsKeyConfirmQuitWhenActive = QuitGateDefaults.confirmQuit
     static let defaultsKeyChromeAppearance = "settings.chromeAppearance"
+    static let defaultsKeyChromeColors = "settings.chromeColors"
 
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.userDefaults) var userDefaults
@@ -125,6 +131,11 @@ struct SettingsFeature {
                 if let raw = userDefaults.stringForKey(Self.defaultsKeyChromeAppearance),
                    let appearance = ChromeAppearance(rawValue: raw) {
                     state.chromeAppearance = appearance
+                }
+                if let json = userDefaults.stringForKey(Self.defaultsKeyChromeColors),
+                   let data = json.data(using: .utf8),
+                   let dict = try? JSONDecoder().decode([String: String].self, from: data) {
+                    state.chromeColorOverrides = dict
                 }
                 if userDefaults.boolForKey(Self.defaultsKeyHasCustomColor) {
                     state.backgroundColorR = userDefaults.doubleForKey(Self.defaultsKeyColorR)
@@ -216,6 +227,25 @@ struct SettingsFeature {
                 // this must NOT rebuild the ghostty terminal config.
                 state.chromeAppearance = appearance
                 userDefaults.setString(appearance.rawValue, Self.defaultsKeyChromeAppearance)
+                return .none
+
+            case .setChromeColor(let key, let hex):
+                // Chrome-only, like setChromeAppearance: persist and let the
+                // chrome wrappers re-resolve. nil hex resets that one colour.
+                if let hex {
+                    state.chromeColorOverrides[key] = hex
+                } else {
+                    state.chromeColorOverrides.removeValue(forKey: key)
+                }
+                if let data = try? JSONEncoder().encode(state.chromeColorOverrides),
+                   let json = String(data: data, encoding: .utf8) {
+                    userDefaults.setString(json, Self.defaultsKeyChromeColors)
+                }
+                return .none
+
+            case .resetChromeColors:
+                state.chromeColorOverrides = [:]
+                userDefaults.setString("", Self.defaultsKeyChromeColors)
                 return .none
 
             case .refreshConfirmQuitWhenActive:

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -461,6 +461,9 @@ struct SettingsFeature {
                         // Read resolved background from ghostty (correct for both theme and custom).
                         GhosttyConfigClient.liveValue.backgroundOpacity = opacity
                         GhosttyConfigClient.liveValue.backgroundColor = newConfig.backgroundColor
+                        // Let the SwiftUI environment re-inject so the markdown /
+                        // scratchpad / diff panes pick up the new background live.
+                        NotificationCenter.default.post(name: GhosttyConfigClient.changedNotification, object: nil)
 
                         // Update window compositing
                         if let window = NSApp.windows.first(where: { $0.isVisible && !($0 is NSPanel) }) {

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -16,6 +16,14 @@ enum SidebarPlacement: String, CaseIterable, Codable, Equatable {
     case endOfList = "end-of-list"
 }
 
+/// Which sidebar fill/stroke opacity a `setSidebarStyle` action targets.
+enum SidebarStyleParam: String, Equatable {
+    case avatarFill
+    case avatarStroke
+    case groupFill
+    case groupStroke
+}
+
 @Reducer
 struct SettingsFeature {
     static let defaultWorktreeBasePath = "~/nex/worktrees/<repo>"
@@ -43,6 +51,12 @@ struct SettingsFeature {
         /// Multiplier on the opacity of the sidebar's WorkspaceColour-tinted
         /// elements (group bands + workspace avatars). 1 = preset intensity.
         var sidebarColorIntensity: Double = 1.0
+        /// Per-element fill/stroke opacities for sidebar groups + icons.
+        /// `groupFill < 0` means "use the per-appearance preset".
+        var sidebarAvatarFillOpacity: Double = 0.20
+        var sidebarAvatarStrokeOpacity: Double = 0.45
+        var sidebarGroupFillOpacity: Double = -1
+        var sidebarGroupStrokeOpacity: Double = 0.0
 
         /// The resolved absolute worktree base path. Expands ~ and substitutes
         /// the `<repo>` placeholder:
@@ -76,6 +90,7 @@ struct SettingsFeature {
         case setChromeColor(key: String, hex: String?)
         case resetChromeColors
         case setSidebarColorIntensity(Double)
+        case setSidebarStyle(SidebarStyleParam, Double)
         case refreshConfirmQuitWhenActive
         case selectTheme(NexTheme?)
         case applyAppearance(opacity: Double, r: Double, g: Double, b: Double, theme: NexTheme?)
@@ -99,6 +114,10 @@ struct SettingsFeature {
     static let defaultsKeyChromeAppearance = "settings.chromeAppearance"
     static let defaultsKeyChromeColors = "settings.chromeColors"
     static let defaultsKeySidebarColorIntensity = "settings.sidebarColorIntensity"
+    static let defaultsKeySidebarAvatarFill = "settings.sidebarAvatarFill"
+    static let defaultsKeySidebarAvatarStroke = "settings.sidebarAvatarStroke"
+    static let defaultsKeySidebarGroupFill = "settings.sidebarGroupFill"
+    static let defaultsKeySidebarGroupStroke = "settings.sidebarGroupStroke"
 
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.userDefaults) var userDefaults
@@ -144,6 +163,18 @@ struct SettingsFeature {
                 }
                 if userDefaults.hasKey(Self.defaultsKeySidebarColorIntensity) {
                     state.sidebarColorIntensity = userDefaults.doubleForKey(Self.defaultsKeySidebarColorIntensity)
+                }
+                if userDefaults.hasKey(Self.defaultsKeySidebarAvatarFill) {
+                    state.sidebarAvatarFillOpacity = userDefaults.doubleForKey(Self.defaultsKeySidebarAvatarFill)
+                }
+                if userDefaults.hasKey(Self.defaultsKeySidebarAvatarStroke) {
+                    state.sidebarAvatarStrokeOpacity = userDefaults.doubleForKey(Self.defaultsKeySidebarAvatarStroke)
+                }
+                if userDefaults.hasKey(Self.defaultsKeySidebarGroupFill) {
+                    state.sidebarGroupFillOpacity = userDefaults.doubleForKey(Self.defaultsKeySidebarGroupFill)
+                }
+                if userDefaults.hasKey(Self.defaultsKeySidebarGroupStroke) {
+                    state.sidebarGroupStrokeOpacity = userDefaults.doubleForKey(Self.defaultsKeySidebarGroupStroke)
                 }
                 if userDefaults.boolForKey(Self.defaultsKeyHasCustomColor) {
                     state.backgroundColorR = userDefaults.doubleForKey(Self.defaultsKeyColorR)
@@ -259,6 +290,23 @@ struct SettingsFeature {
             case .setSidebarColorIntensity(let intensity):
                 state.sidebarColorIntensity = intensity
                 userDefaults.setDouble(intensity, Self.defaultsKeySidebarColorIntensity)
+                return .none
+
+            case .setSidebarStyle(let param, let value):
+                switch param {
+                case .avatarFill:
+                    state.sidebarAvatarFillOpacity = value
+                    userDefaults.setDouble(value, Self.defaultsKeySidebarAvatarFill)
+                case .avatarStroke:
+                    state.sidebarAvatarStrokeOpacity = value
+                    userDefaults.setDouble(value, Self.defaultsKeySidebarAvatarStroke)
+                case .groupFill:
+                    state.sidebarGroupFillOpacity = value
+                    userDefaults.setDouble(value, Self.defaultsKeySidebarGroupFill)
+                case .groupStroke:
+                    state.sidebarGroupStrokeOpacity = value
+                    userDefaults.setDouble(value, Self.defaultsKeySidebarGroupStroke)
+                }
                 return .none
 
             case .refreshConfirmQuitWhenActive:

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -42,8 +42,12 @@ struct SettingsFeature {
         var newGroupPlacement: SidebarPlacement = .endOfList
         var newWorkspacePlacement: SidebarPlacement = .endOfList
         var confirmQuitWhenActive: Bool = true
-        /// Show CPU / memory / load in the bottom status bar.
+        /// Master toggle for the status-bar system stats.
         var showSystemStats: Bool = true
+        /// Which metrics are shown (rawValues of `SystemStatKind`).
+        var enabledSystemStats: Set<String> = ["cpu", "memory", "load"]
+        /// Render an inline sparkline next to each enabled metric.
+        var showSystemStatGraphs: Bool = false
         /// Warm app-chrome palette preference. Drives the sidebar / title bar /
         /// status bar appearance independently of the Ghostty terminal theme.
         var chromeAppearance: ChromeAppearance = .system
@@ -89,6 +93,8 @@ struct SettingsFeature {
         case setNewWorkspacePlacement(SidebarPlacement)
         case setConfirmQuitWhenActive(Bool)
         case setShowSystemStats(Bool)
+        case setSystemStatEnabled(SystemStatKind, Bool)
+        case setShowSystemStatGraphs(Bool)
         case setChromeAppearance(ChromeAppearance)
         case setChromeColor(key: String, hex: String?)
         case resetChromeColors
@@ -115,6 +121,8 @@ struct SettingsFeature {
     static let defaultsKeyNewWorkspacePlacement = "settings.newWorkspacePlacement"
     static let defaultsKeyConfirmQuitWhenActive = QuitGateDefaults.confirmQuit
     static let defaultsKeyShowSystemStats = "settings.showSystemStats"
+    static let defaultsKeyEnabledSystemStats = "settings.enabledSystemStats"
+    static let defaultsKeyShowSystemStatGraphs = "settings.showSystemStatGraphs"
     static let defaultsKeyChromeAppearance = "settings.chromeAppearance"
     static let defaultsKeyChromeColors = "settings.chromeColors"
     static let defaultsKeySidebarColorIntensity = "settings.sidebarColorIntensity"
@@ -158,6 +166,12 @@ struct SettingsFeature {
                 }
                 if userDefaults.hasKey(Self.defaultsKeyShowSystemStats) {
                     state.showSystemStats = userDefaults.boolForKey(Self.defaultsKeyShowSystemStats)
+                }
+                if let raw = userDefaults.stringForKey(Self.defaultsKeyEnabledSystemStats) {
+                    state.enabledSystemStats = Set(raw.split(separator: ",").map(String.init))
+                }
+                if userDefaults.hasKey(Self.defaultsKeyShowSystemStatGraphs) {
+                    state.showSystemStatGraphs = userDefaults.boolForKey(Self.defaultsKeyShowSystemStatGraphs)
                 }
                 if let raw = userDefaults.stringForKey(Self.defaultsKeyChromeAppearance),
                    let appearance = ChromeAppearance(rawValue: raw) {
@@ -270,6 +284,23 @@ struct SettingsFeature {
             case .setShowSystemStats(let enabled):
                 state.showSystemStats = enabled
                 userDefaults.setBool(enabled, Self.defaultsKeyShowSystemStats)
+                return .none
+
+            case .setSystemStatEnabled(let kind, let enabled):
+                if enabled {
+                    state.enabledSystemStats.insert(kind.rawValue)
+                } else {
+                    state.enabledSystemStats.remove(kind.rawValue)
+                }
+                userDefaults.setString(
+                    state.enabledSystemStats.sorted().joined(separator: ","),
+                    Self.defaultsKeyEnabledSystemStats
+                )
+                return .none
+
+            case .setShowSystemStatGraphs(let enabled):
+                state.showSystemStatGraphs = enabled
+                userDefaults.setBool(enabled, Self.defaultsKeyShowSystemStatGraphs)
                 return .none
 
             case .setChromeAppearance(let appearance):

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -48,6 +48,10 @@ struct SettingsFeature {
         var enabledSystemStats: Set<String> = ["cpu", "memory", "load"]
         /// Render an inline sparkline next to each enabled metric.
         var showSystemStatGraphs: Bool = false
+        /// Sparkline colour as `"RRGGBB"`; empty = adaptive chrome default.
+        var sparklineColorHex: String = ""
+        /// Inline sparkline width in points.
+        var sparklineWidth: Double = 28
         /// Warm app-chrome palette preference. Drives the sidebar / title bar /
         /// status bar appearance independently of the Ghostty terminal theme.
         var chromeAppearance: ChromeAppearance = .system
@@ -95,6 +99,8 @@ struct SettingsFeature {
         case setShowSystemStats(Bool)
         case setSystemStatEnabled(SystemStatKind, Bool)
         case setShowSystemStatGraphs(Bool)
+        case setSparklineColor(String)
+        case setSparklineWidth(Double)
         case setChromeAppearance(ChromeAppearance)
         case setChromeColor(key: String, hex: String?)
         case resetChromeColors
@@ -123,6 +129,8 @@ struct SettingsFeature {
     static let defaultsKeyShowSystemStats = "settings.showSystemStats"
     static let defaultsKeyEnabledSystemStats = "settings.enabledSystemStats"
     static let defaultsKeyShowSystemStatGraphs = "settings.showSystemStatGraphs"
+    static let defaultsKeySparklineColor = "settings.sparklineColor"
+    static let defaultsKeySparklineWidth = "settings.sparklineWidth"
     static let defaultsKeyChromeAppearance = "settings.chromeAppearance"
     static let defaultsKeyChromeColors = "settings.chromeColors"
     static let defaultsKeySidebarColorIntensity = "settings.sidebarColorIntensity"
@@ -172,6 +180,12 @@ struct SettingsFeature {
                 }
                 if userDefaults.hasKey(Self.defaultsKeyShowSystemStatGraphs) {
                     state.showSystemStatGraphs = userDefaults.boolForKey(Self.defaultsKeyShowSystemStatGraphs)
+                }
+                if let hex = userDefaults.stringForKey(Self.defaultsKeySparklineColor) {
+                    state.sparklineColorHex = hex
+                }
+                if userDefaults.hasKey(Self.defaultsKeySparklineWidth) {
+                    state.sparklineWidth = userDefaults.doubleForKey(Self.defaultsKeySparklineWidth)
                 }
                 if let raw = userDefaults.stringForKey(Self.defaultsKeyChromeAppearance),
                    let appearance = ChromeAppearance(rawValue: raw) {
@@ -301,6 +315,16 @@ struct SettingsFeature {
             case .setShowSystemStatGraphs(let enabled):
                 state.showSystemStatGraphs = enabled
                 userDefaults.setBool(enabled, Self.defaultsKeyShowSystemStatGraphs)
+                return .none
+
+            case .setSparklineColor(let hex):
+                state.sparklineColorHex = hex
+                userDefaults.setString(hex, Self.defaultsKeySparklineColor)
+                return .none
+
+            case .setSparklineWidth(let width):
+                state.sparklineWidth = width
+                userDefaults.setDouble(width, Self.defaultsKeySparklineWidth)
                 return .none
 
             case .setChromeAppearance(let appearance):

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -40,6 +40,9 @@ struct SettingsFeature {
         /// Per-appearance chrome colour overrides. Keyed `"<light|dark>:<key>"`
         /// (see `ChromeColorKey`) → `"RRGGBB"`. Empty = use the presets.
         var chromeColorOverrides: [String: String] = [:]
+        /// Multiplier on the opacity of the sidebar's WorkspaceColour-tinted
+        /// elements (group bands + workspace avatars). 1 = preset intensity.
+        var sidebarColorIntensity: Double = 1.0
 
         /// The resolved absolute worktree base path. Expands ~ and substitutes
         /// the `<repo>` placeholder:
@@ -72,6 +75,7 @@ struct SettingsFeature {
         case setChromeAppearance(ChromeAppearance)
         case setChromeColor(key: String, hex: String?)
         case resetChromeColors
+        case setSidebarColorIntensity(Double)
         case refreshConfirmQuitWhenActive
         case selectTheme(NexTheme?)
         case applyAppearance(opacity: Double, r: Double, g: Double, b: Double, theme: NexTheme?)
@@ -94,6 +98,7 @@ struct SettingsFeature {
     static let defaultsKeyConfirmQuitWhenActive = QuitGateDefaults.confirmQuit
     static let defaultsKeyChromeAppearance = "settings.chromeAppearance"
     static let defaultsKeyChromeColors = "settings.chromeColors"
+    static let defaultsKeySidebarColorIntensity = "settings.sidebarColorIntensity"
 
     @Dependency(\.surfaceManager) var surfaceManager
     @Dependency(\.userDefaults) var userDefaults
@@ -136,6 +141,9 @@ struct SettingsFeature {
                    let data = json.data(using: .utf8),
                    let dict = try? JSONDecoder().decode([String: String].self, from: data) {
                     state.chromeColorOverrides = dict
+                }
+                if userDefaults.hasKey(Self.defaultsKeySidebarColorIntensity) {
+                    state.sidebarColorIntensity = userDefaults.doubleForKey(Self.defaultsKeySidebarColorIntensity)
                 }
                 if userDefaults.boolForKey(Self.defaultsKeyHasCustomColor) {
                     state.backgroundColorR = userDefaults.doubleForKey(Self.defaultsKeyColorR)
@@ -246,6 +254,11 @@ struct SettingsFeature {
             case .resetChromeColors:
                 state.chromeColorOverrides = [:]
                 userDefaults.setString("", Self.defaultsKeyChromeColors)
+                return .none
+
+            case .setSidebarColorIntensity(let intensity):
+                state.sidebarColorIntensity = intensity
+                userDefaults.setDouble(intensity, Self.defaultsKeySidebarColorIntensity)
                 return .none
 
             case .refreshConfirmQuitWhenActive:

--- a/Nex/Features/Settings/SettingsFeature.swift
+++ b/Nex/Features/Settings/SettingsFeature.swift
@@ -112,6 +112,10 @@ struct SettingsFeature {
         case refreshConfirmQuitWhenActive
         case selectTheme(NexTheme?)
         case applyAppearance(opacity: Double, r: Double, g: Double, b: Double, theme: NexTheme?)
+        /// Apply an imported shareable chrome-style theme: overwrites the colour
+        /// overrides + sidebar + sparkline styling and persists them. Leaves the
+        /// appearance mode and terminal background untouched.
+        case applyStyleTheme(ChromeStyleTheme)
     }
 
     private enum AppearanceDebounceID: Hashable { case debounce }
@@ -366,6 +370,34 @@ struct SettingsFeature {
                 userDefaults.setString("", Self.defaultsKeyChromeColors)
                 return .none
 
+            case .applyStyleTheme(let theme):
+                // Chrome-only, like setChromeColor: overwrite the styling fields
+                // and persist them; the chrome wrappers re-resolve from state.
+                // Appearance mode + terminal background are deliberately left as
+                // the recipient set them.
+                state.chromeColorOverrides = theme.colorOverrides
+                if let data = try? JSONEncoder().encode(theme.colorOverrides),
+                   let json = String(data: data, encoding: .utf8) {
+                    userDefaults.setString(json, Self.defaultsKeyChromeColors)
+                }
+                state.sidebarColorIntensity = theme.sidebarColorIntensity
+                userDefaults.setDouble(theme.sidebarColorIntensity, Self.defaultsKeySidebarColorIntensity)
+                state.sidebarAvatarFillOpacity = theme.sidebarAvatarFillOpacity
+                userDefaults.setDouble(theme.sidebarAvatarFillOpacity, Self.defaultsKeySidebarAvatarFill)
+                state.sidebarAvatarStrokeOpacity = theme.sidebarAvatarStrokeOpacity
+                userDefaults.setDouble(theme.sidebarAvatarStrokeOpacity, Self.defaultsKeySidebarAvatarStroke)
+                state.sidebarGroupFillOpacity = theme.sidebarGroupFillOpacity
+                userDefaults.setDouble(theme.sidebarGroupFillOpacity, Self.defaultsKeySidebarGroupFill)
+                state.sidebarGroupStrokeOpacity = theme.sidebarGroupStrokeOpacity
+                userDefaults.setDouble(theme.sidebarGroupStrokeOpacity, Self.defaultsKeySidebarGroupStroke)
+                state.sparklineColorHex = theme.sparklineColorHex
+                userDefaults.setString(theme.sparklineColorHex, Self.defaultsKeySparklineColor)
+                state.sparklineWidth = theme.sparklineWidth
+                userDefaults.setDouble(theme.sparklineWidth, Self.defaultsKeySparklineWidth)
+                state.sparklineStyle = theme.sparklineStyle
+                userDefaults.setString(theme.sparklineStyle, Self.defaultsKeySparklineStyle)
+                return .none
+
             case .setSidebarColorIntensity(let intensity):
                 state.sidebarColorIntensity = intensity
                 userDefaults.setDouble(intensity, Self.defaultsKeySidebarColorIntensity)
@@ -477,5 +509,26 @@ struct SettingsFeature {
                 }
             }
         }
+    }
+}
+
+extension ChromeStyleTheme {
+    /// Capture the chrome styling currently in `SettingsFeature.State` into a
+    /// shareable theme. `name` becomes the theme's label (set from the file
+    /// name on export).
+    init(capturing state: SettingsFeature.State, name: String? = nil) {
+        self.init(
+            version: Self.currentVersion,
+            name: name,
+            colorOverrides: state.chromeColorOverrides,
+            sidebarColorIntensity: state.sidebarColorIntensity,
+            sidebarAvatarFillOpacity: state.sidebarAvatarFillOpacity,
+            sidebarAvatarStrokeOpacity: state.sidebarAvatarStrokeOpacity,
+            sidebarGroupFillOpacity: state.sidebarGroupFillOpacity,
+            sidebarGroupStrokeOpacity: state.sidebarGroupStrokeOpacity,
+            sparklineColorHex: state.sparklineColorHex,
+            sparklineWidth: state.sparklineWidth,
+            sparklineStyle: state.sparklineStyle
+        )
     }
 }

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -57,6 +57,9 @@ struct SettingsView: View {
             )
             .background(WindowResizabilityModifier())
             .background(chromeTheme.surfaceBackground)
+            // Match the app's header/footer tone on the Settings tab strip.
+            .toolbarBackground(chromeTheme.headerBackground, for: .windowToolbar)
+            .toolbarBackground(.visible, for: .windowToolbar)
             // Listen here too: the main WindowGroup (and ContentView's
             // observer) may be closed while the Settings scene stays
             // open. Without this, the dialog's "Don't ask again" tick
@@ -306,17 +309,11 @@ private struct AppearanceSettingsView: View {
             }
 
             Section("Sidebar") {
-                HStack {
-                    Text("Colour intensity")
-                    Slider(
-                        value: $store.sidebarColorIntensity.sending(\.setSidebarColorIntensity),
-                        in: 0.0 ... 2.0,
-                        step: 0.05
-                    )
-                    Text("\(Int(store.sidebarColorIntensity * 100))%")
-                        .monospacedDigit()
-                        .frame(width: 44, alignment: .trailing)
-                }
+                sliderRow(
+                    "Colour intensity",
+                    value: $store.sidebarColorIntensity.sending(\.setSidebarColorIntensity),
+                    in: 0.0 ... 2.0
+                )
                 Text("Scales how vivid the group bands and workspace avatars are.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -354,17 +351,11 @@ private struct AppearanceSettingsView: View {
                     )
                 }
 
-                HStack {
-                    Text("Background Opacity")
-                    Slider(
-                        value: $store.backgroundOpacity.sending(\.setBackgroundOpacity),
-                        in: 0.1 ... 1.0,
-                        step: 0.05
-                    )
-                    Text("\(Int(store.backgroundOpacity * 100))%")
-                        .monospacedDigit()
-                        .frame(width: 40, alignment: .trailing)
-                }
+                sliderRow(
+                    "Background Opacity",
+                    value: $store.backgroundOpacity.sending(\.setBackgroundOpacity),
+                    in: 0.1 ... 1.0
+                )
             }
         }
         .formStyle(.grouped)
@@ -380,14 +371,21 @@ private struct AppearanceSettingsView: View {
     }
 
     private func opacityRow(_ label: String, _ param: SidebarStyleParam, _ value: Double) -> some View {
-        HStack {
+        sliderRow(
+            label,
+            value: Binding(get: { value }, set: { store.send(.setSidebarStyle(param, $0)) }),
+            in: 0.0 ... 1.0
+        )
+    }
+
+    /// Uniform slider row: fixed-width label + slider + fixed-width percent, so
+    /// every slider in the Appearance tab lines up and is the same length.
+    private func sliderRow(_ label: String, value: Binding<Double>, in range: ClosedRange<Double>) -> some View {
+        HStack(spacing: 10) {
             Text(label)
-            Slider(
-                value: Binding(get: { value }, set: { store.send(.setSidebarStyle(param, $0)) }),
-                in: 0.0 ... 1.0,
-                step: 0.05
-            )
-            Text("\(Int(value * 100))%")
+                .frame(width: 140, alignment: .leading)
+            Slider(value: value, in: range, step: 0.05)
+            Text("\(Int((value.wrappedValue * 100).rounded()))%")
                 .monospacedDigit()
                 .frame(width: 44, alignment: .trailing)
         }

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     let store: StoreOf<AppReducer>
 
     @State private var selectedTab: SettingsTab = .general
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         WithPerceptionTracking {
@@ -55,6 +56,7 @@ struct SettingsView: View {
                 minHeight: 440, idealHeight: 520, maxHeight: .infinity
             )
             .background(WindowResizabilityModifier())
+            .background(chromeTheme.surfaceBackground)
             // Listen here too: the main WindowGroup (and ContentView's
             // observer) may be closed while the Settings scene stays
             // open. Without this, the dialog's "Don't ask again" tick
@@ -105,6 +107,7 @@ private struct WindowResizabilityModifier: NSViewRepresentable {
 private struct GeneralSettingsView: View {
     let appStore: StoreOf<AppReducer>
     @State private var tcpPortText: String = ""
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         WithPerceptionTracking {
@@ -252,6 +255,8 @@ private struct GeneralSettingsView: View {
                 }
             }
             .formStyle(.grouped)
+            .scrollContentBackground(.hidden)
+            .background(chromeTheme.surfaceBackground)
         }
     }
 }
@@ -259,10 +264,27 @@ private struct GeneralSettingsView: View {
 /// Appearance settings tab (extracted from original SettingsView).
 private struct AppearanceSettingsView: View {
     @Bindable var store: StoreOf<SettingsFeature>
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         Form {
-            Section("Appearance") {
+            Section("Chrome") {
+                Picker(
+                    "Appearance",
+                    selection: $store.chromeAppearance.sending(\.setChromeAppearance)
+                ) {
+                    ForEach(ChromeAppearance.allCases, id: \.self) { appearance in
+                        Text(appearance.displayName).tag(appearance)
+                    }
+                }
+                .pickerStyle(.segmented)
+                Text("Themes the Nex window chrome (sidebar, title bar, status bar). "
+                    + "Independent of the terminal theme below.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Terminal") {
                 Picker("Theme", selection: themeBinding) {
                     Text("None (Custom)").tag(NexTheme?.none)
                     ForEach(NexTheme.builtIn) { theme in
@@ -292,6 +314,8 @@ private struct AppearanceSettingsView: View {
             }
         }
         .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .background(chromeTheme.surfaceBackground)
     }
 
     private var themeBinding: Binding<NexTheme?> {
@@ -326,6 +350,7 @@ private struct AppearanceSettingsView: View {
 private struct WebFavouritesSettingsView: View {
     let store: StoreOf<AppReducer>
     @State private var selection: Favourite.ID?
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         WithPerceptionTracking {
@@ -364,9 +389,11 @@ private struct WebFavouritesSettingsView: View {
                         }
                     }
                     .listStyle(.inset)
+                    .scrollContentBackground(.hidden)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(chromeTheme.surfaceBackground)
         }
     }
 }

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ComposableArchitecture
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Identifier for the Settings TabView's tabs, used for deep-linking
 /// from the web pane's "Manage favourites…" menu.
@@ -321,9 +322,33 @@ private struct AppearanceSettingsView: View {
     /// Resolved scheme inside the (themed) Settings scene — tells us which
     /// light/dark override bucket the colour pickers edit.
     @Environment(\.colorScheme) private var systemScheme
+    /// Transient feedback for the Theme export/import/copy/paste actions.
+    @State private var themeStatus: String?
 
     var body: some View {
         Form {
+            Section("Theme") {
+                HStack {
+                    Button("Export…") { exportTheme() }
+                    Button("Import…") { importTheme() }
+                    Spacer()
+                    Button("Copy Code") { copyThemeCode() }
+                    Button("Paste Code") { pasteThemeCode() }
+                }
+                if let themeStatus {
+                    Text(themeStatus)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Save your custom chrome colours and sidebar styling as a "
+                        + "shareable .nextheme file or a copyable code. Importing restyles "
+                        + "the chrome without changing your light/dark mode or terminal "
+                        + "background.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Section("Chrome") {
                 Picker(
                     "Appearance",
@@ -489,6 +514,76 @@ private struct AppearanceSettingsView: View {
                 }
             }
         )
+    }
+
+    // MARK: - Theme export / import
+
+    /// The chrome styling currently in settings, captured into a shareable theme.
+    private func currentTheme(name: String? = nil) -> ChromeStyleTheme {
+        store.withState { ChromeStyleTheme(capturing: $0, name: name) }
+    }
+
+    private static let themeUTType = UTType(filenameExtension: "nextheme") ?? .json
+
+    private func exportTheme() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [Self.themeUTType]
+        panel.nameFieldStringValue = "MyTheme.nextheme"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let name = url.deletingPathExtension().lastPathComponent
+        do {
+            try currentTheme(name: name).jsonData().write(to: url)
+            themeStatus = "Exported \u{201C}\(name)\u{201D}."
+        } catch {
+            themeStatus = "Export failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func importTheme() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = [Self.themeUTType, .json]
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            let theme = try ChromeStyleTheme(jsonData: Data(contentsOf: url))
+            store.send(.applyStyleTheme(theme))
+            let label = theme.name ?? url.deletingPathExtension().lastPathComponent
+            themeStatus = "Imported \u{201C}\(label)\u{201D}."
+        } catch let error as ChromeStyleThemeError {
+            themeStatus = error.message
+        } catch {
+            themeStatus = "Import failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func copyThemeCode() {
+        do {
+            let code = try currentTheme().shareCode()
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(code, forType: .string)
+            themeStatus = "Theme code copied to the clipboard."
+        } catch {
+            themeStatus = "Couldn't generate a theme code."
+        }
+    }
+
+    private func pasteThemeCode() {
+        guard let code = NSPasteboard.general.string(forType: .string),
+              !code.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            themeStatus = "The clipboard has no theme code to paste."
+            return
+        }
+        do {
+            let theme = try ChromeStyleTheme(shareCode: code)
+            store.send(.applyStyleTheme(theme))
+            themeStatus = "Imported theme from the clipboard" + (theme.name.map { " (\u{201C}\($0)\u{201D})" } ?? "") + "."
+        } catch let error as ChromeStyleThemeError {
+            themeStatus = error.message
+        } catch {
+            themeStatus = "That clipboard text isn't a Nex theme."
+        }
     }
 }
 

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -341,7 +341,7 @@ private struct AppearanceSettingsView: View {
             }
 
             Section("Chrome Colours") {
-                ForEach(ChromeColorKey.allCases) { key in
+                ForEach(ChromeColorKey.allCases.filter { !$0.isAgentStatus }) { key in
                     ColorPicker(
                         key.displayName,
                         selection: chromeColorBinding(key),
@@ -356,6 +356,20 @@ private struct AppearanceSettingsView: View {
                     Spacer()
                     Button("Reset") { store.send(.resetChromeColors) }
                 }
+            }
+
+            Section("Agent status") {
+                ForEach(ChromeColorKey.allCases.filter(\.isAgentStatus)) { key in
+                    ColorPicker(
+                        key.displayName,
+                        selection: chromeColorBinding(key),
+                        supportsOpacity: false
+                    )
+                }
+                Text("The dot / badge colour shown for each agent state across the "
+                    + "status bar, sidebar, pane headers, title bar and menu-bar icon.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Sidebar") {

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -305,6 +305,23 @@ private struct AppearanceSettingsView: View {
                 }
             }
 
+            Section("Sidebar") {
+                HStack {
+                    Text("Colour intensity")
+                    Slider(
+                        value: $store.sidebarColorIntensity.sending(\.setSidebarColorIntensity),
+                        in: 0.0 ... 2.0,
+                        step: 0.05
+                    )
+                    Text("\(Int(store.sidebarColorIntensity * 100))%")
+                        .monospacedDigit()
+                        .frame(width: 44, alignment: .trailing)
+                }
+                Text("Scales how vivid the group bands and workspace avatars are.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Terminal") {
                 Picker("Theme", selection: themeBinding) {
                     Text("None (Custom)").tag(NexTheme?.none)

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -325,9 +325,26 @@ private struct AppearanceSettingsView: View {
     /// Transient feedback for the Theme export/import/copy/paste actions.
     @State private var themeStatus: String?
 
+    private let presetColumns = [GridItem(.adaptive(minimum: 132), spacing: 10)]
+
     var body: some View {
         Form {
-            Section("Theme") {
+            Section("Preset Themes") {
+                LazyVGrid(columns: presetColumns, spacing: 12) {
+                    ForEach(BuiltInChromeTheme.all) { preset in
+                        presetCell(preset)
+                    }
+                }
+                .padding(.vertical, 4)
+                Text("One-click chrome palettes based on popular editor themes. Each "
+                    + "recolours the sidebar, title bar, status bar and agent dots, and "
+                    + "switches Light/Dark to suit. Your terminal theme is unchanged; "
+                    + "tweak any colour below afterwards.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Save & Share") {
                 HStack {
                     Button("Export…") { exportTheme() }
                     Button("Import…") { importTheme() }
@@ -516,6 +533,32 @@ private struct AppearanceSettingsView: View {
         )
     }
 
+    // MARK: - Preset themes
+
+    private func presetCell(_ preset: BuiltInChromeTheme) -> some View {
+        Button {
+            applyPreset(preset)
+        } label: {
+            VStack(spacing: 5) {
+                ThemeSwatch(palette: preset.palette)
+                Text(preset.name)
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .buttonStyle(.plain)
+        .help("Apply the \(preset.name) theme (\(preset.appearance.displayName))")
+    }
+
+    private func applyPreset(_ preset: BuiltInChromeTheme) {
+        // Switch to the palette's native mode, then overwrite the styling.
+        store.send(.setChromeAppearance(preset.appearance))
+        store.send(.applyStyleTheme(preset.styleTheme))
+        themeStatus = "Applied \u{201C}\(preset.name)\u{201D} (\(preset.appearance.displayName))."
+    }
+
     // MARK: - Theme export / import
 
     /// The chrome styling currently in settings, captured into a shareable theme.
@@ -584,6 +627,56 @@ private struct AppearanceSettingsView: View {
         } catch {
             themeStatus = "That clipboard text isn't a Nex theme."
         }
+    }
+}
+
+/// A compact mock of the chrome — sidebar strip, header bar and three agent
+/// status dots — painted in a preset's palette, so the gallery previews how a
+/// theme actually looks before it's applied.
+private struct ThemeSwatch: View {
+    let palette: ChromePalette
+
+    private func color(_ hex: String) -> Color {
+        Color(chromeHex: hex) ?? .gray
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Sidebar: an accent pill + two muted "rows".
+            VStack(alignment: .leading, spacing: 4) {
+                Capsule().fill(color(palette.accent)).frame(width: 18, height: 4)
+                Capsule().fill(color(palette.divider)).frame(width: 13, height: 3)
+                Capsule().fill(color(palette.divider)).frame(width: 15, height: 3)
+                Spacer(minLength: 0)
+            }
+            .padding(6)
+            .frame(width: 38, alignment: .topLeading)
+            .frame(maxHeight: .infinity)
+            .background(color(palette.sidebarBackground))
+
+            // Main: a header strip over the surface, with three status dots.
+            VStack(spacing: 0) {
+                Rectangle().fill(color(palette.headerBackground)).frame(height: 10)
+                HStack(spacing: 4) {
+                    Circle().fill(color(palette.statusRunning)).frame(width: 5, height: 5)
+                    Circle().fill(color(palette.statusWaiting)).frame(width: 5, height: 5)
+                    Circle().fill(color(palette.statusInactive)).frame(width: 5, height: 5)
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 5)
+                .padding(.top, 5)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(color(palette.surfaceBackground))
+        }
+        .frame(height: 46)
+        .background(color(palette.windowBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(color(palette.divider), lineWidth: 1)
+        )
     }
 }
 

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -322,6 +322,22 @@ private struct AppearanceSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Sidebar fill & stroke") {
+                opacityRow("Avatar fill", .avatarFill, store.sidebarAvatarFillOpacity)
+                opacityRow("Avatar border", .avatarStroke, store.sidebarAvatarStrokeOpacity)
+                opacityRow(
+                    "Group band fill",
+                    .groupFill,
+                    store.sidebarGroupFillOpacity < 0
+                        ? chromeTheme.groupBandOpacity
+                        : store.sidebarGroupFillOpacity
+                )
+                opacityRow("Group band border", .groupStroke, store.sidebarGroupStrokeOpacity)
+                Text("Fill = colour wash, border = outline. The intensity above multiplies these.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Terminal") {
                 Picker("Theme", selection: themeBinding) {
                     Text("None (Custom)").tag(NexTheme?.none)
@@ -361,6 +377,20 @@ private struct AppearanceSettingsView: View {
             get: { store.selectedTheme },
             set: { store.send(.selectTheme($0)) }
         )
+    }
+
+    private func opacityRow(_ label: String, _ param: SidebarStyleParam, _ value: Double) -> some View {
+        HStack {
+            Text(label)
+            Slider(
+                value: Binding(get: { value }, set: { store.send(.setSidebarStyle(param, $0)) }),
+                in: 0.0 ... 1.0,
+                step: 0.05
+            )
+            Text("\(Int(value * 100))%")
+                .monospacedDigit()
+                .frame(width: 44, alignment: .trailing)
+        }
     }
 
     /// Two-way binding for one customisable chrome colour. Reads the resolved

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -265,6 +265,9 @@ private struct GeneralSettingsView: View {
 private struct AppearanceSettingsView: View {
     @Bindable var store: StoreOf<SettingsFeature>
     @Environment(\.chromeTheme) private var chromeTheme
+    /// Resolved scheme inside the (themed) Settings scene — tells us which
+    /// light/dark override bucket the colour pickers edit.
+    @Environment(\.colorScheme) private var systemScheme
 
     var body: some View {
         Form {
@@ -282,6 +285,24 @@ private struct AppearanceSettingsView: View {
                     + "Independent of the terminal theme below.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+
+            Section("Chrome Colours") {
+                ForEach(ChromeColorKey.allCases) { key in
+                    ColorPicker(
+                        key.displayName,
+                        selection: chromeColorBinding(key),
+                        supportsOpacity: false
+                    )
+                }
+                HStack {
+                    Text("Editing the \(systemScheme == .dark ? "Dark" : "Light") palette — "
+                        + "switch Appearance above to edit the other.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Reset") { store.send(.resetChromeColors) }
+                }
             }
 
             Section("Terminal") {
@@ -322,6 +343,21 @@ private struct AppearanceSettingsView: View {
         Binding(
             get: { store.selectedTheme },
             set: { store.send(.selectTheme($0)) }
+        )
+    }
+
+    /// Two-way binding for one customisable chrome colour. Reads the resolved
+    /// value (override or preset) and writes the override into the bucket for
+    /// the appearance currently shown.
+    private func chromeColorBinding(_ key: ChromeColorKey) -> Binding<Color> {
+        let storageKey = "\(systemScheme == .dark ? "dark" : "light"):\(key.rawValue)"
+        return Binding(
+            get: { key.value(in: chromeTheme) },
+            set: { newColor in
+                if let hex = newColor.chromeHexString {
+                    store.send(.setChromeColor(key: storageKey, hex: hex))
+                }
+            }
         )
     }
 

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -205,11 +205,26 @@ private struct GeneralSettingsView: View {
                 }
 
                 Section("Status bar") {
-                    Toggle("Show system stats (CPU / memory / load)", isOn: Binding(
+                    Toggle("Show system stats", isOn: Binding(
                         get: { settingsStore.showSystemStats },
                         set: { settingsStore.send(.setShowSystemStats($0)) }
                     ))
-                    Text("Show live system-wide CPU usage, memory used, and the 1-minute load average on the right of the bottom status bar.")
+                    if settingsStore.showSystemStats {
+                        ForEach(SystemStatKind.allCases) { kind in
+                            Toggle(isOn: Binding(
+                                get: { settingsStore.enabledSystemStats.contains(kind.rawValue) },
+                                set: { settingsStore.send(.setSystemStatEnabled(kind, $0)) }
+                            )) {
+                                Label(kind.displayName, systemImage: kind.systemImage)
+                            }
+                            .padding(.leading, 16)
+                        }
+                        Toggle("Show mini graphs", isOn: Binding(
+                            get: { settingsStore.showSystemStatGraphs },
+                            set: { settingsStore.send(.setShowSystemStatGraphs($0)) }
+                        ))
+                    }
+                    Text("Live system metrics on the right of the bottom status bar. Hover any metric for a detail graph over time.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -219,10 +219,27 @@ private struct GeneralSettingsView: View {
                             }
                             .padding(.leading, 16)
                         }
-                        Toggle("Show mini graphs", isOn: Binding(
-                            get: { settingsStore.showSystemStatGraphs },
-                            set: { settingsStore.send(.setShowSystemStatGraphs($0)) }
-                        ))
+                        DisclosureGroup("Mini graphs") {
+                            Toggle("Show mini graphs", isOn: Binding(
+                                get: { settingsStore.showSystemStatGraphs },
+                                set: { settingsStore.send(.setShowSystemStatGraphs($0)) }
+                            ))
+                            ColorPicker("Graph colour", selection: Binding(
+                                get: { Color(chromeHex: settingsStore.sparklineColorHex) ?? chromeTheme.textSecondary },
+                                set: { if let hex = $0.chromeHexString { settingsStore.send(.setSparklineColor(hex)) } }
+                            ), supportsOpacity: false)
+                            HStack {
+                                Text("Graph width")
+                                Slider(value: Binding(
+                                    get: { settingsStore.sparklineWidth },
+                                    set: { settingsStore.send(.setSparklineWidth($0)) }
+                                ), in: 16 ... 80, step: 2)
+                                Text("\(Int(settingsStore.sparklineWidth))")
+                                    .monospacedDigit()
+                                    .frame(width: 32, alignment: .trailing)
+                            }
+                            Button("Reset graph colour") { settingsStore.send(.setSparklineColor("")) }
+                        }
                     }
                     Text("Live system metrics on the right of the bottom status bar. Hover any metric for a detail graph over time.")
                         .font(.caption)

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -204,6 +204,16 @@ private struct GeneralSettingsView: View {
                     }
                 }
 
+                Section("Status bar") {
+                    Toggle("Show system stats (CPU / memory / load)", isOn: Binding(
+                        get: { settingsStore.showSystemStats },
+                        set: { settingsStore.send(.setShowSystemStats($0)) }
+                    ))
+                    Text("Show live system-wide CPU usage, memory used, and the 1-minute load average on the right of the bottom status bar.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
                 Section("Quit") {
                     Toggle("Confirm before quitting", isOn: Binding(
                         get: { settingsStore.confirmQuitWhenActive },

--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -224,6 +224,14 @@ private struct GeneralSettingsView: View {
                                 get: { settingsStore.showSystemStatGraphs },
                                 set: { settingsStore.send(.setShowSystemStatGraphs($0)) }
                             ))
+                            Picker("Graph style", selection: Binding(
+                                get: { SparklineStyle(rawValue: settingsStore.sparklineStyle) ?? .line },
+                                set: { settingsStore.send(.setSparklineStyle($0.rawValue)) }
+                            )) {
+                                ForEach(SparklineStyle.allCases) { style in
+                                    Text(style.displayName).tag(style)
+                                }
+                            }
                             ColorPicker("Graph colour", selection: Binding(
                                 get: { Color(chromeHex: settingsStore.sparklineColorHex) ?? chromeTheme.textSecondary },
                                 set: { if let hex = $0.chromeHexString { settingsStore.send(.setSparklineColor(hex)) } }

--- a/Nex/Features/StatusBar/StatusBarController.swift
+++ b/Nex/Features/StatusBar/StatusBarController.swift
@@ -21,6 +21,11 @@ final class StatusBarController: NSObject, @unchecked Sendable {
     private nonisolated(unsafe) var waitingCount: Int = 0
     private nonisolated(unsafe) var runningCount: Int = 0
     private nonisolated(unsafe) var items: [StatusBarItem] = []
+    // Configurable agent-status colours, resolved from the chrome theme. The
+    // menu-bar dot and the popover use these instead of system blue/green so
+    // they match the in-app status colours.
+    private nonisolated(unsafe) var waitingColor: Color = .blue
+    private nonisolated(unsafe) var runningColor: Color = .green
 
     nonisolated(unsafe) var onSelectPane: ((UUID, UUID) -> Void)?
 
@@ -34,10 +39,18 @@ final class StatusBarController: NSObject, @unchecked Sendable {
     }
 
     @MainActor
-    func update(waitingCount: Int, runningCount: Int, items: [StatusBarItem]) {
+    func update(
+        waitingCount: Int,
+        runningCount: Int,
+        items: [StatusBarItem],
+        waitingColor: Color = .blue,
+        runningColor: Color = .green
+    ) {
         self.waitingCount = waitingCount
         self.runningCount = runningCount
         self.items = items
+        self.waitingColor = waitingColor
+        self.runningColor = runningColor
         updateIcon()
 
         // Update popover content if visible
@@ -54,6 +67,8 @@ final class StatusBarController: NSObject, @unchecked Sendable {
         let size = NSSize(width: 18, height: 18)
         let waiting = waitingCount
         let running = runningCount
+        let waitingFill = waitingColor
+        let runningFill = runningColor
 
         let image = NSImage(size: size, flipped: false) { rect in
             // Draw terminal icon
@@ -77,7 +92,7 @@ final class StatusBarController: NSObject, @unchecked Sendable {
                     width: dotSize,
                     height: dotSize
                 )
-                NSColor.systemBlue.setFill()
+                NSColor(waitingFill).setFill()
                 NSBezierPath(ovalIn: dotRect).fill()
             } else if running > 0 {
                 let dotSize: CGFloat = 6
@@ -87,7 +102,7 @@ final class StatusBarController: NSObject, @unchecked Sendable {
                     width: dotSize,
                     height: dotSize
                 )
-                NSColor.systemGreen.setFill()
+                NSColor(runningFill).setFill()
                 NSBezierPath(ovalIn: dotRect).fill()
             }
 
@@ -135,7 +150,11 @@ final class StatusBarController: NSObject, @unchecked Sendable {
         let currentItems = items
         let callback = onSelectPane
         let hostingView = NSHostingView(
-            rootView: StatusBarPopoverView(items: currentItems) { paneID, workspaceID in
+            rootView: StatusBarPopoverView(
+                items: currentItems,
+                waitingColor: waitingColor,
+                runningColor: runningColor
+            ) { paneID, workspaceID in
                 callback?(paneID, workspaceID)
                 target?.performClose(nil)
             }

--- a/Nex/Features/StatusBar/StatusBarPopoverView.swift
+++ b/Nex/Features/StatusBar/StatusBarPopoverView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct StatusBarPopoverView: View {
     let items: [StatusBarItem]
+    var waitingColor: Color = .blue
+    var runningColor: Color = .green
     let onSelectPane: (UUID, UUID) -> Void
 
     private var groupedItems: [(workspaceName: String, workspaceColor: WorkspaceColor, panes: [StatusBarItem])] {
@@ -91,17 +93,17 @@ struct StatusBarPopoverView: View {
         switch status {
         case .waitingForInput:
             Circle()
-                .fill(.blue)
+                .fill(waitingColor)
                 .frame(width: 8, height: 8)
                 .overlay(
                     Circle()
-                        .fill(.blue.opacity(0.4))
+                        .fill(waitingColor.opacity(0.4))
                         .frame(width: 12, height: 12)
                         .pulse()
                 )
         case .running:
             Circle()
-                .fill(.green)
+                .fill(runningColor)
                 .frame(width: 8, height: 8)
         case .idle:
             EmptyView()

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -31,6 +31,16 @@ struct StatusBarView: View {
     /// ~2 minutes of history at the 2s sample cadence.
     private static let historyLength = 60
 
+    /// Resolved sparkline colour: the user's custom hex, else the adaptive
+    /// chrome default.
+    private var sparklineColor: Color {
+        if !store.settings.sparklineColorHex.isEmpty,
+           let custom = Color(chromeHex: store.settings.sparklineColorHex) {
+            return custom
+        }
+        return theme.textSecondary
+    }
+
     /// Metrics to show: the user's enabled set, in canonical order, gated by
     /// the master toggle.
     private var enabledStatKinds: [SystemStatKind] {
@@ -135,7 +145,9 @@ struct StatusBarView: View {
                         kind: kind,
                         stats: systemStats,
                         history: history[kind] ?? [],
-                        showGraph: store.settings.showSystemStatGraphs
+                        showGraph: store.settings.showSystemStatGraphs,
+                        graphColor: sparklineColor,
+                        graphWidth: CGFloat(store.settings.sparklineWidth)
                     )
                 }
                 separator

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -25,6 +25,18 @@ struct StatusBarView: View {
     /// View-layer system-stats poller; never dispatches into TCA.
     @State private var statsSampler = SystemStatsSampler()
     @State private var systemStats = SystemStats.zero
+    /// Rolling per-metric history for the sparklines + hover graphs.
+    @State private var history: [SystemStatKind: [Double]] = [:]
+
+    /// ~2 minutes of history at the 2s sample cadence.
+    private static let historyLength = 60
+
+    /// Metrics to show: the user's enabled set, in canonical order, gated by
+    /// the master toggle.
+    private var enabledStatKinds: [SystemStatKind] {
+        guard store.settings.showSystemStats else { return [] }
+        return SystemStatKind.allCases.filter { store.settings.enabledSystemStats.contains($0.rawValue) }
+    }
 
     var body: some View {
         WithPerceptionTracking {
@@ -41,14 +53,25 @@ struct StatusBarView: View {
             .frame(height: 24)
             .background(theme.footerBackground)
             .overlay(alignment: .top) { theme.divider.frame(height: 1) }
-            .onAppear {
-                if store.settings.showSystemStats { systemStats = statsSampler.sample() }
-            }
+            .onAppear { if store.settings.showSystemStats { recordSample() } }
             // 2s cadence: cheap host_statistics calls, smoother than 1s. The
             // gate skips work entirely when the footer stats are disabled.
             .onReceive(Timer.publish(every: 2, on: .main, in: .common).autoconnect()) { _ in
-                if store.settings.showSystemStats { systemStats = statsSampler.sample() }
+                if store.settings.showSystemStats { recordSample() }
             }
+        }
+    }
+
+    /// Sample all metrics and append each scalar to its capped history ring, so
+    /// a metric's sparkline is already populated when the user enables it.
+    private func recordSample() {
+        let snapshot = statsSampler.sample()
+        systemStats = snapshot
+        for kind in SystemStatKind.allCases {
+            var series = history[kind] ?? []
+            series.append(kind.scalar(snapshot))
+            if series.count > Self.historyLength { series.removeFirst(series.count - Self.historyLength) }
+            history[kind] = series
         }
     }
 
@@ -105,8 +128,16 @@ struct StatusBarView: View {
 
     private func rightSection(_ summary: ChromeStatusSummary) -> some View {
         HStack(spacing: 8) {
-            if store.settings.showSystemStats {
-                statsSection(systemStats)
+            let kinds = enabledStatKinds
+            if !kinds.isEmpty {
+                ForEach(kinds) { kind in
+                    SystemStatGauge(
+                        kind: kind,
+                        stats: systemStats,
+                        history: history[kind] ?? [],
+                        showGraph: store.settings.showSystemStatGraphs
+                    )
+                }
                 separator
             }
             countItem(color: theme.statusRunning, value: summary.running, label: "running")
@@ -122,36 +153,6 @@ struct StatusBarView: View {
         }
         .lineLimit(1)
         .fixedSize()
-    }
-
-    /// CPU / memory / load triad. Each value is monospaced so it doesn't
-    /// jitter the layout as it ticks; the tooltip carries the precise numbers.
-    private func statsSection(_ stats: SystemStats) -> some View {
-        HStack(spacing: 8) {
-            statItem("cpu", "\(Int(stats.cpuPercent.rounded()))%")
-            statItem("memorychip", "\(Int(stats.memPercent.rounded()))%")
-            statItem("gauge.with.dots.needle.33percent", String(format: "%.2f", stats.loadAverage1m))
-        }
-        .help("CPU \(Int(stats.cpuPercent.rounded()))% · "
-            + "Memory \(memoryLabel(stats)) · "
-            + "Load \(String(format: "%.2f", stats.loadAverage1m))")
-    }
-
-    private func statItem(_ systemImage: String, _ text: String) -> some View {
-        HStack(spacing: 3) {
-            Image(systemName: systemImage).font(.system(size: 9))
-            Text(text).monospacedDigit()
-        }
-        .foregroundStyle(theme.textTertiary)
-    }
-
-    private func memoryLabel(_ stats: SystemStats) -> String {
-        let gib = 1_073_741_824.0
-        return String(
-            format: "%.1f / %.0f GB",
-            Double(stats.memUsedBytes) / gib,
-            Double(stats.memTotalBytes) / gib
-        )
     }
 
     private func countItem(color: Color, value: Int, label: String) -> some View {

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct ChromeStatusSummary: Equatable {
     var running = 0
     var waiting = 0
-    var done = 0
+    var inactive = 0
 }
 
 /// Bottom status bar: focused-pane context (cwd · branch · agent · elapsed)
@@ -154,7 +154,7 @@ struct StatusBarView: View {
             }
             StatusCountItem(store: store, kind: .running, color: theme.statusRunning, value: summary.running)
             StatusCountItem(store: store, kind: .waiting, color: theme.statusWaiting, value: summary.waiting)
-            StatusCountItem(store: store, kind: .done, color: theme.statusDone, value: summary.done)
+            StatusCountItem(store: store, kind: .inactive, color: theme.statusInactive, value: summary.inactive)
             TimelineView(.periodic(from: .now, by: 1)) { context in
                 Text(context.date, format: .dateTime.hour().minute())
                     .monospacedDigit()
@@ -167,13 +167,22 @@ struct StatusBarView: View {
 
 /// The three agent states surfaced in the footer's right-hand counts.
 enum AgentStatusKind: Equatable {
-    case running, waiting, done
+    case running, waiting, inactive
+
+    /// The pane status this kind lists (inactive = an attached but idle agent).
+    func matches(_ pane: Pane) -> Bool {
+        switch self {
+        case .running: pane.status == .running
+        case .waiting: pane.status == .waitingForInput
+        case .inactive: pane.agentSessionID != nil && pane.status == .idle
+        }
+    }
 
     var label: String {
         switch self {
         case .running: "running"
         case .waiting: "waiting"
-        case .done: "done"
+        case .inactive: "inactive"
         }
     }
 
@@ -181,7 +190,7 @@ enum AgentStatusKind: Equatable {
         switch self {
         case .running: "Running agents"
         case .waiting: "Awaiting input"
-        case .done: "Completed"
+        case .inactive: "Inactive agents"
         }
     }
 }
@@ -197,9 +206,9 @@ struct AgentPaneRef: Identifiable {
 }
 
 /// A footer count (dot · number · label). When there are panes in this state
-/// (running / waiting), a click opens a popover listing them; selecting one
-/// switches to its workspace and focuses it. `.done` is a session counter with
-/// no live panes, and a 0-count item is inert (plain, non-interactive).
+/// (running / waiting / inactive) a click opens a popover listing them;
+/// selecting one switches to its workspace and focuses it. A 0-count item is
+/// inert (plain, non-interactive).
 struct StatusCountItem: View {
     let store: StoreOf<AppReducer>
     let kind: AgentStatusKind
@@ -210,9 +219,8 @@ struct StatusCountItem: View {
 
     var body: some View {
         // Any non-zero count opens a detail popover; 0-count items stay plain
-        // (un-dimmed, non-clickable). Running/waiting rows navigate to the live
-        // pane; done lists the recently-finished agents (nothing to navigate
-        // to), so its rows are read-only.
+        // (un-dimmed, non-clickable). Every kind lists live panes and a row
+        // click jumps to that pane.
         if value > 0 {
             Button { showingDetail = true } label: { countLabel }
                 .buttonStyle(.plain)
@@ -221,10 +229,8 @@ struct StatusCountItem: View {
                     AgentStatusDetailPopover(
                         kind: kind,
                         color: color,
-                        count: value,
                         panes: panes,
-                        completed: completed,
-                        onSelect: kind == .done ? nil : { ref in
+                        onSelect: { ref in
                             navigate(to: ref)
                             showingDetail = false
                         }
@@ -261,19 +267,11 @@ struct StatusCountItem: View {
         }
     }
 
-    /// Recently-finished agents for the `.done` popover (newest first), else [].
-    private var completed: [CompletedAgent] {
-        kind == .done ? store.completedAgents : []
-    }
-
-    /// Panes currently in this state (empty for `.done`). Read lazily when the
-    /// popover opens.
+    /// Live panes in this state. Read lazily when the popover opens.
     private var panes: [AgentPaneRef] {
-        guard kind != .done else { return [] }
-        let target: PaneStatus = kind == .running ? .running : .waitingForInput
-        return store.workspaces.flatMap { workspace in
+        store.workspaces.flatMap { workspace in
             workspace.panes
-                .filter { $0.status == target }
+                .filter { kind.matches($0) }
                 .map { pane in
                     AgentPaneRef(
                         id: pane.id,
@@ -290,14 +288,11 @@ struct StatusCountItem: View {
 
 /// Popover for a footer agent count: a titled list of the panes in that state
 /// (workspace · pane · live elapsed for running). When `onSelect` is provided
-/// each row is a button that jumps to that pane. `.done` shows the session
-/// total instead (nothing to navigate to).
+/// each row is a button that jumps to that pane.
 struct AgentStatusDetailPopover: View {
     let kind: AgentStatusKind
     let color: Color
-    let count: Int
     let panes: [AgentPaneRef]
-    var completed: [CompletedAgent] = []
     var onSelect: ((AgentPaneRef) -> Void)?
     @Environment(\.chromeTheme) private var theme
 
@@ -311,23 +306,7 @@ struct AgentStatusDetailPopover: View {
             }
             .padding(.bottom, 2)
 
-            if kind == .done {
-                Text("\(count) completed this session")
-                    .font(.system(size: 11))
-                    .foregroundStyle(theme.textTertiary)
-                if !completed.isEmpty {
-                    VStack(alignment: .leading, spacing: 2) {
-                        ForEach(Array(completed.prefix(12).enumerated()), id: \.offset) { _, agent in
-                            completedRow(agent)
-                        }
-                    }
-                    if count > completed.count {
-                        Text("+ \(count - completed.count) earlier")
-                            .font(.system(size: 10))
-                            .foregroundStyle(theme.textTertiary)
-                    }
-                }
-            } else if panes.isEmpty {
+            if panes.isEmpty {
                 Text("None.")
                     .font(.system(size: 12))
                     .foregroundStyle(theme.textTertiary)
@@ -378,24 +357,5 @@ struct AgentStatusDetailPopover: View {
         .padding(.vertical, 3)
         .padding(.horizontal, 4)
         .contentShape(Rectangle())
-    }
-
-    /// Read-only row for a finished agent: workspace · pane · completion time.
-    private func completedRow(_ agent: CompletedAgent) -> some View {
-        HStack(spacing: 6) {
-            Circle().fill(agent.workspaceColor.color).frame(width: 7, height: 7)
-            Text(agent.workspaceName).foregroundStyle(theme.textSecondary)
-            Text("·").foregroundStyle(theme.textTertiary)
-            Text(agent.paneTitle)
-                .foregroundStyle(theme.textPrimary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-            Spacer(minLength: 10)
-            Text(agent.completedAt, style: .time)
-                .monospacedDigit()
-                .foregroundStyle(theme.textTertiary)
-        }
-        .font(.system(size: 12))
-        .padding(.horizontal, 4)
     }
 }

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -121,7 +121,6 @@ struct StatusBarView: View {
                 // relaunch-restored `.running` pane until the agent
                 // re-emits a start).
                 if let started = pane.agentStartedAt {
-                    Text("·").foregroundStyle(theme.textTertiary)
                     TimelineView(.periodic(from: .now, by: 1)) { context in
                         Text(chromeElapsedLabel(from: started, to: context.date))
                             .monospacedDigit()
@@ -137,7 +136,8 @@ struct StatusBarView: View {
     }
 
     private func rightSection(_ summary: ChromeStatusSummary) -> some View {
-        HStack(spacing: 8) {
+        // Spacing-separated (no dot separators) — the gaps carry the grouping.
+        HStack(spacing: 14) {
             let kinds = enabledStatKinds
             if !kinds.isEmpty {
                 ForEach(kinds) { kind in
@@ -151,14 +151,10 @@ struct StatusBarView: View {
                         graphStyle: SparklineStyle(rawValue: store.settings.sparklineStyle) ?? .line
                     )
                 }
-                separator
             }
-            countItem(color: theme.statusRunning, value: summary.running, label: "running")
-            separator
-            countItem(color: theme.statusWaiting, value: summary.waiting, label: "waiting")
-            separator
-            countItem(color: theme.statusDone, value: summary.done, label: "done")
-            separator
+            StatusCountItem(store: store, kind: .running, color: theme.statusRunning, value: summary.running)
+            StatusCountItem(store: store, kind: .waiting, color: theme.statusWaiting, value: summary.waiting)
+            StatusCountItem(store: store, kind: .done, color: theme.statusDone, value: summary.done)
             TimelineView(.periodic(from: .now, by: 1)) { context in
                 Text(context.date, format: .dateTime.hour().minute())
                     .monospacedDigit()
@@ -167,8 +163,81 @@ struct StatusBarView: View {
         .lineLimit(1)
         .fixedSize()
     }
+}
 
-    private func countItem(color: Color, value: Int, label: String) -> some View {
+/// The three agent states surfaced in the footer's right-hand counts.
+enum AgentStatusKind: Equatable {
+    case running, waiting, done
+
+    var label: String {
+        switch self {
+        case .running: "running"
+        case .waiting: "waiting"
+        case .done: "done"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .running: "Running agents"
+        case .waiting: "Awaiting input"
+        case .done: "Completed"
+        }
+    }
+}
+
+/// One running/waiting pane shown in the hover popover + click menu.
+struct AgentPaneRef: Identifiable {
+    let id: UUID
+    let workspaceID: UUID
+    let workspaceName: String
+    let workspaceColor: WorkspaceColor
+    let paneTitle: String
+    let startedAt: Date?
+}
+
+/// A footer count (dot · number · label). When there are panes in this state
+/// (running / waiting), a click opens a popover listing them; selecting one
+/// switches to its workspace and focuses it. `.done` is a session counter with
+/// no live panes, and a 0-count item is inert (plain, non-interactive).
+struct StatusCountItem: View {
+    let store: StoreOf<AppReducer>
+    let kind: AgentStatusKind
+    let color: Color
+    let value: Int
+    @Environment(\.chromeTheme) private var theme
+    @State private var showingDetail = false
+
+    /// Running/waiting with at least one pane open a navigable popover; `.done`
+    /// is a session counter with nothing to navigate to.
+    private var isNavigable: Bool { kind != .done && value > 0 }
+
+    var body: some View {
+        // Only the navigable items become buttons, so the 0-count items keep
+        // their plain (un-dimmed, non-clickable) appearance.
+        if isNavigable {
+            Button { showingDetail = true } label: { countLabel }
+                .buttonStyle(.plain)
+                .focusEffectDisabled()
+                .popover(isPresented: $showingDetail, arrowEdge: .top) {
+                    AgentStatusDetailPopover(
+                        kind: kind,
+                        color: color,
+                        count: value,
+                        panes: panes,
+                        onSelect: { ref in
+                            navigate(to: ref)
+                            showingDetail = false
+                        }
+                    )
+                    .environment(\.chromeTheme, theme)
+                }
+        } else {
+            countLabel
+        }
+    }
+
+    private var countLabel: some View {
         HStack(spacing: 4) {
             Circle().fill(color).frame(width: 6, height: 6)
             // Fixed-width count so the label (and everything after) doesn't
@@ -176,11 +245,115 @@ struct StatusBarView: View {
             Text("\(value)")
                 .monospacedDigit()
                 .frame(width: 14, alignment: .trailing)
-            Text(label)
+            Text(kind.label)
+        }
+        // Plain button can tint its label; restate the footer's neutral tone.
+        .foregroundStyle(theme.textSecondary)
+    }
+
+    private func navigate(to ref: AgentPaneRef) {
+        store.send(.setActiveWorkspace(ref.workspaceID))
+        store.send(.workspaces(.element(id: ref.workspaceID, action: .focusPane(ref.id))))
+    }
+
+    /// Panes currently in this state (empty for `.done`). Read lazily when the
+    /// popover opens.
+    private var panes: [AgentPaneRef] {
+        guard kind != .done else { return [] }
+        let target: PaneStatus = kind == .running ? .running : .waitingForInput
+        return store.workspaces.flatMap { workspace in
+            workspace.panes
+                .filter { $0.status == target }
+                .map { pane in
+                    AgentPaneRef(
+                        id: pane.id,
+                        workspaceID: workspace.id,
+                        workspaceName: workspace.name,
+                        workspaceColor: workspace.color,
+                        paneTitle: pane.title ?? pane.label ?? "Shell",
+                        startedAt: pane.agentStartedAt
+                    )
+                }
+        }
+    }
+}
+
+/// Popover for a footer agent count: a titled list of the panes in that state
+/// (workspace · pane · live elapsed for running). When `onSelect` is provided
+/// each row is a button that jumps to that pane. `.done` shows the session
+/// total instead (nothing to navigate to).
+struct AgentStatusDetailPopover: View {
+    let kind: AgentStatusKind
+    let color: Color
+    let count: Int
+    let panes: [AgentPaneRef]
+    var onSelect: ((AgentPaneRef) -> Void)?
+    @Environment(\.chromeTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Circle().fill(color).frame(width: 7, height: 7)
+                Text(kind.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(theme.textPrimary)
+            }
+            .padding(.bottom, 2)
+
+            if kind == .done {
+                Text("\(count) agent\(count == 1 ? "" : "s") completed this session.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(theme.textSecondary)
+            } else if panes.isEmpty {
+                Text("None.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(theme.textTertiary)
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(panes) { row($0) }
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 252, alignment: .leading)
+        .background(theme.surfaceBackground)
+        // No focus ring on the popover / its row buttons (the macOS focus
+        // effect otherwise draws an accent-tinted ring when the popover is key).
+        .focusEffectDisabled()
+    }
+
+    @ViewBuilder
+    private func row(_ ref: AgentPaneRef) -> some View {
+        if let onSelect {
+            Button { onSelect(ref) } label: { rowContent(ref) }
+                .buttonStyle(.plain)
+        } else {
+            rowContent(ref)
         }
     }
 
-    private var separator: some View {
-        Text("·").foregroundStyle(theme.textTertiary)
+    private func rowContent(_ ref: AgentPaneRef) -> some View {
+        HStack(spacing: 6) {
+            Circle().fill(ref.workspaceColor.color).frame(width: 7, height: 7)
+            Text(ref.workspaceName).foregroundStyle(theme.textSecondary)
+            Text("·").foregroundStyle(theme.textTertiary)
+            Text(ref.paneTitle)
+                .foregroundStyle(theme.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 10)
+            if kind == .running, let started = ref.startedAt {
+                TimelineView(.periodic(from: .now, by: 1)) { context in
+                    Text(chromeElapsedLabel(from: started, to: context.date))
+                        .monospacedDigit()
+                        .foregroundStyle(theme.activeAgent)
+                }
+            }
+        }
+        .font(.system(size: 12))
+        // Whole row (incl. the trailing gap) is the hit target.
+        .padding(.vertical, 3)
+        .padding(.horizontal, 4)
+        .contentShape(Rectangle())
     }
 }

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -22,6 +22,9 @@ struct ChromeStatusSummary: Equatable {
 struct StatusBarView: View {
     let store: StoreOf<AppReducer>
     @Environment(\.chromeTheme) private var theme
+    /// View-layer system-stats poller; never dispatches into TCA.
+    @State private var statsSampler = SystemStatsSampler()
+    @State private var systemStats = SystemStats.zero
 
     var body: some View {
         WithPerceptionTracking {
@@ -38,6 +41,14 @@ struct StatusBarView: View {
             .frame(height: 24)
             .background(theme.footerBackground)
             .overlay(alignment: .top) { theme.divider.frame(height: 1) }
+            .onAppear {
+                if store.settings.showSystemStats { systemStats = statsSampler.sample() }
+            }
+            // 2s cadence: cheap host_statistics calls, smoother than 1s. The
+            // gate skips work entirely when the footer stats are disabled.
+            .onReceive(Timer.publish(every: 2, on: .main, in: .common).autoconnect()) { _ in
+                if store.settings.showSystemStats { systemStats = statsSampler.sample() }
+            }
         }
     }
 
@@ -94,6 +105,10 @@ struct StatusBarView: View {
 
     private func rightSection(_ summary: ChromeStatusSummary) -> some View {
         HStack(spacing: 8) {
+            if store.settings.showSystemStats {
+                statsSection(systemStats)
+                separator
+            }
             countItem(color: theme.statusRunning, value: summary.running, label: "running")
             separator
             countItem(color: theme.statusWaiting, value: summary.waiting, label: "waiting")
@@ -107,6 +122,36 @@ struct StatusBarView: View {
         }
         .lineLimit(1)
         .fixedSize()
+    }
+
+    /// CPU / memory / load triad. Each value is monospaced so it doesn't
+    /// jitter the layout as it ticks; the tooltip carries the precise numbers.
+    private func statsSection(_ stats: SystemStats) -> some View {
+        HStack(spacing: 8) {
+            statItem("cpu", "\(Int(stats.cpuPercent.rounded()))%")
+            statItem("memorychip", "\(Int(stats.memPercent.rounded()))%")
+            statItem("gauge.with.dots.needle.33percent", String(format: "%.2f", stats.loadAverage1m))
+        }
+        .help("CPU \(Int(stats.cpuPercent.rounded()))% · "
+            + "Memory \(memoryLabel(stats)) · "
+            + "Load \(String(format: "%.2f", stats.loadAverage1m))")
+    }
+
+    private func statItem(_ systemImage: String, _ text: String) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: systemImage).font(.system(size: 9))
+            Text(text).monospacedDigit()
+        }
+        .foregroundStyle(theme.textTertiary)
+    }
+
+    private func memoryLabel(_ stats: SystemStats) -> String {
+        let gib = 1_073_741_824.0
+        return String(
+            format: "%.1f / %.0f GB",
+            Double(stats.memUsedBytes) / gib,
+            Double(stats.memTotalBytes) / gib
+        )
     }
 
     private func countItem(color: Color, value: Int, label: String) -> some View {

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -208,14 +208,12 @@ struct StatusCountItem: View {
     @Environment(\.chromeTheme) private var theme
     @State private var showingDetail = false
 
-    /// Running/waiting with at least one pane open a navigable popover; `.done`
-    /// is a session counter with nothing to navigate to.
-    private var isNavigable: Bool { kind != .done && value > 0 }
-
     var body: some View {
-        // Only the navigable items become buttons, so the 0-count items keep
-        // their plain (un-dimmed, non-clickable) appearance.
-        if isNavigable {
+        // Any non-zero count opens a detail popover; 0-count items stay plain
+        // (un-dimmed, non-clickable). Running/waiting rows navigate to the live
+        // pane; done lists the recently-finished agents (nothing to navigate
+        // to), so its rows are read-only.
+        if value > 0 {
             Button { showingDetail = true } label: { countLabel }
                 .buttonStyle(.plain)
                 .focusEffectDisabled()
@@ -225,7 +223,8 @@ struct StatusCountItem: View {
                         color: color,
                         count: value,
                         panes: panes,
-                        onSelect: { ref in
+                        completed: completed,
+                        onSelect: kind == .done ? nil : { ref in
                             navigate(to: ref)
                             showingDetail = false
                         }
@@ -253,7 +252,18 @@ struct StatusCountItem: View {
 
     private func navigate(to ref: AgentPaneRef) {
         store.send(.setActiveWorkspace(ref.workspaceID))
-        store.send(.workspaces(.element(id: ref.workspaceID, action: .focusPane(ref.id))))
+        // Defer focus until the popover has dismissed and the main window has
+        // restored its prior first responder — otherwise that restoration
+        // re-emits focus for the previously-focused surface and reverts the
+        // selection when the target pane is in the already-active workspace.
+        DispatchQueue.main.async {
+            store.send(.workspaces(.element(id: ref.workspaceID, action: .focusPane(ref.id))))
+        }
+    }
+
+    /// Recently-finished agents for the `.done` popover (newest first), else [].
+    private var completed: [CompletedAgent] {
+        kind == .done ? store.completedAgents : []
     }
 
     /// Panes currently in this state (empty for `.done`). Read lazily when the
@@ -287,6 +297,7 @@ struct AgentStatusDetailPopover: View {
     let color: Color
     let count: Int
     let panes: [AgentPaneRef]
+    var completed: [CompletedAgent] = []
     var onSelect: ((AgentPaneRef) -> Void)?
     @Environment(\.chromeTheme) private var theme
 
@@ -301,9 +312,21 @@ struct AgentStatusDetailPopover: View {
             .padding(.bottom, 2)
 
             if kind == .done {
-                Text("\(count) agent\(count == 1 ? "" : "s") completed this session.")
-                    .font(.system(size: 12))
-                    .foregroundStyle(theme.textSecondary)
+                Text("\(count) completed this session")
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.textTertiary)
+                if !completed.isEmpty {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(Array(completed.prefix(12).enumerated()), id: \.offset) { _, agent in
+                            completedRow(agent)
+                        }
+                    }
+                    if count > completed.count {
+                        Text("+ \(count - completed.count) earlier")
+                            .font(.system(size: 10))
+                            .foregroundStyle(theme.textTertiary)
+                    }
+                }
             } else if panes.isEmpty {
                 Text("None.")
                     .font(.system(size: 12))
@@ -355,5 +378,24 @@ struct AgentStatusDetailPopover: View {
         .padding(.vertical, 3)
         .padding(.horizontal, 4)
         .contentShape(Rectangle())
+    }
+
+    /// Read-only row for a finished agent: workspace · pane · completion time.
+    private func completedRow(_ agent: CompletedAgent) -> some View {
+        HStack(spacing: 6) {
+            Circle().fill(agent.workspaceColor.color).frame(width: 7, height: 7)
+            Text(agent.workspaceName).foregroundStyle(theme.textSecondary)
+            Text("·").foregroundStyle(theme.textTertiary)
+            Text(agent.paneTitle)
+                .foregroundStyle(theme.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 10)
+            Text(agent.completedAt, style: .time)
+                .monospacedDigit()
+                .foregroundStyle(theme.textTertiary)
+        }
+        .font(.system(size: 12))
+        .padding(.horizontal, 4)
     }
 }

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -102,6 +102,10 @@ struct StatusBarView: View {
                     .foregroundStyle(theme.textTertiary)
                 }
 
+                if let stats = gitStats(for: pane) {
+                    gitStatsLabel(stats)
+                }
+
                 if pane.agentSessionID != nil {
                     agentSection(pane)
                 }
@@ -110,6 +114,45 @@ struct StatusBarView: View {
             // the right-hand counts off-screen on a narrow window.
             .lineLimit(1)
         }
+    }
+
+    /// Working-tree diff stats for the focused pane's repo, mirroring the
+    /// sidebar inspector's `doc N +A -B`. The pane carries no association id, so
+    /// match its cwd to the repo association whose worktree path it sits in
+    /// (longest prefix wins for nested/multi-repo workspaces). `nil` when the
+    /// pane isn't inside a tracked worktree, or its tree is clean.
+    private func gitStats(for pane: Pane) -> (files: Int, adds: Int, dels: Int)? {
+        guard let workspace = store.activeWorkspace else { return nil }
+        let cwd = pane.workingDirectory
+        let match = workspace.repoAssociations
+            .filter { cwd == $0.worktreePath || cwd.hasPrefix($0.worktreePath + "/") }
+            .max { $0.worktreePath.count < $1.worktreePath.count }
+        guard let assoc = match,
+              case .dirty(let files, let adds, let dels) = store.gitStatuses[assoc.id] ?? .unknown
+        else { return nil }
+        return (files, adds, dels)
+    }
+
+    @ViewBuilder
+    private func gitStatsLabel(_ stats: (files: Int, adds: Int, dels: Int)) -> some View {
+        HStack(spacing: 4) {
+            HStack(spacing: 2) {
+                Image(systemName: "doc").font(.system(size: 9))
+                Text("\(stats.files)")
+            }
+            .foregroundStyle(theme.textTertiary)
+            if stats.adds > 0 {
+                Text("+\(stats.adds)").foregroundStyle(.green)
+            }
+            if stats.dels > 0 {
+                Text("-\(stats.dels)").foregroundStyle(.red)
+            }
+        }
+        .font(.system(size: 10, design: .monospaced))
+        .accessibilityLabel(
+            "\(stats.files) file\(stats.files == 1 ? "" : "s") changed, "
+                + "\(stats.adds) added, \(stats.dels) removed"
+        )
     }
 
     @ViewBuilder

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -171,7 +171,12 @@ struct StatusBarView: View {
     private func countItem(color: Color, value: Int, label: String) -> some View {
         HStack(spacing: 4) {
             Circle().fill(color).frame(width: 6, height: 6)
-            Text("\(value) \(label)")
+            // Fixed-width count so the label (and everything after) doesn't
+            // shift when the number goes single → double digit.
+            Text("\(value)")
+                .monospacedDigit()
+                .frame(width: 14, alignment: .trailing)
+            Text(label)
         }
     }
 

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -133,7 +133,6 @@ struct StatusBarView: View {
         return (files, adds, dels)
     }
 
-    @ViewBuilder
     private func gitStatsLabel(_ stats: (files: Int, adds: Int, dels: Int)) -> some View {
         HStack(spacing: 4) {
             HStack(spacing: 2) {

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ComposableArchitecture
 import SwiftUI
 
@@ -215,6 +216,7 @@ struct StatusCountItem: View {
     let color: Color
     let value: Int
     @Environment(\.chromeTheme) private var theme
+    @Environment(\.surfaceManager) private var surfaceManager
     @State private var showingDetail = false
 
     var body: some View {
@@ -258,12 +260,16 @@ struct StatusCountItem: View {
 
     private func navigate(to ref: AgentPaneRef) {
         store.send(.setActiveWorkspace(ref.workspaceID))
-        // Defer focus until the popover has dismissed and the main window has
-        // restored its prior first responder — otherwise that restoration
-        // re-emits focus for the previously-focused surface and reverts the
-        // selection when the target pane is in the already-active workspace.
-        DispatchQueue.main.async {
-            store.send(.workspaces(.element(id: ref.workspaceID, action: .focusPane(ref.id))))
+        store.send(.workspaces(.element(id: ref.workspaceID, action: .focusPane(ref.id))))
+        // Make the target surface the main window's first responder *now*, while
+        // the popover still holds key. When the popover dismisses and the main
+        // window becomes key again it fires `becomeFirstResponder` on its current
+        // first responder — without this that's the previously-focused surface,
+        // which re-emits its focus and reverts the selection for a pane already
+        // in the active workspace. (Cross-workspace the surface isn't in a window
+        // yet, so this no-ops and the `focusPane` above drives focus on render.)
+        if let surface = surfaceManager.surface(for: ref.id) {
+            surface.window?.makeFirstResponder(surface)
         }
     }
 

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -1,0 +1,122 @@
+import ComposableArchitecture
+import SwiftUI
+
+/// Cross-workspace agent counts shown in the bottom status bar.
+struct ChromeStatusSummary: Equatable {
+    var running = 0
+    var waiting = 0
+    var done = 0
+}
+
+/// Bottom status bar: focused-pane context (cwd · branch · agent · elapsed)
+/// on the left, global agent counts + a clock on the right.
+///
+/// A distinct child view that reads the store directly inside
+/// `WithPerceptionTracking`, so its counts and elapsed time update in
+/// Release builds (where the outer tracking is a no-op). The 1-second tick
+/// is a view-layer `TimelineView` and never dispatches a reducer action,
+/// so it can't thrash persistence/effects.
+///
+/// The mockup's centre `ACCEPT-EDITS` mode pill is intentionally absent:
+/// that is Claude Code's own permission mode, which Nex cannot read.
+struct StatusBarView: View {
+    let store: StoreOf<AppReducer>
+    @Environment(\.chromeTheme) private var theme
+
+    var body: some View {
+        WithPerceptionTracking {
+            let summary = store.chromeStatusSummary
+            let pane = store.activeWorkspace?.focusedPane
+            HStack(spacing: 10) {
+                leftSection(pane)
+                Spacer(minLength: 8)
+                rightSection(summary)
+            }
+            .font(.system(size: 11))
+            .foregroundStyle(theme.textSecondary)
+            .padding(.horizontal, 12)
+            .frame(height: 24)
+            .background(theme.footerBackground)
+            .overlay(alignment: .top) { theme.divider.frame(height: 1) }
+        }
+    }
+
+    @ViewBuilder
+    private func leftSection(_ pane: Pane?) -> some View {
+        if let pane {
+            HStack(spacing: 8) {
+                Text(chromeHomeAbbreviated(pane.workingDirectory))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if let branch = pane.gitBranch {
+                    HStack(spacing: 3) {
+                        Image(systemName: "arrow.triangle.branch").font(.system(size: 9))
+                        Text(branch)
+                    }
+                    .foregroundStyle(theme.textTertiary)
+                }
+
+                if pane.agentSessionID != nil {
+                    agentSection(pane)
+                }
+            }
+            // Guard against a pathologically long branch/agent label pushing
+            // the right-hand counts off-screen on a narrow window.
+            .lineLimit(1)
+        }
+    }
+
+    @ViewBuilder
+    private func agentSection(_ pane: Pane) -> some View {
+        switch pane.status {
+        case .running:
+            HStack(spacing: 4) {
+                Text("claude").foregroundStyle(theme.activeAgent)
+                // Elapsed only when we have a start time (nil after a
+                // relaunch-restored `.running` pane until the agent
+                // re-emits a start).
+                if let started = pane.agentStartedAt {
+                    Text("·").foregroundStyle(theme.textTertiary)
+                    TimelineView(.periodic(from: .now, by: 1)) { context in
+                        Text(chromeElapsedLabel(from: started, to: context.date))
+                            .monospacedDigit()
+                            .foregroundStyle(theme.activeAgent)
+                    }
+                }
+            }
+        case .waitingForInput:
+            Text("awaiting input").foregroundStyle(theme.statusWaiting)
+        case .idle:
+            EmptyView()
+        }
+    }
+
+    private func rightSection(_ summary: ChromeStatusSummary) -> some View {
+        HStack(spacing: 8) {
+            countItem(color: theme.statusRunning, value: summary.running, label: "running")
+            separator
+            countItem(color: theme.statusWaiting, value: summary.waiting, label: "waiting")
+            separator
+            countItem(color: theme.statusDone, value: summary.done, label: "done")
+            separator
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                Text(context.date, format: .dateTime.hour().minute())
+                    .monospacedDigit()
+            }
+        }
+        .lineLimit(1)
+        .fixedSize()
+    }
+
+    private func countItem(color: Color, value: Int, label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text("\(value) \(label)")
+        }
+    }
+
+    private var separator: some View {
+        Text("·").foregroundStyle(theme.textTertiary)
+    }
+}

--- a/Nex/Features/StatusBar/StatusBarView.swift
+++ b/Nex/Features/StatusBar/StatusBarView.swift
@@ -147,7 +147,8 @@ struct StatusBarView: View {
                         history: history[kind] ?? [],
                         showGraph: store.settings.showSystemStatGraphs,
                         graphColor: sparklineColor,
-                        graphWidth: CGFloat(store.settings.sparklineWidth)
+                        graphWidth: CGFloat(store.settings.sparklineWidth),
+                        graphStyle: SparklineStyle(rawValue: store.settings.sparklineStyle) ?? .line
                     )
                 }
                 separator

--- a/Nex/Features/StatusBar/SystemStatGauge.swift
+++ b/Nex/Features/StatusBar/SystemStatGauge.swift
@@ -44,6 +44,8 @@ struct SystemStatGauge: View {
     let stats: SystemStats
     let history: [Double]
     let showGraph: Bool
+    var graphColor: Color
+    var graphWidth: CGFloat
     @Environment(\.chromeTheme) private var theme
     @State private var hovering = false
 
@@ -52,15 +54,15 @@ struct SystemStatGauge: View {
             Image(systemName: kind.systemImage).font(.system(size: 9))
             Text(kind.compactLabel(stats)).monospacedDigit()
             if showGraph, history.count >= 2 {
-                Sparkline(values: history, isPercentage: kind.isPercentage, color: theme.textSecondary)
-                    .frame(width: 28, height: 11)
+                Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor)
+                    .frame(width: graphWidth, height: 11)
             }
         }
         .foregroundStyle(theme.textTertiary)
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
         .popover(isPresented: $hovering, arrowEdge: .top) {
-            StatDetailPopover(kind: kind, stats: stats, history: history)
+            StatDetailPopover(kind: kind, stats: stats, history: history, graphColor: graphColor)
                 .environment(\.chromeTheme, theme)
         }
     }
@@ -72,6 +74,7 @@ struct StatDetailPopover: View {
     let kind: SystemStatKind
     let stats: SystemStats
     let history: [Double]
+    var graphColor: Color
     @Environment(\.chromeTheme) private var theme
 
     var body: some View {
@@ -87,7 +90,7 @@ struct StatDetailPopover: View {
                 .monospacedDigit()
                 .foregroundStyle(theme.textSecondary)
 
-            Sparkline(values: history, isPercentage: kind.isPercentage, color: theme.accent, filled: true)
+            Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor, filled: true)
                 .frame(width: 196, height: 52)
                 .background(RoundedRectangle(cornerRadius: 6).fill(theme.textPrimary.opacity(0.04)))
                 .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.divider, lineWidth: 1))

--- a/Nex/Features/StatusBar/SystemStatGauge.swift
+++ b/Nex/Features/StatusBar/SystemStatGauge.swift
@@ -94,7 +94,9 @@ struct SystemStatGauge: View {
     var body: some View {
         HStack(spacing: 3) {
             Image(systemName: kind.systemImage).font(.system(size: 9))
-            Text(kind.compactLabel(stats)).monospacedDigit()
+            Text(kind.compactLabel(stats))
+                .monospacedDigit()
+                .frame(width: kind.valueWidth, alignment: .leading)
             if showGraph, history.count >= 2 {
                 Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor, style: graphStyle)
                     .frame(width: graphWidth, height: 11)

--- a/Nex/Features/StatusBar/SystemStatGauge.swift
+++ b/Nex/Features/StatusBar/SystemStatGauge.swift
@@ -1,38 +1,79 @@
 import SwiftUI
 
-/// A tiny line chart of recent values. Bounded (percentage) metrics scale to a
-/// fixed 0…100; the rest auto-scale to the window's max so a flat trace still
-/// reads. Drawn with `Canvas` so it stays cheap at footer size.
+/// How a sparkline is drawn.
+enum SparklineStyle: String, CaseIterable, Identifiable {
+    case line
+    case dots
+
+    var id: String { rawValue }
+    var displayName: String {
+        switch self {
+        case .line: "Line"
+        case .dots: "Stacked dots"
+        }
+    }
+}
+
+/// A tiny chart of recent values. Bounded (percentage) metrics scale to a fixed
+/// 0…100; the rest auto-scale to the window's max so a flat trace still reads.
+/// Drawn with `Canvas` so it stays cheap at footer size. `.line` draws a
+/// (optionally filled) trace; `.dots` draws a column of stacked dots per sample
+/// whose height tracks the value.
 struct Sparkline: View {
     let values: [Double]
     let isPercentage: Bool
     var color: Color
+    var style: SparklineStyle = .line
     var filled: Bool = false
 
     var body: some View {
         Canvas { ctx, size in
             guard values.count >= 2 else { return }
-            let maxV = isPercentage ? 100.0 : max(values.max() ?? 1, 0.0001)
-            let range = max(maxV, 0.0001)
-            let stepX = size.width / CGFloat(values.count - 1)
-            func point(_ i: Int) -> CGPoint {
-                let norm = min(1, max(0, values[i] / range))
-                let y = size.height - CGFloat(norm) * (size.height - 1) - 0.5
-                return CGPoint(x: CGFloat(i) * stepX, y: y)
+            let range = max(isPercentage ? 100.0 : (values.max() ?? 1), 0.0001)
+            switch style {
+            case .line: drawLine(ctx, size, range)
+            case .dots: drawDots(ctx, size, range)
             }
-            var line = Path()
-            line.move(to: point(0))
-            for i in 1 ..< values.count {
-                line.addLine(to: point(i))
+        }
+    }
+
+    private func drawLine(_ ctx: GraphicsContext, _ size: CGSize, _ range: Double) {
+        let stepX = size.width / CGFloat(values.count - 1)
+        func point(_ i: Int) -> CGPoint {
+            let norm = min(1, max(0, values[i] / range))
+            return CGPoint(x: CGFloat(i) * stepX, y: size.height - CGFloat(norm) * (size.height - 1) - 0.5)
+        }
+        var line = Path()
+        line.move(to: point(0))
+        for i in 1 ..< values.count {
+            line.addLine(to: point(i))
+        }
+        if filled {
+            var area = line
+            area.addLine(to: CGPoint(x: size.width, y: size.height))
+            area.addLine(to: CGPoint(x: 0, y: size.height))
+            area.closeSubpath()
+            ctx.fill(area, with: .color(color.opacity(0.15)))
+        }
+        ctx.stroke(line, with: .color(color), lineWidth: 1)
+    }
+
+    private func drawDots(_ ctx: GraphicsContext, _ size: CGSize, _ range: Double) {
+        let colSpacing: CGFloat = 3
+        let rowSpacing: CGFloat = 2.6
+        let radius: CGFloat = 1.0
+        let rows = max(1, Int(size.height / rowSpacing))
+        let cols = max(1, Int(size.width / colSpacing))
+        let recent = Array(values.suffix(cols))
+        for (index, value) in recent.enumerated() {
+            let norm = min(1, max(0, value / range))
+            let filledRows = Int((norm * Double(rows)).rounded())
+            let x = size.width - CGFloat(recent.count - index) * colSpacing + colSpacing / 2
+            for r in 0 ..< rows {
+                let y = size.height - (CGFloat(r) + 0.5) * rowSpacing
+                let rect = CGRect(x: x - radius, y: y - radius, width: radius * 2, height: radius * 2)
+                ctx.fill(Path(ellipseIn: rect), with: .color(color.opacity(r < filledRows ? 1 : 0.12)))
             }
-            if filled {
-                var area = line
-                area.addLine(to: CGPoint(x: size.width, y: size.height))
-                area.addLine(to: CGPoint(x: 0, y: size.height))
-                area.closeSubpath()
-                ctx.fill(area, with: .color(color.opacity(0.15)))
-            }
-            ctx.stroke(line, with: .color(color), lineWidth: 1)
         }
     }
 }
@@ -46,6 +87,7 @@ struct SystemStatGauge: View {
     let showGraph: Bool
     var graphColor: Color
     var graphWidth: CGFloat
+    var graphStyle: SparklineStyle
     @Environment(\.chromeTheme) private var theme
     @State private var hovering = false
 
@@ -54,7 +96,7 @@ struct SystemStatGauge: View {
             Image(systemName: kind.systemImage).font(.system(size: 9))
             Text(kind.compactLabel(stats)).monospacedDigit()
             if showGraph, history.count >= 2 {
-                Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor)
+                Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor, style: graphStyle)
                     .frame(width: graphWidth, height: 11)
             }
         }
@@ -62,7 +104,7 @@ struct SystemStatGauge: View {
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
         .popover(isPresented: $hovering, arrowEdge: .top) {
-            StatDetailPopover(kind: kind, stats: stats, history: history, graphColor: graphColor)
+            StatDetailPopover(kind: kind, stats: stats, history: history, graphColor: graphColor, graphStyle: graphStyle)
                 .environment(\.chromeTheme, theme)
         }
     }
@@ -75,6 +117,7 @@ struct StatDetailPopover: View {
     let stats: SystemStats
     let history: [Double]
     var graphColor: Color
+    var graphStyle: SparklineStyle
     @Environment(\.chromeTheme) private var theme
 
     var body: some View {
@@ -90,7 +133,7 @@ struct StatDetailPopover: View {
                 .monospacedDigit()
                 .foregroundStyle(theme.textSecondary)
 
-            Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor, filled: true)
+            Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor, style: graphStyle, filled: true)
                 .frame(width: 196, height: 52)
                 .background(RoundedRectangle(cornerRadius: 6).fill(theme.textPrimary.opacity(0.04)))
                 .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.divider, lineWidth: 1))

--- a/Nex/Features/StatusBar/SystemStatGauge.swift
+++ b/Nex/Features/StatusBar/SystemStatGauge.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+/// A tiny line chart of recent values. Bounded (percentage) metrics scale to a
+/// fixed 0…100; the rest auto-scale to the window's max so a flat trace still
+/// reads. Drawn with `Canvas` so it stays cheap at footer size.
+struct Sparkline: View {
+    let values: [Double]
+    let isPercentage: Bool
+    var color: Color
+    var filled: Bool = false
+
+    var body: some View {
+        Canvas { ctx, size in
+            guard values.count >= 2 else { return }
+            let maxV = isPercentage ? 100.0 : max(values.max() ?? 1, 0.0001)
+            let range = max(maxV, 0.0001)
+            let stepX = size.width / CGFloat(values.count - 1)
+            func point(_ i: Int) -> CGPoint {
+                let norm = min(1, max(0, values[i] / range))
+                let y = size.height - CGFloat(norm) * (size.height - 1) - 0.5
+                return CGPoint(x: CGFloat(i) * stepX, y: y)
+            }
+            var line = Path()
+            line.move(to: point(0))
+            for i in 1 ..< values.count {
+                line.addLine(to: point(i))
+            }
+            if filled {
+                var area = line
+                area.addLine(to: CGPoint(x: size.width, y: size.height))
+                area.addLine(to: CGPoint(x: 0, y: size.height))
+                area.closeSubpath()
+                ctx.fill(area, with: .color(color.opacity(0.15)))
+            }
+            ctx.stroke(line, with: .color(color), lineWidth: 1)
+        }
+    }
+}
+
+/// One footer stat: icon + value, with an optional inline sparkline, and a
+/// hover popover that shows the detail breakdown plus a larger graph over time.
+struct SystemStatGauge: View {
+    let kind: SystemStatKind
+    let stats: SystemStats
+    let history: [Double]
+    let showGraph: Bool
+    @Environment(\.chromeTheme) private var theme
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: kind.systemImage).font(.system(size: 9))
+            Text(kind.compactLabel(stats)).monospacedDigit()
+            if showGraph, history.count >= 2 {
+                Sparkline(values: history, isPercentage: kind.isPercentage, color: theme.textSecondary)
+                    .frame(width: 28, height: 11)
+            }
+        }
+        .foregroundStyle(theme.textTertiary)
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        .popover(isPresented: $hovering, arrowEdge: .top) {
+            StatDetailPopover(kind: kind, stats: stats, history: history)
+                .environment(\.chromeTheme, theme)
+        }
+    }
+}
+
+/// Hover popover: name, the verbose breakdown, a filled history graph, and
+/// now/min/max/avg over the retained window.
+struct StatDetailPopover: View {
+    let kind: SystemStatKind
+    let stats: SystemStats
+    let history: [Double]
+    @Environment(\.chromeTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: kind.systemImage)
+                Text(kind.displayName).font(.system(size: 13, weight: .semibold))
+            }
+            .foregroundStyle(theme.textPrimary)
+
+            Text(kind.detailLabel(stats))
+                .font(.system(size: 12))
+                .monospacedDigit()
+                .foregroundStyle(theme.textSecondary)
+
+            Sparkline(values: history, isPercentage: kind.isPercentage, color: theme.accent, filled: true)
+                .frame(width: 196, height: 52)
+                .background(RoundedRectangle(cornerRadius: 6).fill(theme.textPrimary.opacity(0.04)))
+                .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.divider, lineWidth: 1))
+
+            HStack(spacing: 14) {
+                summaryItem("now", history.last ?? 0)
+                summaryItem("min", history.min() ?? 0)
+                summaryItem("max", history.max() ?? 0)
+                summaryItem("avg", history.isEmpty ? 0 : history.reduce(0, +) / Double(history.count))
+            }
+            .foregroundStyle(theme.textSecondary)
+
+            Text("last \(history.count) samples · ~\(history.count * 2)s")
+                .font(.system(size: 9))
+                .foregroundStyle(theme.textTertiary)
+        }
+        .padding(12)
+        .frame(width: 220, alignment: .leading)
+        .background(theme.surfaceBackground)
+    }
+
+    private func summaryItem(_ label: String, _ value: Double) -> some View {
+        VStack(spacing: 1) {
+            Text(label).font(.system(size: 8)).foregroundStyle(theme.textTertiary)
+            Text(formatted(value)).font(.system(size: 11)).monospacedDigit()
+        }
+    }
+
+    private func formatted(_ value: Double) -> String {
+        switch kind {
+        case .cpu, .memory, .diskSpace: "\(Int(value.rounded()))%"
+        case .load: String(format: "%.2f", value)
+        case .network, .diskIO: SystemStatsFormat.rate(value)
+        }
+    }
+}

--- a/Nex/Features/StatusBar/SystemStatGauge.swift
+++ b/Nex/Features/StatusBar/SystemStatGauge.swift
@@ -102,7 +102,7 @@ struct SystemStatGauge: View {
             }
             .frame(width: kind.labelWidth, alignment: .trailing)
             if showGraph, history.count >= 2 {
-                Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor, style: graphStyle)
+                Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor, style: graphStyle, filled: true)
                     .frame(width: graphWidth, height: 11)
             }
         }

--- a/Nex/Features/StatusBar/SystemStatGauge.swift
+++ b/Nex/Features/StatusBar/SystemStatGauge.swift
@@ -93,10 +93,14 @@ struct SystemStatGauge: View {
 
     var body: some View {
         HStack(spacing: 3) {
-            Image(systemName: kind.systemImage).font(.system(size: 9))
-            Text(kind.compactLabel(stats))
-                .monospacedDigit()
-                .frame(width: kind.valueWidth, alignment: .leading)
+            // Right-align the icon+value cluster in a fixed slot: the value
+            // abuts the sparkline (no internal gap) and the slack falls before
+            // the icon, reading as inter-metric spacing rather than a gap.
+            HStack(spacing: 3) {
+                Image(systemName: kind.systemImage).font(.system(size: 9))
+                Text(kind.compactLabel(stats)).monospacedDigit()
+            }
+            .frame(width: kind.labelWidth, alignment: .trailing)
             if showGraph, history.count >= 2 {
                 Sparkline(values: history, isPercentage: kind.isPercentage, color: graphColor, style: graphStyle)
                     .frame(width: graphWidth, height: 11)

--- a/Nex/Features/WebPane/StoragePanel.swift
+++ b/Nex/Features/WebPane/StoragePanel.swift
@@ -19,6 +19,7 @@ struct StoragePanel: View {
     let onClose: () -> Void
 
     @Environment(\.webPaneStore) private var webPaneStore
+    @Environment(\.chromeTheme) private var chromeTheme
 
     @State private var cookies: [HTTPCookie] = []
     /// Grouped + sorted view of `cookies`. Cached in @State so body
@@ -50,7 +51,7 @@ struct StoragePanel: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
-        .background(Color(nsColor: .windowBackgroundColor))
+        .background(chromeTheme.surfaceBackground)
         .overlay(alignment: .bottom) { Divider() }
         .onAppear(perform: refreshCookies)
         .confirmationDialog(

--- a/Nex/Features/WebPane/WebBatchInspectPanel.swift
+++ b/Nex/Features/WebPane/WebBatchInspectPanel.swift
@@ -27,6 +27,7 @@ struct WebBatchInspectPanel: View {
     /// session, or `nil` on the first batch. Seeds the picker.
     var initialSelection: BatchTargetMemory?
 
+    @Environment(\.chromeTheme) private var chromeTheme
     @State private var selection: TargetSelection = .unselected
 
     /// `.unselected` blocks Send so the user can't accidentally
@@ -61,7 +62,7 @@ struct WebBatchInspectPanel: View {
             Divider()
             footer
         }
-        .background(Color(nsColor: .windowBackgroundColor))
+        .background(chromeTheme.surfaceBackground)
         .overlay(alignment: .top) { Divider() }
         .onAppear { seedSelection() }
         // The WKWebView underneath sets `cursor:crosshair` while the
@@ -284,7 +285,7 @@ struct WebBatchInspectPanel: View {
             .frame(minWidth: 140, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 5)
-                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .fill(chromeTheme.headerBackground)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 5)

--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -56,6 +56,7 @@ struct WebPaneChrome: View {
     /// doesn't always reach the Settings scene through the responder
     /// chain; `openSettings()` is the supported entry point.
     @Environment(\.openSettings) private var openSettings
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         VStack(spacing: 0) {
@@ -64,7 +65,7 @@ struct WebPaneChrome: View {
                 tabStrip
             }
         }
-        .background(Color(nsColor: .windowBackgroundColor))
+        .background(chromeTheme.headerBackground)
         .overlay(alignment: .bottom) {
             ZStack(alignment: .leading) {
                 Divider()
@@ -395,6 +396,8 @@ struct WebURLBar: View {
     var canStar: Bool = false
     var onToggleStar: (() -> Void)?
 
+    @Environment(\.chromeTheme) private var chromeTheme
+
     var body: some View {
         HStack(spacing: 4) {
             WebURLField(
@@ -422,7 +425,7 @@ struct WebURLBar: View {
         .frame(height: 21)
         .background(
             RoundedRectangle(cornerRadius: 4)
-                .fill(Color(nsColor: .textBackgroundColor))
+                .fill(chromeTheme.surfaceBackground)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 4)

--- a/Nex/Features/WebPane/WebPaneView.swift
+++ b/Nex/Features/WebPane/WebPaneView.swift
@@ -58,6 +58,7 @@ struct WebPaneView: View {
     let onOpenFavourite: (String) -> Void
 
     @Environment(\.webPaneStore) private var webPaneStore
+    @Environment(\.chromeTheme) private var chromeTheme
     @State private var storagePanelVisible: Bool = false
     @State private var displayedURL: String = ""
     /// Title that pairs with `displayedURL`. Updated from the same
@@ -155,7 +156,7 @@ struct WebPaneView: View {
                 )
             }
         }
-        .background(Color(nsColor: .textBackgroundColor))
+        .background(chromeTheme.surfaceBackground)
         .onAppear(perform: refreshState)
         .onChange(of: active?.id) { _, _ in refreshState() }
         .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.stateDidChangeNotification)) { note in

--- a/Nex/Features/Workspace/GroupCustomEmojiSheet.swift
+++ b/Nex/Features/Workspace/GroupCustomEmojiSheet.swift
@@ -2,25 +2,27 @@ import AppKit
 import SwiftUI
 
 /// Small sheet the user drops an arbitrary emoji into for a group's
-/// header icon. Input is truncated to the first grapheme cluster so a
-/// compound glyph (e.g. flag emoji, skin-toned emoji) survives
-/// intact while anything wider than one visual character is dropped.
+/// header icon or a workspace's avatar. Input is truncated to the first
+/// grapheme cluster so a compound glyph (e.g. flag emoji, skin-toned
+/// emoji) survives intact while anything wider than one visual character
+/// is dropped.
 ///
 /// The macOS character picker (searchable, covers every emoji) is
 /// one click away via the `Browse All Emoji…` button — it calls
 /// `NSApp.orderFrontCharacterPalette(_:)`, which routes the
 /// user's selection into the focused `TextField` below.
 struct GroupCustomEmojiSheet: View {
-    let groupName: String
+    let subjectName: String
     let onConfirm: (String) -> Void
     let onCancel: () -> Void
 
     @State private var emoji: String = ""
     @FocusState private var fieldFocused: Bool
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Custom Emoji for \"\(groupName)\"")
+            Text("Custom Emoji for \"\(subjectName)\"")
                 .font(.headline)
 
             Text("Type or paste a single emoji. Use \u{2303}\u{2318}Space, or the button below, to search every emoji. Non-emoji input is rejected.")
@@ -72,6 +74,7 @@ struct GroupCustomEmojiSheet: View {
         }
         .padding(20)
         .frame(width: 340)
+        .background(chromeTheme.surfaceBackground)
     }
 
     private var isValidEmoji: Bool {

--- a/Nex/Features/Workspace/GroupHeaderRow.swift
+++ b/Nex/Features/Workspace/GroupHeaderRow.swift
@@ -17,31 +17,24 @@ struct GroupHeaderRow: View {
 
     @State private var renameText: String = ""
     @FocusState private var renameFieldFocused: Bool
+    @Environment(\.chromeTheme) private var theme
+
+    /// Group-colour wash behind the header. Rendered as a rounded, inset
+    /// band (a pill) per the mockup. Falls back to a neutral tint when the
+    /// group has no colour.
+    private var headerTint: Color {
+        (color?.color ?? theme.textTertiary).opacity(theme.groupBandOpacity)
+    }
 
     var body: some View {
-        HStack(spacing: 8) {
-            // Icon carries the group identity. The chosen glyph sits
-            // in a 4pt-wide slot that matches the colour pill on
-            // workspace rows, so a group header and a root workspace
-            // share the same leading-column anchor. The glyph is
-            // wider than 4pt; it overflows the slot and centres on
-            // the 18pt-from-entry-edge column — visually aligned with
-            // the pill.
-            //
-            // When no `icon` is set the default filled/outlined folder
-            // glyph tints with the group's colour. Custom SF Symbols
-            // pick up the same tint. Emoji glyphs carry their own
-            // palette and render untinted.
-            ZStack {
-                Color.clear.frame(width: 4, height: 24)
-                iconGlyph
-            }
+        HStack(spacing: 9) {
+            groupIcon
 
             if isRenaming {
                 TextField("Group name", text: $renameText)
                     .textFieldStyle(.plain)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.primary)
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(theme.textPrimary)
                     .focused($renameFieldFocused)
                     .onAppear {
                         renameText = name
@@ -73,8 +66,8 @@ struct GroupHeaderRow: View {
                     }
             } else {
                 Text(name)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(theme.textPrimary)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -82,36 +75,25 @@ struct GroupHeaderRow: View {
             Spacer(minLength: 4)
 
             if !isRenaming {
-                if hasWaitingPanes {
-                    AgentStatusDot(color: .blue)
-                } else if hasRunningPanes {
-                    AgentStatusDot(color: .green)
-                }
-
-                Text("\(workspaceCount)")
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 1)
-                    .background(
-                        Capsule().fill(Color.primary.opacity(0.06))
-                    )
+                Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(theme.textTertiary)
             }
         }
-        // Match a workspace row's laid-out height: a workspace row's
-        // inner HStack is driven by the 13pt name + 10pt subtitle
-        // VStack at ~29pt, plus 8pt vertical padding on each side
-        // ≈ 45pt total. Driving the header to the same content height
-        // here + the same 8pt vertical padding aligns the group's
-        // count badge vertically with the workspace rows' ⌘N badges.
-        .frame(minHeight: 29)
-        .padding(.vertical, 8)
-        // 16pt total horizontal padding matches the workspace row's
-        // layered padding (8pt internal inside `WorkspaceRowView` + 8pt
-        // external in `WorkspaceListView`'s `workspaceRow`). That puts
-        // the 4pt folder slot at 16pt from the entry leading edge —
-        // centred at 18pt, exactly under the workspace row's pill.
-        .padding(.horizontal, 16)
+        // 6pt vertical padding matches WorkspaceRowView so a group band is
+        // the same height as a workspace row (both have a 22pt icon/avatar).
+        .padding(.vertical, 6)
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        // Rounded, inset band (pill) — matches the mockup. The 8pt outer
+        // inset keeps it clear of the sidebar edges; the list's trailing-8
+        // scroller padding then balances the right margin.
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous).fill(headerTint)
+        )
+        .padding(.leading, 8)
+        // Vertical breathing room between adjacent group bands.
+        .padding(.vertical, 2)
         .contentShape(Rectangle())
         .onTapGesture {
             if isRenaming {
@@ -124,6 +106,25 @@ struct GroupHeaderRow: View {
         }
     }
 
+    /// Group glyph with the agent-activity dot overlaid on its corner
+    /// (green = running, blue = waiting), matching the mockup.
+    private var groupIcon: some View {
+        iconGlyph
+            .frame(width: 22, height: 22)
+            .overlay(alignment: .topTrailing) {
+                if hasWaitingPanes {
+                    statusDot(theme.statusWaiting)
+                } else if hasRunningPanes {
+                    statusDot(theme.statusRunning)
+                }
+            }
+    }
+
+    private func statusDot(_ color: Color) -> some View {
+        PulsingStatusDot(color: color, borderColor: theme.sidebarBackground)
+            .offset(x: 3, y: -2)
+    }
+
     @ViewBuilder
     private var iconGlyph: some View {
         switch icon {
@@ -131,8 +132,8 @@ struct GroupHeaderRow: View {
             // Default: colour-tinted folder (filled when a colour is
             // set, outlined otherwise).
             Image(systemName: color == nil ? "folder" : "folder.fill")
-                .font(.system(size: 11))
-                .foregroundStyle(color?.color ?? Color.secondary)
+                .font(.system(size: 14))
+                .foregroundStyle(color?.color ?? theme.textSecondary)
         case .systemName(let name):
             // Custom SF Symbol. Inherit the group's colour tint so it
             // reads the same as the default folder would. Folder is
@@ -142,13 +143,13 @@ struct GroupHeaderRow: View {
             // coloured group.
             let effective = (name == "folder" && color != nil) ? "folder.fill" : name
             Image(systemName: effective)
-                .font(.system(size: 11))
-                .foregroundStyle(color?.color ?? Color.secondary)
+                .font(.system(size: 14))
+                .foregroundStyle(color?.color ?? theme.textSecondary)
         case .emoji(let grapheme):
             // Emoji glyphs render with their native palette — SwiftUI
             // can't recolour them cleanly, so we skip the tint.
             Text(grapheme)
-                .font(.system(size: 11))
+                .font(.system(size: 13))
         }
     }
 }

--- a/Nex/Features/Workspace/GroupHeaderRow.swift
+++ b/Nex/Features/Workspace/GroupHeaderRow.swift
@@ -18,12 +18,13 @@ struct GroupHeaderRow: View {
     @State private var renameText: String = ""
     @FocusState private var renameFieldFocused: Bool
     @Environment(\.chromeTheme) private var theme
+    @Environment(\.sidebarColorIntensity) private var colorIntensity
 
     /// Group-colour wash behind the header. Rendered as a rounded, inset
     /// band (a pill) per the mockup. Falls back to a neutral tint when the
     /// group has no colour.
     private var headerTint: Color {
-        (color?.color ?? theme.textTertiary).opacity(theme.groupBandOpacity)
+        (color?.color ?? theme.textTertiary).opacity(min(1, theme.groupBandOpacity * colorIntensity))
     }
 
     var body: some View {

--- a/Nex/Features/Workspace/GroupHeaderRow.swift
+++ b/Nex/Features/Workspace/GroupHeaderRow.swift
@@ -91,11 +91,9 @@ struct GroupHeaderRow: View {
         // 6pt vertical padding matches WorkspaceRowView so a group band is
         // the same height as a workspace row (both have a 22pt icon/avatar).
         .padding(.vertical, 6)
-        .padding(.horizontal, 12)
+        // 8pt inner inset matches WorkspaceRowView's internal horizontal pad.
+        .padding(.horizontal, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
-        // Rounded, inset band (pill) — matches the mockup. The 8pt outer
-        // inset keeps it clear of the sidebar edges; the list's trailing-8
-        // scroller padding then balances the right margin.
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(headerTint)
@@ -104,6 +102,9 @@ struct GroupHeaderRow: View {
                         .strokeBorder(headerStroke, lineWidth: 1)
                 )
         )
+        // 8pt outer leading stands in for the workspace row's call-site
+        // .padding(.horizontal, 8) (which the group entry doesn't get), so the
+        // band edge + icon line up with the workspace ring + avatar.
         .padding(.leading, 8)
         // Vertical breathing room between adjacent group bands.
         .padding(.vertical, 2)

--- a/Nex/Features/Workspace/GroupHeaderRow.swift
+++ b/Nex/Features/Workspace/GroupHeaderRow.swift
@@ -19,12 +19,19 @@ struct GroupHeaderRow: View {
     @FocusState private var renameFieldFocused: Bool
     @Environment(\.chromeTheme) private var theme
     @Environment(\.sidebarColorIntensity) private var colorIntensity
+    @Environment(\.sidebarFillStroke) private var fillStroke
 
     /// Group-colour wash behind the header. Rendered as a rounded, inset
     /// band (a pill) per the mockup. Falls back to a neutral tint when the
     /// group has no colour.
     private var headerTint: Color {
-        (color?.color ?? theme.textTertiary).opacity(min(1, theme.groupBandOpacity * colorIntensity))
+        let fill = fillStroke.resolvedGroupFill(preset: theme.groupBandOpacity)
+        return (color?.color ?? theme.textTertiary).opacity(min(1, fill * colorIntensity))
+    }
+
+    /// Optional band border (opt-in; default off).
+    private var headerStroke: Color {
+        (color?.color ?? theme.textTertiary).opacity(min(1, fillStroke.groupStroke * colorIntensity))
     }
 
     var body: some View {
@@ -90,7 +97,12 @@ struct GroupHeaderRow: View {
         // inset keeps it clear of the sidebar edges; the list's trailing-8
         // scroller padding then balances the right margin.
         .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous).fill(headerTint)
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(headerTint)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .strokeBorder(headerStroke, lineWidth: 1)
+                )
         )
         .padding(.leading, 8)
         // Vertical breathing room between adjacent group bands.

--- a/Nex/Features/Workspace/NewGroupSheet.swift
+++ b/Nex/Features/Workspace/NewGroupSheet.swift
@@ -10,6 +10,7 @@ struct NewGroupSheet: View {
 
     @State private var text: String = ""
     @State private var selectedColor: WorkspaceColor?
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -69,6 +70,7 @@ struct NewGroupSheet: View {
         }
         .padding()
         .frame(width: 320)
+        .background(chromeTheme.surfaceBackground)
         .onAppear { text = defaultName }
     }
 

--- a/Nex/Features/Workspace/NewWorkspaceSheet.swift
+++ b/Nex/Features/Workspace/NewWorkspaceSheet.swift
@@ -25,6 +25,7 @@ struct NewWorkspaceSheet: View {
     @State private var isRepoPickerPresented = false
     @State private var selectedGroupID: UUID?
     @FocusState private var focusedField: Field?
+    @Environment(\.chromeTheme) private var chromeTheme
 
     init(store: StoreOf<AppReducer>) {
         self.store = store
@@ -150,6 +151,7 @@ struct NewWorkspaceSheet: View {
             }
             .padding(20)
             .frame(width: 360)
+            .background(chromeTheme.surfaceBackground)
             .onAppear {
                 // Dispatching lets the sheet finish presenting before we
                 // steal first responder. Without this, the TextField

--- a/Nex/Features/Workspace/RenameWorkspaceSheet.swift
+++ b/Nex/Features/Workspace/RenameWorkspaceSheet.swift
@@ -7,6 +7,7 @@ struct RenameWorkspaceSheet: View {
     let onDismiss: () -> Void
 
     @State private var text: String = ""
+    @Environment(\.chromeTheme) private var chromeTheme
 
     var body: some View {
         VStack(spacing: 16) {
@@ -28,6 +29,7 @@ struct RenameWorkspaceSheet: View {
         }
         .padding()
         .frame(width: 300)
+        .background(chromeTheme.surfaceBackground)
         .onAppear { text = currentName }
     }
 

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -24,6 +24,9 @@ struct WorkspaceFeature {
         var name: String
         var slug: String
         var color: WorkspaceColor
+        /// Optional avatar icon override (SF Symbol or emoji). `nil` falls
+        /// back to the first letter of the workspace name.
+        var icon: GroupIcon?
         var panes: IdentifiedArrayOf<Pane>
         var layout: PaneLayout
         var focusedPaneID: UUID?
@@ -96,6 +99,13 @@ struct WorkspaceFeature {
             return result.count >= 2 ? result : []
         }
 
+        /// The currently focused pane, if any. Used by the chrome (title
+        /// bar / status bar) to surface the active pane's cwd, branch, and
+        /// agent state.
+        var focusedPane: Pane? {
+            focusedPaneID.flatMap { panes[id: $0] }
+        }
+
         init(
             id: UUID = UUID(),
             name: String,
@@ -129,12 +139,14 @@ struct WorkspaceFeature {
             createdAt: Date,
             lastAccessedAt: Date,
             labels: [String] = [],
+            icon: GroupIcon? = nil,
             webPanes: [UUID: WebPaneState] = [:]
         ) {
             self.id = id
             self.name = name
             self.slug = slug
             self.color = color
+            self.icon = icon
             self.panes = panes
             self.layout = layout
             self.focusedPaneID = focusedPaneID
@@ -1255,7 +1267,13 @@ struct WorkspaceFeature {
                 return .none
 
             case .agentStarted(let paneID):
-                state.mutatePane(id: paneID) { $0.status = .running }
+                state.mutatePane(id: paneID) {
+                    // Start the elapsed clock only on a fresh run (a
+                    // non-running → running transition) so repeated start
+                    // pings within one run don't reset "claude · mm:ss".
+                    if $0.status != .running { $0.agentStartedAt = now }
+                    $0.status = .running
+                }
                 return .none
 
             case .agentStopped(let paneID):

--- a/Nex/Features/Workspace/WorkspaceInspectorView.swift
+++ b/Nex/Features/Workspace/WorkspaceInspectorView.swift
@@ -8,6 +8,7 @@ extension UUID: @retroactive Identifiable {
 /// Trailing inspector panel showing workspace metadata, repo associations, and pane list.
 struct WorkspaceInspectorView: View {
     let store: StoreOf<AppReducer>
+    @Environment(\.chromeTheme) private var chromeTheme
     @State private var isRepoPickerPresented = false
     @State private var isWorktreePickerPresented = false
     @State private var worktreeRepoID: UUID?
@@ -53,7 +54,7 @@ struct WorkspaceInspectorView: View {
                     }
                 }
                 .frame(width: 280)
-                .background(Color(nsColor: .controlBackgroundColor))
+                .background(chromeTheme.sidebarBackground)
                 .sheet(isPresented: $isRepoPickerPresented) {
                     RepoPickerView(
                         repos: store.repoRegistry,
@@ -439,6 +440,7 @@ struct CreateWorktreeSheet: View {
     var onChangeRepo: (() -> Void)?
 
     @State private var branchEdited = false
+    @Environment(\.chromeTheme) private var chromeTheme
 
     private var isValid: Bool {
         !worktreeName.trimmingCharacters(in: .whitespaces).isEmpty
@@ -500,6 +502,7 @@ struct CreateWorktreeSheet: View {
         }
         .padding(20)
         .frame(width: 320)
+        .background(chromeTheme.surfaceBackground)
     }
 }
 

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct WorkspaceListView: View {
     let store: StoreOf<AppReducer>
     @Environment(\.openSettings) private var openSettings
+    @Environment(\.colorScheme) private var systemScheme
+    @Environment(\.chromeTheme) private var chromeTheme
     @State private var draggedWorkspaceID: UUID?
     /// Group currently being dragged (drag on a group header). Mutually
     /// exclusive with `draggedWorkspaceID`; shares `dragCurrentY` and
@@ -199,11 +201,25 @@ struct WorkspaceListView: View {
             )) {
                 if let prompt = store.groupCustomEmojiPrompt {
                     GroupCustomEmojiSheet(
-                        groupName: prompt.groupName,
+                        subjectName: prompt.groupName,
                         onConfirm: { emoji in
                             store.send(.confirmGroupCustomEmoji(emoji))
                         },
                         onCancel: { store.send(.cancelGroupCustomEmoji) }
+                    )
+                }
+            }
+            .sheet(isPresented: Binding(
+                get: { store.workspaceCustomEmojiPrompt != nil },
+                set: { if !$0 { store.send(.cancelWorkspaceCustomEmoji) } }
+            )) {
+                if let prompt = store.workspaceCustomEmojiPrompt {
+                    GroupCustomEmojiSheet(
+                        subjectName: prompt.workspaceName,
+                        onConfirm: { emoji in
+                            store.send(.confirmWorkspaceCustomEmoji(emoji))
+                        },
+                        onCancel: { store.send(.cancelWorkspaceCustomEmoji) }
                     )
                 }
             }
@@ -338,27 +354,57 @@ struct WorkspaceListView: View {
                 selectionHeader
             }
             .safeAreaInset(edge: .bottom) {
-                Menu {
-                    Button("New Workspace") { store.send(.showNewWorkspaceSheet()) }
-                    Button("New Group") {
-                        let placeholder = defaultGroupName(existing: store.groups)
-                        store.send(.createGroup(name: placeholder, autoRename: true))
+                // Left: "+ New Workspace" (primary action) + a chevron menu
+                // for New Workspace / New Group. Right: the ⌘N shortcut hint.
+                // `.menuStyle(.borderlessButton)` flattens a complex custom
+                // label, so the row is composed from a plain Button + a small
+                // single-glyph chevron Menu rather than one Menu label.
+                HStack(spacing: 6) {
+                    Button {
+                        store.send(.showNewWorkspaceSheet())
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "plus")
+                            Text("New Workspace")
+                        }
+                        .contentShape(Rectangle())
                     }
-                } label: {
-                    Label("New Workspace", systemImage: "plus")
-                        .frame(maxWidth: .infinity)
-                } primaryAction: {
-                    store.send(.showNewWorkspaceSheet())
+                    .buttonStyle(.plain)
+
+                    Menu {
+                        Button("New Workspace") { store.send(.showNewWorkspaceSheet()) }
+                        Button("New Group") {
+                            let placeholder = defaultGroupName(existing: store.groups)
+                            store.send(.createGroup(name: placeholder, autoRename: true))
+                        }
+                    } label: {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 9, weight: .semibold))
+                            .contentShape(Rectangle())
+                    }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .fixedSize()
+                    // The borderlessButton style tints its label with the
+                    // accent; force it to the text colour to match the label.
+                    .tint(chromeTheme.textSecondary)
+                    .foregroundStyle(chromeTheme.textSecondary)
+
+                    Spacer()
+
+                    Text("\u{2318}N")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(chromeTheme.textTertiary)
                 }
-                .menuStyle(.borderlessButton)
                 .padding(12)
-                // Opaque fill matching the sidebar root background
-                // (ContentView paints the same colour). `safeAreaInset`
-                // lets the scroll view's rows slide *under* this bar, so
-                // without a solid background the colour pill and pane
-                // count of the row above bleed through behind the button.
+                // Opaque fill matching the sidebar root background. The top
+                // divider separates the footer from the scrolling list.
                 .frame(maxWidth: .infinity)
-                .background(Color(nsColor: .controlBackgroundColor))
+                .background(chromeTheme.sidebarBackground)
+                .foregroundStyle(chromeTheme.textSecondary)
+                .overlay(alignment: .top) {
+                    chromeTheme.divider.frame(height: 1)
+                }
             }
         }
     }
@@ -387,10 +433,10 @@ struct WorkspaceListView: View {
                   let group = store.groups[id: gid],
                   !group.isCollapsed
             else { return nil }
-            return group.color?.color ?? Color.secondary
+            return group.color?.color ?? chromeTheme.divider
         case .groupEmpty(let groupID):
             guard let group = store.groups[id: groupID] else { return nil }
-            return group.color?.color ?? Color.secondary
+            return group.color?.color ?? chromeTheme.divider
         }
     }
 
@@ -540,11 +586,21 @@ struct WorkspaceListView: View {
         return ids
     }
 
+    /// True when the resolved chrome appearance is currently dark — drives the
+    /// sun/moon glyph and which scheme the quick-toggle flips to.
+    private var isChromeDark: Bool {
+        switch store.settings.chromeAppearance {
+        case .dark: true
+        case .light: false
+        case .system: systemScheme == .dark
+        }
+    }
+
     private var filterField: some View {
         HStack(spacing: 6) {
-            Image(systemName: "line.3.horizontal.decrease.circle")
+            Image(systemName: "magnifyingglass")
                 .font(.system(size: 11))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(chromeTheme.textTertiary)
 
             TextField("Filter workspaces or labels", text: $filterText)
                 .textFieldStyle(.plain)
@@ -576,15 +632,30 @@ struct WorkspaceListView: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(chromeTheme.textTertiary)
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("sidebar.filter.clear")
             }
+
+            // Quick light/dark toggle for the warm chrome palette. Flips to the
+            // opposite explicit scheme; the tri-state (incl. System) lives in
+            // Settings → Appearance. Button only — no keybinding, so no
+            // KeyBindingMap collision.
+            Button {
+                store.send(.settings(.setChromeAppearance(isChromeDark ? .light : .dark)))
+            } label: {
+                Image(systemName: isChromeDark ? "moon.fill" : "sun.max.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(chromeTheme.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .help("Toggle light / dark chrome")
+            .accessibilityIdentifier("sidebar.appearance.toggle")
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
-        .background(Color(nsColor: .controlBackgroundColor).opacity(0.6))
+        .background(chromeTheme.sidebarBackground)
     }
 
     /// Workspaces whose name OR any label contains `filterText`
@@ -665,7 +736,6 @@ struct WorkspaceListView: View {
     @ViewBuilder
     private func filteredWorkspaceRow(workspaceID: UUID) -> some View {
         if let workspaceStore = store.scope(state: \.workspaces[id: workspaceID], action: \.workspaces[id: workspaceID]) {
-            let aggregateStatus = aggregateGitStatus(for: workspaceStore.state)
             let waiting = workspaceStore.panes.count(where: { $0.status == .waitingForInput })
             let running = workspaceStore.panes.contains { $0.status == .running }
             let parentGroupName = store.state.groupID(forWorkspace: workspaceID)
@@ -675,9 +745,6 @@ struct WorkspaceListView: View {
                 WorkspaceRowView(
                     name: workspaceStore.name,
                     color: workspaceStore.color,
-                    paneCount: workspaceStore.panes.count,
-                    repoCount: workspaceStore.repoAssociations.count,
-                    gitStatus: aggregateStatus,
                     isActive: workspaceID == store.activeWorkspaceID,
                     // Negative index suppresses the `⌘N` badge in
                     // `WorkspaceRowView` (the badge is gated on `index <
@@ -686,6 +753,7 @@ struct WorkspaceListView: View {
                     // either be wrong or meaningless, so we hide it
                     // wholesale in filtered rows.
                     index: -1,
+                    icon: workspaceStore.icon,
                     waitingPaneCount: waiting,
                     hasRunningPanes: running,
                     isSelected: store.selectedWorkspaceIDs.contains(workspaceID),
@@ -810,6 +878,7 @@ struct WorkspaceListView: View {
                     }
                 }
             }
+            workspaceChangeIconMenu(workspaceID: workspaceID)
             labelsMenu(workspaceID: workspaceID, workspaceStore: workspaceStore)
             moveToGroupMenu(workspaceID: workspaceID)
             Divider()
@@ -1037,6 +1106,36 @@ struct WorkspaceListView: View {
         }
     }
 
+    /// Workspace counterpart of `changeIconMenu`, reusing the same symbol /
+    /// emoji palettes. "Reset" returns to the first-letter avatar.
+    private func workspaceChangeIconMenu(workspaceID: UUID) -> some View {
+        Menu("Change Icon") {
+            Menu("Symbol") {
+                ForEach(Self.groupIconSymbolPalette, id: \.systemName) { entry in
+                    Button {
+                        store.send(.setWorkspaceIcon(id: workspaceID, icon: .systemName(entry.systemName)))
+                    } label: {
+                        Label(entry.label, systemImage: entry.systemName)
+                    }
+                }
+            }
+            Menu("Emoji") {
+                ForEach(Self.groupIconEmojiPalette, id: \.self) { emoji in
+                    Button(emoji) {
+                        store.send(.setWorkspaceIcon(id: workspaceID, icon: .emoji(emoji)))
+                    }
+                }
+            }
+            Button("Custom Emoji...") {
+                store.send(.requestWorkspaceCustomEmoji(workspaceID))
+            }
+            Divider()
+            Button("Reset to Letter") {
+                store.send(.setWorkspaceIcon(id: workspaceID, icon: nil))
+            }
+        }
+    }
+
     private func workspaceRow(
         workspaceStore: StoreOf<WorkspaceFeature>,
         depth: Int
@@ -1056,7 +1155,6 @@ struct WorkspaceListView: View {
             // as being consumed by the group rather than flying away.
             let isLanding = landingPreview?.workspaceID == workspaceID
 
-            let aggregateStatus = aggregateGitStatus(for: workspaceStore.state)
             // Show the dragged row nested when the current target is a
             // preview-only group drop (empty group `.intoGroup` or any
             // `.ontoGroupHeader`) so the visual matches where the
@@ -1069,11 +1167,9 @@ struct WorkspaceListView: View {
             WorkspaceRowView(
                 name: workspaceStore.name,
                 color: workspaceStore.color,
-                paneCount: workspaceStore.panes.count,
-                repoCount: workspaceStore.repoAssociations.count,
-                gitStatus: aggregateStatus,
                 isActive: workspaceID == store.activeWorkspaceID,
                 index: flatIndex,
+                icon: workspaceStore.icon,
                 waitingPaneCount: workspaceStore.panes.count(where: { $0.status == .waitingForInput }),
                 hasRunningPanes: workspaceStore.panes.contains { $0.status == .running },
                 isSelected: store.selectedWorkspaceIDs.contains(workspaceID),
@@ -1975,31 +2071,6 @@ struct WorkspaceListView: View {
                 workspaceID: workspaceID, groupID: groupID, index: nil
             ))
         }
-    }
-
-    /// Aggregate git status: dirty if any association is dirty, clean if all clean, unknown otherwise.
-    private func aggregateGitStatus(for workspace: WorkspaceFeature.State) -> RepoGitStatus {
-        let statuses = workspace.repoAssociations.map { assoc in
-            store.gitStatuses[assoc.id] ?? .unknown
-        }
-        if statuses.isEmpty { return .unknown }
-        if statuses.contains(where: { if case .dirty = $0 { true } else { false } }) {
-            var totalChanged = 0
-            var totalAdds = 0
-            var totalDels = 0
-            for status in statuses {
-                if case .dirty(let count, let adds, let dels) = status {
-                    totalChanged += count
-                    totalAdds += adds
-                    totalDels += dels
-                }
-            }
-            return .dirty(changedFiles: totalChanged, additions: totalAdds, deletions: totalDels)
-        }
-        if statuses.allSatisfy({ $0 == .clean }) {
-            return .clean
-        }
-        return .unknown
     }
 }
 

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -272,6 +272,12 @@ struct WorkspaceListView: View {
                         // can drive pixel-perfect scrolling and query
                         // documentVisibleRect for viewport detection.
                         ScrollViewFinder { sv in
+                            // Thin overlay scroller regardless of the system
+                            // "Show scroll bars: Always" setting. Re-asserted on
+                            // every update (ScrollViewFinder.updateNSView)
+                            // because AppKit reverts it to the wide legacy
+                            // scroller as the list re-lays-out.
+                            if sv.scrollerStyle != .overlay { sv.scrollerStyle = .overlay }
                             if hostScrollView !== sv { hostScrollView = sv }
                         }
                         .frame(height: 0)
@@ -683,6 +689,10 @@ struct WorkspaceListView: View {
                 selectionHeader
 
                 ScrollView {
+                    // Match the main list's thin overlay scroller (re-asserted
+                    // on every update; AppKit reverts it during re-layout).
+                    ScrollViewFinder { if $0.scrollerStyle != .overlay { $0.scrollerStyle = .overlay } }
+                        .frame(height: 0)
                     let ids = filteredWorkspaceIDs
                     if ids.isEmpty {
                         VStack(spacing: 4) {
@@ -2143,6 +2153,10 @@ private struct ScrollViewFinder: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context _: Context) {
         guard let probe = nsView as? ProbeView else { return }
         probe.onFound = onFound
+        // Re-fire on every SwiftUI update so callers can re-assert state AppKit
+        // resets during re-layout — e.g. the thin overlay scroller style, which
+        // otherwise reverts to the wide legacy scroller as the list navigates.
+        probe.reportIfAvailable()
     }
 
     private final class ProbeView: NSView {

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 struct WorkspaceListView: View {
     let store: StoreOf<AppReducer>
     @Environment(\.openSettings) private var openSettings
-    @Environment(\.colorScheme) private var systemScheme
     @Environment(\.chromeTheme) private var chromeTheme
     @State private var draggedWorkspaceID: UUID?
     /// Group currently being dragged (drag on a group header). Mutually
@@ -586,16 +585,6 @@ struct WorkspaceListView: View {
         return ids
     }
 
-    /// True when the resolved chrome appearance is currently dark — drives the
-    /// sun/moon glyph and which scheme the quick-toggle flips to.
-    private var isChromeDark: Bool {
-        switch store.settings.chromeAppearance {
-        case .dark: true
-        case .light: false
-        case .system: systemScheme == .dark
-        }
-    }
-
     private var filterField: some View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
@@ -638,21 +627,6 @@ struct WorkspaceListView: View {
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("sidebar.filter.clear")
             }
-
-            // Quick light/dark toggle for the warm chrome palette. Flips to the
-            // opposite explicit scheme; the tri-state (incl. System) lives in
-            // Settings → Appearance. Button only — no keybinding, so no
-            // KeyBindingMap collision.
-            Button {
-                store.send(.settings(.setChromeAppearance(isChromeDark ? .light : .dark)))
-            } label: {
-                Image(systemName: isChromeDark ? "moon.fill" : "sun.max.fill")
-                    .font(.system(size: 13))
-                    .foregroundStyle(chromeTheme.textSecondary)
-            }
-            .buttonStyle(.plain)
-            .help("Toggle light / dark chrome")
-            .accessibilityIdentifier("sidebar.appearance.toggle")
         }
         // Inner padding → the rounded "pill" fill; outer padding → the margin
         // between the pill and the sidebar edges (matches the mockup).

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -2163,8 +2163,8 @@ private struct ScrollViewFinder: NSViewRepresentable {
 
     private final class ProbeView: NSView {
         var onFound: ((NSScrollView) -> Void)?
-        // Registered/removed on the main thread; `nonisolated(unsafe)` so the
-        // nonisolated deinit can remove the observer.
+        /// Registered/removed on the main thread; `nonisolated(unsafe)` so the
+        /// nonisolated deinit can remove the observer.
         private nonisolated(unsafe) var updateObserver: NSObjectProtocol?
 
         override func viewDidMoveToWindow() {

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -597,14 +597,15 @@ struct WorkspaceListView: View {
     }
 
     private var filterField: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 11))
+                .font(.system(size: 13))
                 .foregroundStyle(chromeTheme.textTertiary)
 
             TextField("Filter workspaces or labels", text: $filterText)
                 .textFieldStyle(.plain)
-                .font(.system(size: 11))
+                .font(.system(size: 13))
+                .foregroundStyle(chromeTheme.textPrimary)
                 .focused($isFilterFieldFocused)
                 .accessibilityIdentifier("sidebar.filter.field")
                 .onSubmit {
@@ -631,7 +632,7 @@ struct WorkspaceListView: View {
                     isFilterFieldFocused = false
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 11))
+                        .font(.system(size: 13))
                         .foregroundStyle(chromeTheme.textTertiary)
                 }
                 .buttonStyle(.plain)
@@ -646,15 +647,27 @@ struct WorkspaceListView: View {
                 store.send(.settings(.setChromeAppearance(isChromeDark ? .light : .dark)))
             } label: {
                 Image(systemName: isChromeDark ? "moon.fill" : "sun.max.fill")
-                    .font(.system(size: 11))
+                    .font(.system(size: 13))
                     .foregroundStyle(chromeTheme.textSecondary)
             }
             .buttonStyle(.plain)
             .help("Toggle light / dark chrome")
             .accessibilityIdentifier("sidebar.appearance.toggle")
         }
+        // Inner padding → the rounded "pill" fill; outer padding → the margin
+        // between the pill and the sidebar edges (matches the mockup).
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(chromeTheme.textPrimary.opacity(0.05))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(chromeTheme.textPrimary.opacity(0.08), lineWidth: 1)
+                )
+        )
         .padding(.horizontal, 10)
-        .padding(.vertical, 6)
+        .padding(.vertical, 8)
         .background(chromeTheme.sidebarBackground)
     }
 

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -2163,20 +2163,31 @@ private struct ScrollViewFinder: NSViewRepresentable {
 
     private final class ProbeView: NSView {
         var onFound: ((NSScrollView) -> Void)?
-        // Set once on the main thread, read in deinit; `nonisolated(unsafe)` so
-        // the nonisolated deinit can remove the observer.
-        private nonisolated(unsafe) var styleObserver: NSObjectProtocol?
+        // Registered/removed on the main thread; `nonisolated(unsafe)` so the
+        // nonisolated deinit can remove the observer.
+        private nonisolated(unsafe) var updateObserver: NSObjectProtocol?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
-            // AppKit resets every scroll view to the system "preferred" scroller
-            // style on certain events — e.g. a WKWebView appearing when a
-            // markdown pane toggles edit/view. The sidebar doesn't re-render
-            // then, so re-assert the overlay style whenever that fires.
-            if styleObserver == nil {
-                styleObserver = NotificationCenter.default.addObserver(
-                    forName: NSScroller.preferredScrollerStyleDidChangeNotification,
-                    object: nil,
+            if let updateObserver {
+                NotificationCenter.default.removeObserver(updateObserver)
+                self.updateObserver = nil
+            }
+            if let window {
+                // AppKit reverts the thin overlay scroller back to the wide
+                // legacy scroller during layout passes that don't re-run this
+                // view's SwiftUI update — e.g. a markdown pane toggling
+                // edit/view, which creates/destroys a WKWebView. The system
+                // `preferredScrollerStyle` never changes (it stays on "always
+                // show"), so there's no scroller notification to hook; instead
+                // the window posts `didUpdate` after each layout pass. Re-assert
+                // the overlay style then — the same path a window resize takes,
+                // which is why resizing the window fixes it manually. The
+                // re-assert in `onFound` is guarded, so this is a cheap no-op
+                // once the style already sticks.
+                updateObserver = NotificationCenter.default.addObserver(
+                    forName: NSWindow.didUpdateNotification,
+                    object: window,
                     queue: .main
                 ) { [weak self] _ in
                     self?.reportIfAvailable()
@@ -2193,7 +2204,7 @@ private struct ScrollViewFinder: NSViewRepresentable {
         }
 
         deinit {
-            if let styleObserver { NotificationCenter.default.removeObserver(styleObserver) }
+            if let updateObserver { NotificationCenter.default.removeObserver(updateObserver) }
         }
     }
 }

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -2163,9 +2163,25 @@ private struct ScrollViewFinder: NSViewRepresentable {
 
     private final class ProbeView: NSView {
         var onFound: ((NSScrollView) -> Void)?
+        // Set once on the main thread, read in deinit; `nonisolated(unsafe)` so
+        // the nonisolated deinit can remove the observer.
+        private nonisolated(unsafe) var styleObserver: NSObjectProtocol?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            // AppKit resets every scroll view to the system "preferred" scroller
+            // style on certain events — e.g. a WKWebView appearing when a
+            // markdown pane toggles edit/view. The sidebar doesn't re-render
+            // then, so re-assert the overlay style whenever that fires.
+            if styleObserver == nil {
+                styleObserver = NotificationCenter.default.addObserver(
+                    forName: NSScroller.preferredScrollerStyleDidChangeNotification,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    self?.reportIfAvailable()
+                }
+            }
             DispatchQueue.main.async { [weak self] in
                 self?.reportIfAvailable()
             }
@@ -2174,6 +2190,10 @@ private struct ScrollViewFinder: NSViewRepresentable {
         func reportIfAvailable() {
             guard let sv = enclosingScrollView else { return }
             onFound?(sv)
+        }
+
+        deinit {
+            if let styleObserver { NotificationCenter.default.removeObserver(styleObserver) }
         }
     }
 }

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -2156,7 +2156,9 @@ private struct ScrollViewFinder: NSViewRepresentable {
         // Re-fire on every SwiftUI update so callers can re-assert state AppKit
         // resets during re-layout — e.g. the thin overlay scroller style, which
         // otherwise reverts to the wide legacy scroller as the list navigates.
-        probe.reportIfAvailable()
+        // Dispatched async so `onFound` (which captures @State) never mutates
+        // SwiftUI state synchronously during a view update.
+        DispatchQueue.main.async { [weak probe] in probe?.reportIfAvailable() }
     }
 
     private final class ProbeView: NSView {

--- a/Nex/Features/Workspace/WorkspaceRowView.swift
+++ b/Nex/Features/Workspace/WorkspaceRowView.swift
@@ -39,6 +39,7 @@ struct WorkspaceRowView: View {
     var labelStyles: [String: ResolvedLabelStyle] = [:]
 
     @Environment(\.chromeTheme) private var theme
+    @Environment(\.sidebarColorIntensity) private var colorIntensity
 
     /// Maximum chips rendered inline before collapsing into a `+N` more
     /// indicator. Three keeps rows visually compact in the narrow
@@ -106,11 +107,11 @@ struct WorkspaceRowView: View {
     /// running, blue = waiting) — matching the group header.
     private var avatar: some View {
         RoundedRectangle(cornerRadius: 5, style: .continuous)
-            .fill(color.color.opacity(0.20))
+            .fill(color.color.opacity(min(1, 0.20 * colorIntensity)))
             .frame(width: 22, height: 22)
             .overlay(
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .strokeBorder(color.color.opacity(0.45), lineWidth: 1)
+                    .strokeBorder(color.color.opacity(min(1, 0.45 * colorIntensity)), lineWidth: 1)
             )
             .overlay(avatarContent)
             .overlay(alignment: .topTrailing) {

--- a/Nex/Features/Workspace/WorkspaceRowView.swift
+++ b/Nex/Features/Workspace/WorkspaceRowView.swift
@@ -40,6 +40,7 @@ struct WorkspaceRowView: View {
 
     @Environment(\.chromeTheme) private var theme
     @Environment(\.sidebarColorIntensity) private var colorIntensity
+    @Environment(\.sidebarFillStroke) private var fillStroke
 
     /// Maximum chips rendered inline before collapsing into a `+N` more
     /// indicator. Three keeps rows visually compact in the narrow
@@ -107,11 +108,11 @@ struct WorkspaceRowView: View {
     /// running, blue = waiting) — matching the group header.
     private var avatar: some View {
         RoundedRectangle(cornerRadius: 5, style: .continuous)
-            .fill(color.color.opacity(min(1, 0.20 * colorIntensity)))
+            .fill(color.color.opacity(min(1, fillStroke.avatarFill * colorIntensity)))
             .frame(width: 22, height: 22)
             .overlay(
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .strokeBorder(color.color.opacity(min(1, 0.45 * colorIntensity)), lineWidth: 1)
+                    .strokeBorder(color.color.opacity(min(1, fillStroke.avatarStroke * colorIntensity)), lineWidth: 1)
             )
             .overlay(avatarContent)
             .overlay(alignment: .topTrailing) {

--- a/Nex/Features/Workspace/WorkspaceRowView.swift
+++ b/Nex/Features/Workspace/WorkspaceRowView.swift
@@ -1,16 +1,19 @@
 import SwiftUI
 
-/// Pulsing status dot used by workspace rows and group headers to signal
-/// agent activity in the sidebar.
-struct AgentStatusDot: View {
+/// Pulsing agent-activity dot overlaid on a workspace avatar or group icon
+/// corner. The `borderColor` ring separates it from the glyph underneath.
+struct PulsingStatusDot: View {
     let color: Color
+    let borderColor: Color
+    var size: CGFloat = 9
     @State private var isPulsing = false
 
     var body: some View {
         Circle()
             .fill(color)
-            .frame(width: 10, height: 10)
-            .opacity(isPulsing ? 0.3 : 1.0)
+            .frame(width: size, height: size)
+            .overlay(Circle().stroke(borderColor, lineWidth: 1.5))
+            .opacity(isPulsing ? 0.35 : 1.0)
             .animation(
                 .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
                 value: isPulsing
@@ -23,11 +26,9 @@ struct AgentStatusDot: View {
 struct WorkspaceRowView: View {
     let name: String
     let color: WorkspaceColor
-    let paneCount: Int
-    let repoCount: Int
-    let gitStatus: RepoGitStatus
     let isActive: Bool
     let index: Int
+    var icon: GroupIcon?
     var waitingPaneCount: Int = 0
     var hasRunningPanes: Bool = false
     var isSelected: Bool = false
@@ -37,18 +38,18 @@ struct WorkspaceRowView: View {
     /// level from the configured presets; a missing key renders neutral.
     var labelStyles: [String: ResolvedLabelStyle] = [:]
 
+    @Environment(\.chromeTheme) private var theme
+
     /// Maximum chips rendered inline before collapsing into a `+N` more
     /// indicator. Three keeps rows visually compact in the narrow
     /// sidebar; the inspector shows the full set.
     private static let maxInlineLabels = 3
 
     var body: some View {
-        HStack(spacing: 8) {
-            RoundedRectangle(cornerRadius: 3)
-                .fill(color.color)
-                .frame(width: 4, height: rowAccentHeight)
+        HStack(spacing: 9) {
+            avatar
 
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: 3) {
                 // Always semibold so a long name doesn't re-wrap when
                 // `isActive` toggles (regular and semibold measure
                 // differently per character). Active/inactive is still
@@ -56,45 +57,24 @@ struct WorkspaceRowView: View {
                 // highlight.
                 Text(name)
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(isActive ? .primary : .secondary)
-
-                HStack(spacing: 6) {
-                    Text("\(paneCount) pane\(paneCount == 1 ? "" : "s")")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.tertiary)
-
-                    if repoCount > 0 {
-                        HStack(spacing: 2) {
-                            gitStatusDot
-                            Text("\(repoCount)")
-                                .font(.system(size: 10))
-                                .foregroundStyle(.tertiary)
-                        }
-                    }
-                }
+                    .foregroundStyle(isActive ? theme.textPrimary : theme.textSecondary)
+                    .lineLimit(1)
 
                 if !labels.isEmpty {
-                    HStack(spacing: 3) {
+                    HStack(spacing: 4) {
                         ForEach(Array(labels.prefix(Self.maxInlineLabels)), id: \.self) { label in
                             RowLabelChip(text: label, style: labelStyles[label])
                         }
                         if labels.count > Self.maxInlineLabels {
                             Text("+\(labels.count - Self.maxInlineLabels)")
                                 .font(.system(size: 9, weight: .medium))
-                                .foregroundStyle(.tertiary)
+                                .foregroundStyle(theme.textTertiary)
                         }
                     }
-                    .padding(.top, 1)
                 }
             }
 
-            Spacer()
-
-            if waitingPaneCount > 0 {
-                AgentStatusDot(color: .blue)
-            } else if hasRunningPanes {
-                AgentStatusDot(color: .green)
-            }
+            Spacer(minLength: 4)
 
             // Negative indices opt out of the badge entirely. Used by
             // the filtered sidebar where workspace indices into
@@ -102,29 +82,17 @@ struct WorkspaceRowView: View {
             if index >= 0, index < 9 {
                 Text("⌘\(index + 1)")
                     .font(.system(size: 10, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(theme.textTertiary)
             }
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, 6)
         .padding(.horizontal, 8)
-        .background(
-            ZStack {
-                if isSelected {
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(Color.accentColor.opacity(0.18))
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(Color.accentColor.opacity(0.6), lineWidth: 1)
-                }
-                if isActive {
-                    RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.1))
-                    // Accent outline makes the active workspace more
-                    // prominent than the bare white fill could on its
-                    // own, especially against a busy sidebar.
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(Color.accentColor, lineWidth: 1.5)
-                }
-            }
-        )
+        .background(rowBackground)
+        // Outer gap (outside the selection ring) matching the group bands'
+        // 2pt, so the spacing between a row and an adjacent group/row is the
+        // same everywhere — incl. the gap between a selected row's ring and
+        // the group header above/below it.
+        .padding(.vertical, 2)
         // Nesting inset is applied AFTER the background so the fill +
         // outline stay within the row's content area. A nested row
         // gets its outline indented from the sidebar edge instead of
@@ -133,21 +101,70 @@ struct WorkspaceRowView: View {
         .contentShape(Rectangle())
     }
 
-    /// The color bar grows when label chips are visible so it stays
-    /// roughly aligned with the row's full content height.
-    private var rowAccentHeight: CGFloat {
-        labels.isEmpty ? 24 : 36
+    /// Rounded-square colour avatar carrying the workspace's initial, with
+    /// the agent-activity dot overlaid on its top-right corner (green =
+    /// running, blue = waiting) — matching the group header.
+    private var avatar: some View {
+        RoundedRectangle(cornerRadius: 5, style: .continuous)
+            .fill(color.color.opacity(0.20))
+            .frame(width: 22, height: 22)
+            .overlay(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .strokeBorder(color.color.opacity(0.45), lineWidth: 1)
+            )
+            .overlay(avatarContent)
+            .overlay(alignment: .topTrailing) {
+                if waitingPaneCount > 0 {
+                    statusDot(theme.statusWaiting)
+                } else if hasRunningPanes {
+                    statusDot(theme.statusRunning)
+                }
+            }
     }
 
+    private func statusDot(_ color: Color) -> some View {
+        PulsingStatusDot(color: color, borderColor: theme.sidebarBackground)
+            .offset(x: 3, y: -3)
+    }
+
+    /// Avatar contents: a custom emoji or SF Symbol when set, otherwise the
+    /// first letter of the workspace name.
     @ViewBuilder
-    private var gitStatusDot: some View {
-        let dotColor: Color = switch gitStatus {
-        case .unknown: .secondary
-        case .clean: .green
-        case .dirty: .orange
+    private var avatarContent: some View {
+        switch icon {
+        case .emoji(let grapheme):
+            Text(grapheme).font(.system(size: 12))
+        case .systemName(let symbolName):
+            Image(systemName: symbolName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(color.color)
+        case .none:
+            Text(avatarGlyph)
+                .font(.system(size: 11, weight: .bold, design: .rounded))
+                .foregroundStyle(color.color)
         }
-        Image(systemName: "arrow.triangle.branch")
-            .font(.system(size: 9, weight: .semibold))
-            .foregroundStyle(dotColor)
+    }
+
+    /// First grapheme of the name, upper-cased. Falls back to "?" for an
+    /// empty/whitespace name. Non-Latin scripts (e.g. kanji) render as-is.
+    private var avatarGlyph: String {
+        guard let first = name.trimmingCharacters(in: .whitespaces).first else { return "?" }
+        return String(first).uppercased()
+    }
+
+    private var rowBackground: some View {
+        ZStack {
+            if isSelected {
+                RoundedRectangle(cornerRadius: 7).fill(theme.selectionFill)
+                RoundedRectangle(cornerRadius: 7).stroke(theme.selectionStroke.opacity(0.7), lineWidth: 1)
+            }
+            if isActive {
+                RoundedRectangle(cornerRadius: 7).fill(theme.selectionFill.opacity(0.7))
+                // Accent outline makes the active workspace more prominent
+                // than the bare fill could on its own, especially against a
+                // busy sidebar.
+                RoundedRectangle(cornerRadius: 7).stroke(theme.selectionStroke, lineWidth: 1.5)
+            }
+        }
     }
 }

--- a/Nex/Ghostty/GhosttyConfigClient.swift
+++ b/Nex/Ghostty/GhosttyConfigClient.swift
@@ -10,6 +10,11 @@ struct GhosttyConfigClient: @unchecked Sendable {
     var backgroundOpacity: Double = 1.0
     var backgroundColor: NSColor = .windowBackgroundColor
 
+    /// Posted after `liveValue` changes (e.g. an appearance change) so the
+    /// SwiftUI `\.ghosttyConfig` environment can be re-injected and the
+    /// non-terminal panes pick up the new background live.
+    static let changedNotification = Notification.Name("nex.ghosttyConfigChanged")
+
     /// Build from the live ghostty config. Call on main actor after `GhosttyApp.shared.start()`.
     @MainActor
     static func load() -> GhosttyConfigClient {

--- a/Nex/Models/LabelPreset.swift
+++ b/Nex/Models/LabelPreset.swift
@@ -115,6 +115,10 @@ extension [LabelPreset] {
 /// GRDB entity graph.
 enum LabelPresetsStorage {
     static let defaultsKey = "settings.labelPresets"
+    /// One-shot marker for the legacy-label → preset back-fill. Once set, the
+    /// migration never runs again, so a preset the user later deletes is not
+    /// resurrected just because a workspace still carries that label.
+    static let migratedKey = "settings.labelPresets.migrated"
 
     private static let encoder = JSONEncoder()
     private static let decoder = JSONDecoder()

--- a/Nex/Models/Pane.swift
+++ b/Nex/Models/Pane.swift
@@ -37,6 +37,12 @@ struct Pane: Identifiable, Equatable {
     /// Closing this pane restores the source instead of taking the
     /// normal close path. In-memory only; not persisted.
     var parkedSourcePaneID: UUID?
+    /// Wall-clock time the current agent run started, used by the chrome
+    /// to show "claude · mm:ss" elapsed. Set when status transitions into
+    /// `.running` (guarded so repeated start pings within a run don't reset
+    /// it). Transient — not persisted, so a pane restored as `.running`
+    /// has this nil until the resumed agent re-emits a start.
+    var agentStartedAt: Date?
 
     /// Convenience accessor for rendering logic.
     var isUsingExternalEditor: Bool { externalEditorCommand != nil }
@@ -58,6 +64,7 @@ struct Pane: Identifiable, Equatable {
         agentSessionID: String? = nil,
         markdownFontSize: Double = Pane.defaultMarkdownFontSize,
         parkedSourcePaneID: UUID? = nil,
+        agentStartedAt: Date? = nil,
         createdAt: Date = Date(),
         lastActivityAt: Date = Date()
     ) {
@@ -75,6 +82,7 @@ struct Pane: Identifiable, Equatable {
         self.agentSessionID = agentSessionID
         self.markdownFontSize = markdownFontSize
         self.parkedSourcePaneID = parkedSourcePaneID
+        self.agentStartedAt = agentStartedAt
         self.createdAt = createdAt
         self.lastActivityAt = lastActivityAt
     }

--- a/Nex/Models/PaneLayout.swift
+++ b/Nex/Models/PaneLayout.swift
@@ -9,7 +9,7 @@ struct SplitDividerInfo: Identifiable {
 }
 
 indirect enum PaneLayout: Equatable, Codable {
-    static let dividerThickness: CGFloat = 4
+    static let dividerThickness: CGFloat = 2
     case leaf(UUID)
     case split(SplitDirection, ratio: Double, first: PaneLayout, second: PaneLayout)
     case empty

--- a/Nex/Models/WorkspaceColor.swift
+++ b/Nex/Models/WorkspaceColor.swift
@@ -1,7 +1,8 @@
+import AppKit
 import SwiftUI
 
 enum WorkspaceColor: String, Codable, CaseIterable, Identifiable {
-    case red, orange, yellow, green, blue, purple, pink, gray
+    case red, orange, yellow, green, blue, purple, pink, gray, black, white
 
     var id: String { rawValue }
 
@@ -15,7 +16,21 @@ enum WorkspaceColor: String, Codable, CaseIterable, Identifiable {
         case .purple: .purple
         case .pink: .pink
         case .gray: .gray
+        // Black/white are adaptive monochromes so they stay visible (and
+        // distinct from each other) against both the light and dark chrome:
+        // black is always the dark end, white the light end.
+        case .black: Self.adaptiveMono(light: 0.11, dark: 0.45)
+        case .white: Self.adaptiveMono(light: 0.68, dark: 0.96)
         }
+    }
+
+    /// A neutral grey whose brightness flips with the active appearance so a
+    /// monochrome workspace colour never disappears into the chrome.
+    private static func adaptiveMono(light: CGFloat, dark: CGFloat) -> Color {
+        Color(nsColor: NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            return NSColor(white: isDark ? dark : light, alpha: 1)
+        })
     }
 
     var displayName: String { rawValue.capitalized }

--- a/Nex/Models/WorkspaceGroup.swift
+++ b/Nex/Models/WorkspaceGroup.swift
@@ -51,3 +51,10 @@ struct GroupCustomEmojiPrompt: Equatable {
     let groupID: UUID
     let groupName: String
 }
+
+/// Workspace counterpart of `GroupCustomEmojiPrompt`, driving the custom
+/// emoji sheet for a workspace avatar icon.
+struct WorkspaceCustomEmojiPrompt: Equatable {
+    let workspaceID: UUID
+    let workspaceName: String
+}

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -11,6 +11,12 @@ struct NexApp: App {
     }
 
     @State private var shortcutMonitor: PaneShortcutMonitor?
+    // Holds the loaded ghostty config so the `\.ghosttyConfig` environment
+    // reflects the real terminal background once it's read in `.onAppear`.
+    // Injecting `.liveValue` directly captured the pre-load default
+    // (windowBackgroundColor), so markdown / scratchpad / diff panes rendered a
+    // different background from the terminal surfaces.
+    @State private var ghosttyConfig = GhosttyConfigClient()
     @StateObject private var updaterViewModel = UpdaterViewModel(
         startUpdater: !NexApp.isTestMode
     )
@@ -29,7 +35,7 @@ struct NexApp: App {
             RootChromeView(store: store)
                 .environment(\.surfaceManager, SurfaceManager.liveValue)
                 .environment(\.socketServer, SocketServer.liveValue)
-                .environment(\.ghosttyConfig, .liveValue)
+                .environment(\.ghosttyConfig, ghosttyConfig)
                 .environment(\.webPaneStore, WebPaneStore.liveValue)
                 .background(SpacesBindingAttacher())
                 .frame(minWidth: 600, minHeight: 400)
@@ -98,6 +104,9 @@ struct NexApp: App {
                     }
 
                     GhosttyConfigClient.liveValue = config
+                    // Drive the environment so the pane views (markdown /
+                    // scratchpad / diff) pick up the real terminal background.
+                    ghosttyConfig = config
 
                     if let window = NSApp.windows.first {
                         if config.backgroundOpacity < 1 {

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -26,7 +26,7 @@ struct NexApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView(store: store)
+            RootChromeView(store: store)
                 .environment(\.surfaceManager, SurfaceManager.liveValue)
                 .environment(\.socketServer, SocketServer.liveValue)
                 .environment(\.ghosttyConfig, .liveValue)
@@ -93,6 +93,14 @@ struct NexApp: App {
                             window.isOpaque = false
                             window.backgroundColor = .white.withAlphaComponent(0.001)
                         }
+                        // NB: do NOT set `isMovableByWindowBackground` — it turns
+                        // the whole window (incl. the sidebar) into a drag handle,
+                        // which hijacks sidebar row/group reordering. With
+                        // `.hiddenTitleBar` the titlebar region the custom title
+                        // bar overlaps is already window-draggable (its
+                        // non-interactive SwiftUI content reports
+                        // mouseDownCanMoveWindow), so the bar still moves the
+                        // window without breaking sidebar drags.
                     }
 
                     // Global hotkey callback — registration happens from the
@@ -142,7 +150,7 @@ struct NexApp: App {
                     shortcutMonitor = monitor
                 }
         }
-        .windowStyle(.titleBar)
+        .windowStyle(.hiddenTitleBar)
         .commands {
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesView(updaterViewModel: updaterViewModel)
@@ -152,7 +160,9 @@ struct NexApp: App {
         }
 
         Settings {
-            SettingsView(store: store)
+            ChromeThemed(store: store) {
+                SettingsView(store: store)
+            }
         }
 
         Window("Nex Help", id: "help") {

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -39,6 +39,12 @@ struct NexApp: App {
                 .environment(\.webPaneStore, WebPaneStore.liveValue)
                 .background(SpacesBindingAttacher())
                 .frame(minWidth: 600, minHeight: 400)
+                // An appearance change updates `liveValue` and posts this; mirror
+                // it into @State so the env re-injects and the non-terminal panes
+                // pick up the new terminal background live.
+                .onReceive(NotificationCenter.default.publisher(for: GhosttyConfigClient.changedNotification)) { _ in
+                    ghosttyConfig = .liveValue
+                }
                 .onAppear {
                     guard !Self.isTestMode else { return }
 

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -62,11 +62,22 @@ struct NexApp: App {
                     let statusBar = StatusBarController.liveValue
                     statusBar.setup()
                     statusBar.onSelectPane = { paneID, workspaceID in
-                        store.send(.setActiveWorkspace(workspaceID))
-                        store.send(.workspaces(.element(id: workspaceID, action: .focusPane(paneID))))
+                        // Raise the window FIRST. Making it key restores its
+                        // previous first responder (the previously-focused
+                        // surface), whose `becomeFirstResponder` re-emits
+                        // `paneFocusedNotification` and syncs focus back to the
+                        // OLD pane. Setting the new focus before that lets the
+                        // restoration revert it — which is why selecting a pane
+                        // in the already-active workspace snapped back to the
+                        // old pane (cross-workspace the old surface isn't in
+                        // view, so nothing reverts).
                         NSApp.activate()
-                        if let window = NSApp.windows.first {
-                            window.makeKeyAndOrderFront(nil)
+                        NSApp.windows.first?.makeKeyAndOrderFront(nil)
+                        store.send(.setActiveWorkspace(workspaceID))
+                        // Apply focus after the window has restored its old
+                        // first responder, so our selection is the last word.
+                        DispatchQueue.main.async {
+                            store.send(.workspaces(.element(id: workspaceID, action: .focusPane(paneID))))
                         }
                     }
 

--- a/Nex/Services/DatabaseService.swift
+++ b/Nex/Services/DatabaseService.swift
@@ -234,6 +234,17 @@ final class DatabaseService: Sendable {
             }
         }
 
+        migrator.registerMigration("v16_workspace_icon") { db in
+            // Guarded like the other ADD COLUMN migrations: a pre-release
+            // DB may already have the column from an earlier build.
+            let columns = try db.columns(in: "workspace").map(\.name)
+            if !columns.contains("icon") {
+                try db.alter(table: "workspace") { t in
+                    t.add(column: "icon", .text)
+                }
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }
@@ -253,6 +264,9 @@ struct WorkspaceRecord: Codable, FetchableRecord, PersistableRecord {
     var lastAccessedAt: Double
     var sortOrder: Int
     var labelsJSON: String
+    /// Prefix-qualified `GroupIcon.storageString` (`"system:<name>"` /
+    /// `"emoji:<grapheme>"`); nil falls back to the first-letter avatar.
+    var icon: String?
 }
 
 struct PaneRecord: Codable, FetchableRecord, PersistableRecord {

--- a/Nex/Services/PersistenceService.swift
+++ b/Nex/Services/PersistenceService.swift
@@ -202,6 +202,8 @@ actor PersistenceService {
                         .flatMap { try? JSONDecoder().decode([String].self, from: $0) }
                         ?? []
 
+                    let icon = record.icon.flatMap { GroupIcon(storageString: $0) }
+
                     let workspace = WorkspaceFeature.State(
                         id: wsID,
                         name: record.name,
@@ -214,6 +216,7 @@ actor PersistenceService {
                         createdAt: Date(timeIntervalSince1970: record.createdAt),
                         lastAccessedAt: Date(timeIntervalSince1970: record.lastAccessedAt),
                         labels: labels,
+                        icon: icon,
                         webPanes: webPanes
                     )
                     workspaces.append(workspace)
@@ -320,7 +323,8 @@ struct PersistenceSnapshot {
                 createdAt: workspace.createdAt.timeIntervalSince1970,
                 lastAccessedAt: workspace.lastAccessedAt.timeIntervalSince1970,
                 sortOrder: index,
-                labelsJSON: labelsJSON
+                labelsJSON: labelsJSON,
+                icon: workspace.icon?.storageString
             )
         }
 

--- a/Nex/Services/SystemStatsService.swift
+++ b/Nex/Services/SystemStatsService.swift
@@ -1,0 +1,84 @@
+import Darwin
+import Foundation
+
+/// A point-in-time snapshot of system resource usage shown in the footer.
+struct SystemStats: Equatable {
+    /// Aggregate CPU busy percentage across all cores (0…100).
+    var cpuPercent: Double
+    var memUsedBytes: UInt64
+    var memTotalBytes: UInt64
+    /// 1-minute load average.
+    var loadAverage1m: Double
+
+    var memPercent: Double {
+        memTotalBytes > 0 ? Double(memUsedBytes) / Double(memTotalBytes) * 100 : 0
+    }
+
+    static let zero = SystemStats(cpuPercent: 0, memUsedBytes: 0, memTotalBytes: 0, loadAverage1m: 0)
+}
+
+/// Samples system-wide CPU / memory / load via the Mach host APIs.
+///
+/// CPU is a delta of host CPU ticks between successive `sample()` calls, so the
+/// very first sample reports 0 until a baseline exists. This is a view-layer
+/// helper polled by the footer on a timer — it never touches TCA state, so it
+/// can't thrash persistence or effects.
+final class SystemStatsSampler {
+    private var previousTicks: host_cpu_load_info?
+
+    func sample() -> SystemStats {
+        SystemStats(
+            cpuPercent: sampleCPU(),
+            memUsedBytes: sampleMemoryUsed(),
+            memTotalBytes: ProcessInfo.processInfo.physicalMemory,
+            loadAverage1m: sampleLoad()
+        )
+    }
+
+    private func sampleCPU() -> Double {
+        var info = host_cpu_load_info()
+        var count = mach_msg_type_number_t(MemoryLayout<host_cpu_load_info_data_t>.stride / MemoryLayout<integer_t>.stride)
+        let result = withUnsafeMutablePointer(to: &info) { ptr in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return 0 }
+        defer { previousTicks = info }
+        guard let prev = previousTicks else { return 0 }
+        // cpu_ticks is (user, system, idle, nice). Wrapping subtraction guards
+        // the (rare) counter rollover.
+        let user = Double(info.cpu_ticks.0 &- prev.cpu_ticks.0)
+        let system = Double(info.cpu_ticks.1 &- prev.cpu_ticks.1)
+        let idle = Double(info.cpu_ticks.2 &- prev.cpu_ticks.2)
+        let nice = Double(info.cpu_ticks.3 &- prev.cpu_ticks.3)
+        let busy = user + system + nice
+        let total = busy + idle
+        guard total > 0 else { return 0 }
+        return min(100, max(0, busy / total * 100))
+    }
+
+    private func sampleMemoryUsed() -> UInt64 {
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64_data_t>.stride / MemoryLayout<integer_t>.stride)
+        let result = withUnsafeMutablePointer(to: &stats) { ptr in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return 0 }
+        let pageSize = UInt64(sysconf(_SC_PAGESIZE))
+        // Approximates Activity Monitor's "Memory Used" (App + Wired +
+        // Compressed); inactive/free are treated as available.
+        let active = UInt64(stats.active_count)
+        let wired = UInt64(stats.wire_count)
+        let compressed = UInt64(stats.compressor_page_count)
+        return (active + wired + compressed) * pageSize
+    }
+
+    private func sampleLoad() -> Double {
+        var loads = [Double](repeating: 0, count: 3)
+        guard getloadavg(&loads, 3) == 3 else { return 0 }
+        return loads[0]
+    }
+}

--- a/Nex/Services/SystemStatsService.swift
+++ b/Nex/Services/SystemStatsService.swift
@@ -65,6 +65,16 @@ enum SystemStatKind: String, CaseIterable, Identifiable, Codable {
         }
     }
 
+    /// Fixed width reserved for the value label so the footer layout doesn't
+    /// shift as the digit count changes (e.g. "5%" → "100%", "0B/s" → "1.4M/s").
+    var valueWidth: CGFloat {
+        switch self {
+        case .cpu, .memory, .diskSpace: 30 // "100%"
+        case .load: 40 // up to "999.99"
+        case .network, .diskIO: 58 // "1023.9K/s"
+        }
+    }
+
     /// The scalar plotted in the sparkline / history.
     func scalar(_ s: SystemStats) -> Double {
         switch self {

--- a/Nex/Services/SystemStatsService.swift
+++ b/Nex/Services/SystemStatsService.swift
@@ -65,13 +65,15 @@ enum SystemStatKind: String, CaseIterable, Identifiable, Codable {
         }
     }
 
-    /// Fixed width reserved for the value label so the footer layout doesn't
-    /// shift as the digit count changes (e.g. "5%" → "100%", "0B/s" → "1.4M/s").
-    var valueWidth: CGFloat {
+    /// Fixed width for the icon+value cluster. The cluster is right-aligned in
+    /// this slot so the value always abuts its sparkline (no internal gap) and
+    /// the slack falls before the icon, reading as inter-metric spacing — while
+    /// the value's right edge (and everything after) stays static.
+    var labelWidth: CGFloat {
         switch self {
-        case .cpu, .memory, .diskSpace: 30 // "100%"
-        case .load: 40 // up to "999.99"
-        case .network, .diskIO: 58 // "1023.9K/s"
+        case .cpu, .memory, .diskSpace: 44 // icon + "100%"
+        case .load: 50 // icon + "99.99"
+        case .network, .diskIO: 60 // icon + "999M/s"
         }
     }
 
@@ -128,8 +130,25 @@ enum SystemStatsFormat {
         return i == 0 ? "\(Int(v))\(units[i])" : String(format: "%.1f%@", v, units[i])
     }
 
+    /// Compact rate, bounded to ~6 chars ("0B/s", "1.4M/s", "999M/s") so the
+    /// footer slot stays tight. Switches units at 1000 to avoid 4-digit values
+    /// and drops decimals as the magnitude grows.
     static func rate(_ bytesPerSec: Double) -> String {
-        "\(bytes(bytesPerSec))/s"
+        let units = ["B", "K", "M", "G", "T"]
+        var v = bytesPerSec
+        var i = 0
+        while v >= 1000, i < units.count - 1 {
+            v /= 1000
+            i += 1
+        }
+        let num = if i == 0 || v >= 100 {
+            "\(Int(v.rounded()))"
+        } else if v >= 10 {
+            String(format: "%.0f", v)
+        } else {
+            String(format: "%.1f", v)
+        }
+        return "\(num)\(units[i])/s"
     }
 }
 

--- a/Nex/Services/SystemStatsService.swift
+++ b/Nex/Services/SystemStatsService.swift
@@ -1,38 +1,170 @@
 import Darwin
 import Foundation
+import IOKit
 
 /// A point-in-time snapshot of system resource usage shown in the footer.
 struct SystemStats: Equatable {
     /// Aggregate CPU busy percentage across all cores (0…100).
-    var cpuPercent: Double
-    var memUsedBytes: UInt64
-    var memTotalBytes: UInt64
+    var cpuPercent: Double = 0
+    var memUsedBytes: UInt64 = 0
+    var memTotalBytes: UInt64 = 0
     /// 1-minute load average.
-    var loadAverage1m: Double
+    var loadAverage1m: Double = 0
+    /// Network throughput (bytes/sec) since the previous sample.
+    var netDownBytesPerSec: Double = 0
+    var netUpBytesPerSec: Double = 0
+    /// Disk throughput (bytes/sec) since the previous sample.
+    var diskReadBytesPerSec: Double = 0
+    var diskWriteBytesPerSec: Double = 0
+    var diskUsedBytes: UInt64 = 0
+    var diskTotalBytes: UInt64 = 0
 
-    var memPercent: Double {
-        memTotalBytes > 0 ? Double(memUsedBytes) / Double(memTotalBytes) * 100 : 0
-    }
+    var memPercent: Double { memTotalBytes > 0 ? Double(memUsedBytes) / Double(memTotalBytes) * 100 : 0 }
+    var diskPercent: Double { diskTotalBytes > 0 ? Double(diskUsedBytes) / Double(diskTotalBytes) * 100 : 0 }
+    var netTotalBytesPerSec: Double { netDownBytesPerSec + netUpBytesPerSec }
+    var diskIOBytesPerSec: Double { diskReadBytesPerSec + diskWriteBytesPerSec }
 
-    static let zero = SystemStats(cpuPercent: 0, memUsedBytes: 0, memTotalBytes: 0, loadAverage1m: 0)
+    static let zero = SystemStats()
 }
 
-/// Samples system-wide CPU / memory / load via the Mach host APIs.
+/// One toggleable footer metric. Carries its display metadata so the footer and
+/// the Settings list stay in sync.
+enum SystemStatKind: String, CaseIterable, Identifiable, Codable {
+    case cpu, memory, load, network, diskIO, diskSpace
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .cpu: "CPU"
+        case .memory: "Memory"
+        case .load: "Load average"
+        case .network: "Network"
+        case .diskIO: "Disk I/O"
+        case .diskSpace: "Disk space"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .cpu: "cpu"
+        case .memory: "memorychip"
+        case .load: "gauge.with.dots.needle.33percent"
+        case .network: "network"
+        case .diskIO: "externaldrive.badge.timemachine"
+        case .diskSpace: "internaldrive"
+        }
+    }
+
+    /// Bounded 0–100 metrics scale their sparkline to a fixed 0…100; the rest
+    /// auto-scale to the visible window's max.
+    var isPercentage: Bool {
+        switch self {
+        case .cpu, .memory, .diskSpace: true
+        case .load, .network, .diskIO: false
+        }
+    }
+
+    /// The scalar plotted in the sparkline / history.
+    func scalar(_ s: SystemStats) -> Double {
+        switch self {
+        case .cpu: s.cpuPercent
+        case .memory: s.memPercent
+        case .load: s.loadAverage1m
+        case .network: s.netTotalBytesPerSec
+        case .diskIO: s.diskIOBytesPerSec
+        case .diskSpace: s.diskPercent
+        }
+    }
+
+    /// Compact label shown in the footer.
+    func compactLabel(_ s: SystemStats) -> String {
+        switch self {
+        case .cpu: "\(Int(s.cpuPercent.rounded()))%"
+        case .memory: "\(Int(s.memPercent.rounded()))%"
+        case .load: String(format: "%.2f", s.loadAverage1m)
+        case .network: SystemStatsFormat.rate(s.netTotalBytesPerSec)
+        case .diskIO: SystemStatsFormat.rate(s.diskIOBytesPerSec)
+        case .diskSpace: "\(Int(s.diskPercent.rounded()))%"
+        }
+    }
+
+    /// Verbose label shown in the hover popover.
+    func detailLabel(_ s: SystemStats) -> String {
+        switch self {
+        case .cpu: "\(Int(s.cpuPercent.rounded()))% busy"
+        case .memory: "\(SystemStatsFormat.bytes(s.memUsedBytes)) / \(SystemStatsFormat.bytes(s.memTotalBytes))"
+        case .load: String(format: "%.2f (1-min)", s.loadAverage1m)
+        case .network: "↓ \(SystemStatsFormat.rate(s.netDownBytesPerSec))   ↑ \(SystemStatsFormat.rate(s.netUpBytesPerSec))"
+        case .diskIO: "R \(SystemStatsFormat.rate(s.diskReadBytesPerSec))   W \(SystemStatsFormat.rate(s.diskWriteBytesPerSec))"
+        case .diskSpace: "\(SystemStatsFormat.bytes(s.diskUsedBytes)) / \(SystemStatsFormat.bytes(s.diskTotalBytes))"
+        }
+    }
+}
+
+/// Shared byte/rate formatting so the footer and popover agree.
+enum SystemStatsFormat {
+    static func bytes(_ value: UInt64) -> String {
+        bytes(Double(value))
+    }
+
+    static func bytes(_ value: Double) -> String {
+        let units = ["B", "K", "M", "G", "T"]
+        var v = value
+        var i = 0
+        while v >= 1024, i < units.count - 1 {
+            v /= 1024; i += 1
+        }
+        return i == 0 ? "\(Int(v))\(units[i])" : String(format: "%.1f%@", v, units[i])
+    }
+
+    static func rate(_ bytesPerSec: Double) -> String {
+        "\(bytes(bytesPerSec))/s"
+    }
+}
+
+/// Samples system-wide CPU / memory / load / network / disk via the Mach,
+/// BSD, and IOKit host APIs.
 ///
-/// CPU is a delta of host CPU ticks between successive `sample()` calls, so the
-/// very first sample reports 0 until a baseline exists. This is a view-layer
-/// helper polled by the footer on a timer — it never touches TCA state, so it
-/// can't thrash persistence or effects.
+/// Rate metrics (CPU, network, disk I/O) are deltas between successive
+/// `sample()` calls, so the first sample reports 0 until a baseline exists.
+/// This is a view-layer helper polled by the footer on a timer — it never
+/// touches TCA state, so it can't thrash persistence or effects.
 final class SystemStatsSampler {
     private var previousTicks: host_cpu_load_info?
+    private var previousNet: (down: UInt64, up: UInt64)?
+    private var previousDisk: (read: UInt64, write: UInt64)?
+    private var previousTime: Date?
 
     func sample() -> SystemStats {
-        SystemStats(
-            cpuPercent: sampleCPU(),
-            memUsedBytes: sampleMemoryUsed(),
-            memTotalBytes: ProcessInfo.processInfo.physicalMemory,
-            loadAverage1m: sampleLoad()
-        )
+        let now = Date()
+        let elapsed = previousTime.map { max(0.001, now.timeIntervalSince($0)) } ?? 0
+        previousTime = now
+
+        var stats = SystemStats()
+        stats.cpuPercent = sampleCPU()
+        stats.memUsedBytes = sampleMemoryUsed()
+        stats.memTotalBytes = ProcessInfo.processInfo.physicalMemory
+        stats.loadAverage1m = sampleLoad()
+
+        let net = sampleNetwork()
+        if let prev = previousNet, elapsed > 0 {
+            stats.netDownBytesPerSec = Double(net.down &- prev.down) / elapsed
+            stats.netUpBytesPerSec = Double(net.up &- prev.up) / elapsed
+        }
+        previousNet = net
+
+        let disk = sampleDiskIO()
+        if let prev = previousDisk, elapsed > 0 {
+            stats.diskReadBytesPerSec = Double(disk.read &- prev.read) / elapsed
+            stats.diskWriteBytesPerSec = Double(disk.write &- prev.write) / elapsed
+        }
+        previousDisk = disk
+
+        let space = sampleDiskSpace()
+        stats.diskUsedBytes = space.used
+        stats.diskTotalBytes = space.total
+        return stats
     }
 
     private func sampleCPU() -> Double {
@@ -46,8 +178,6 @@ final class SystemStatsSampler {
         guard result == KERN_SUCCESS else { return 0 }
         defer { previousTicks = info }
         guard let prev = previousTicks else { return 0 }
-        // cpu_ticks is (user, system, idle, nice). Wrapping subtraction guards
-        // the (rare) counter rollover.
         let user = Double(info.cpu_ticks.0 &- prev.cpu_ticks.0)
         let system = Double(info.cpu_ticks.1 &- prev.cpu_ticks.1)
         let idle = Double(info.cpu_ticks.2 &- prev.cpu_ticks.2)
@@ -68,8 +198,6 @@ final class SystemStatsSampler {
         }
         guard result == KERN_SUCCESS else { return 0 }
         let pageSize = UInt64(sysconf(_SC_PAGESIZE))
-        // Approximates Activity Monitor's "Memory Used" (App + Wired +
-        // Compressed); inactive/free are treated as available.
         let active = UInt64(stats.active_count)
         let wired = UInt64(stats.wire_count)
         let compressed = UInt64(stats.compressor_page_count)
@@ -80,5 +208,61 @@ final class SystemStatsSampler {
         var loads = [Double](repeating: 0, count: 3)
         guard getloadavg(&loads, 3) == 3 else { return 0 }
         return loads[0]
+    }
+
+    /// Sum ifi_ibytes/ifi_obytes across non-loopback link-layer interfaces.
+    /// The 32-bit counters wrap; wrapping subtraction keeps short-interval
+    /// rates correct as long as < 4 GiB moved between samples.
+    private func sampleNetwork() -> (down: UInt64, up: UInt64) {
+        var down: UInt64 = 0
+        var up: UInt64 = 0
+        var addrs: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&addrs) == 0, let first = addrs else { return (0, 0) }
+        defer { freeifaddrs(addrs) }
+        var ptr: UnsafeMutablePointer<ifaddrs>? = first
+        while let cur = ptr {
+            let name = String(cString: cur.pointee.ifa_name)
+            if cur.pointee.ifa_addr?.pointee.sa_family == UInt8(AF_LINK), !name.hasPrefix("lo"),
+               let data = cur.pointee.ifa_data?.assumingMemoryBound(to: if_data.self) {
+                down &+= UInt64(data.pointee.ifi_ibytes)
+                up &+= UInt64(data.pointee.ifi_obytes)
+            }
+            ptr = cur.pointee.ifa_next
+        }
+        return (down, up)
+    }
+
+    /// Sum cumulative bytes read/written across every IOBlockStorageDriver.
+    private func sampleDiskIO() -> (read: UInt64, write: UInt64) {
+        var read: UInt64 = 0
+        var write: UInt64 = 0
+        var iterator: io_iterator_t = 0
+        guard let matching = IOServiceMatching("IOBlockStorageDriver"),
+              IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator) == KERN_SUCCESS
+        else { return (0, 0) }
+        defer { IOObjectRelease(iterator) }
+        var drive = IOIteratorNext(iterator)
+        while drive != 0 {
+            var props: Unmanaged<CFMutableDictionary>?
+            if IORegistryEntryCreateCFProperties(drive, &props, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+               let dict = props?.takeRetainedValue() as? [String: Any],
+               let stats = dict["Statistics"] as? [String: Any] {
+                read &+= (stats["Bytes (Read)"] as? NSNumber)?.uint64Value ?? 0
+                write &+= (stats["Bytes (Write)"] as? NSNumber)?.uint64Value ?? 0
+            }
+            IOObjectRelease(drive)
+            drive = IOIteratorNext(iterator)
+        }
+        return (read, write)
+    }
+
+    private func sampleDiskSpace() -> (used: UInt64, total: UInt64) {
+        let url = URL(fileURLWithPath: NSHomeDirectory())
+        guard let values = try? url.resourceValues(forKeys: [.volumeTotalCapacityKey, .volumeAvailableCapacityKey]),
+              let total = values.volumeTotalCapacity, let available = values.volumeAvailableCapacity
+        else { return (0, 0) }
+        let totalU = UInt64(max(0, total))
+        let usedU = totalU - UInt64(max(0, available))
+        return (usedU, totalU)
     }
 }

--- a/Nex/Services/SystemStatsService.swift
+++ b/Nex/Services/SystemStatsService.swift
@@ -178,15 +178,20 @@ final class SystemStatsSampler {
 
         let net = sampleNetwork()
         if let prev = previousNet, elapsed > 0 {
-            stats.netDownBytesPerSec = Double(net.down &- prev.down) / elapsed
-            stats.netUpBytesPerSec = Double(net.up &- prev.up) / elapsed
+            // Treat any decrease as a counter reset → 0 for this sample. The
+            // 32-bit per-interface counters are summed into 64-bit before the
+            // delta, so a single interface's wrap (or one dropping out) shrinks
+            // the sum; a wrapping `&-` would underflow to a ~1.8e19 byte/s spike
+            // that auto-scales the sparkline and flattens the whole trace.
+            stats.netDownBytesPerSec = net.down >= prev.down ? Double(net.down - prev.down) / elapsed : 0
+            stats.netUpBytesPerSec = net.up >= prev.up ? Double(net.up - prev.up) / elapsed : 0
         }
         previousNet = net
 
         let disk = sampleDiskIO()
         if let prev = previousDisk, elapsed > 0 {
-            stats.diskReadBytesPerSec = Double(disk.read &- prev.read) / elapsed
-            stats.diskWriteBytesPerSec = Double(disk.write &- prev.write) / elapsed
+            stats.diskReadBytesPerSec = disk.read >= prev.read ? Double(disk.read - prev.read) / elapsed : 0
+            stats.diskWriteBytesPerSec = disk.write >= prev.write ? Double(disk.write - prev.write) / elapsed : 0
         }
         previousDisk = disk
 

--- a/Nex/Services/UserDefaultsClient.swift
+++ b/Nex/Services/UserDefaultsClient.swift
@@ -30,7 +30,13 @@ extension UserDefaultsClient: DependencyKey {
         )
     }()
 
-    static let testValue: UserDefaultsClient = {
+    static let testValue = ephemeral()
+
+    /// A fresh in-memory client with its own isolated storage. `testValue` is a
+    /// single shared instance, so its dict leaks across every TestStore in a run
+    /// — tests that assert on persisted flags (e.g. the one-shot label-migration
+    /// marker) must use a private `.ephemeral()` so the flag starts unset.
+    static func ephemeral() -> UserDefaultsClient {
         let storage = NSLock()
         nonisolated(unsafe) var dict: [String: Any] = [:]
         return UserDefaultsClient(
@@ -42,7 +48,7 @@ extension UserDefaultsClient: DependencyKey {
             setDouble: { val, key in storage.withLock { dict[key] = val } },
             setString: { val, key in storage.withLock { dict[key] = val } }
         )
-    }()
+    }
 }
 
 extension DependencyValues {

--- a/Nex/Theme/BuiltInChromeThemes.swift
+++ b/Nex/Theme/BuiltInChromeThemes.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// The eleven chrome colours a preset theme specifies, as `"RRGGBB"` strings.
+/// Mapped onto `ChromeColorKey`s for a single light/dark bucket.
+struct ChromePalette: Equatable {
+    let windowBackground: String
+    let sidebarBackground: String
+    let headerBackground: String
+    let footerBackground: String
+    let surfaceBackground: String
+    let accent: String
+    let paneFocus: String
+    let divider: String
+    let statusRunning: String
+    let statusWaiting: String
+    let statusInactive: String
+
+    /// `"<bucket>:<ChromeColorKey>"` → `"RRGGBB"` overrides for one appearance
+    /// bucket (`"light"` or `"dark"`).
+    func overrides(bucket: String) -> [String: String] {
+        [
+            "\(bucket):windowBackground": windowBackground,
+            "\(bucket):sidebarBackground": sidebarBackground,
+            "\(bucket):headerBackground": headerBackground,
+            "\(bucket):footerBackground": footerBackground,
+            "\(bucket):surfaceBackground": surfaceBackground,
+            "\(bucket):accent": accent,
+            "\(bucket):paneFocus": paneFocus,
+            "\(bucket):divider": divider,
+            "\(bucket):statusRunning": statusRunning,
+            "\(bucket):statusWaiting": statusWaiting,
+            "\(bucket):statusInactive": statusInactive
+        ]
+    }
+}
+
+/// A built-in chrome palette the user can apply in one click, modelled on a
+/// popular editor/terminal theme. Selecting one writes its palette into the
+/// matching appearance bucket and switches Light/Dark to suit — the terminal
+/// theme is left alone.
+struct BuiltInChromeTheme: Identifiable, Equatable {
+    let name: String
+    /// The mode this palette is designed for; selecting the theme switches to it.
+    let appearance: ChromeAppearance
+    let palette: ChromePalette
+
+    var id: String { name }
+
+    /// The shareable styling payload for this preset: the palette in its native
+    /// bucket, the sparkline tinted to the accent, everything else at defaults.
+    var styleTheme: ChromeStyleTheme {
+        ChromeStyleTheme(
+            version: ChromeStyleTheme.currentVersion,
+            name: name,
+            colorOverrides: palette.overrides(bucket: appearance == .light ? "light" : "dark"),
+            sidebarColorIntensity: 1.0,
+            sidebarAvatarFillOpacity: 0.20,
+            sidebarAvatarStrokeOpacity: 0.45,
+            sidebarGroupFillOpacity: -1,
+            sidebarGroupStrokeOpacity: 0.0,
+            sparklineColorHex: palette.accent,
+            sparklineWidth: 28,
+            sparklineStyle: "line"
+        )
+    }
+}
+
+extension BuiltInChromeTheme {
+    /// The preset gallery, ordered dark-first then light. Colours sampled from
+    /// each theme's published palette.
+    static let all: [BuiltInChromeTheme] = [
+        // Dracula — https://draculatheme.com
+        BuiltInChromeTheme(name: "Dracula", appearance: .dark, palette: ChromePalette(
+            windowBackground: "21222C",
+            sidebarBackground: "282A36",
+            headerBackground: "343746",
+            footerBackground: "282A36",
+            surfaceBackground: "2B2D3A",
+            accent: "BD93F9",
+            paneFocus: "BD93F9",
+            divider: "44475A",
+            statusRunning: "50FA7B",
+            statusWaiting: "8BE9FD",
+            statusInactive: "6272A4"
+        )),
+        // Nord — https://www.nordtheme.com
+        BuiltInChromeTheme(name: "Nord", appearance: .dark, palette: ChromePalette(
+            windowBackground: "2E3440",
+            sidebarBackground: "2E3440",
+            headerBackground: "3B4252",
+            footerBackground: "2E3440",
+            surfaceBackground: "353C4A",
+            accent: "88C0D0",
+            paneFocus: "88C0D0",
+            divider: "3B4252",
+            statusRunning: "A3BE8C",
+            statusWaiting: "81A1C1",
+            statusInactive: "4C566A"
+        )),
+        // Gruvbox Dark — https://github.com/morhetz/gruvbox
+        BuiltInChromeTheme(name: "Gruvbox Dark", appearance: .dark, palette: ChromePalette(
+            windowBackground: "1D2021",
+            sidebarBackground: "282828",
+            headerBackground: "3C3836",
+            footerBackground: "282828",
+            surfaceBackground: "32302F",
+            accent: "FE8019",
+            paneFocus: "FE8019",
+            divider: "3C3836",
+            statusRunning: "B8BB26",
+            statusWaiting: "83A598",
+            statusInactive: "7C6F64"
+        )),
+        // Tokyo Night — https://github.com/folke/tokyonight.nvim
+        BuiltInChromeTheme(name: "Tokyo Night", appearance: .dark, palette: ChromePalette(
+            windowBackground: "16161E",
+            sidebarBackground: "1A1B26",
+            headerBackground: "1F2335",
+            footerBackground: "1A1B26",
+            surfaceBackground: "1F2335",
+            accent: "7AA2F7",
+            paneFocus: "7AA2F7",
+            divider: "292E42",
+            statusRunning: "9ECE6A",
+            statusWaiting: "7DCFFF",
+            statusInactive: "565F89"
+        )),
+        // Catppuccin Mocha — https://catppuccin.com
+        BuiltInChromeTheme(name: "Catppuccin Mocha", appearance: .dark, palette: ChromePalette(
+            windowBackground: "181825",
+            sidebarBackground: "1E1E2E",
+            headerBackground: "313244",
+            footerBackground: "1E1E2E",
+            surfaceBackground: "313244",
+            accent: "CBA6F7",
+            paneFocus: "CBA6F7",
+            divider: "45475A",
+            statusRunning: "A6E3A1",
+            statusWaiting: "89B4FA",
+            statusInactive: "6C7086"
+        )),
+        // Solarized Light — https://ethanschoonover.com/solarized
+        BuiltInChromeTheme(name: "Solarized Light", appearance: .light, palette: ChromePalette(
+            windowBackground: "EEE8D5",
+            sidebarBackground: "EEE8D5",
+            headerBackground: "FDF6E3",
+            footerBackground: "EEE8D5",
+            surfaceBackground: "FDF6E3",
+            accent: "268BD2",
+            paneFocus: "268BD2",
+            divider: "D9D2BE",
+            statusRunning: "859900",
+            statusWaiting: "2AA198",
+            statusInactive: "93A1A1"
+        )),
+        // Gruvbox Light — https://github.com/morhetz/gruvbox
+        BuiltInChromeTheme(name: "Gruvbox Light", appearance: .light, palette: ChromePalette(
+            windowBackground: "EBDBB2",
+            sidebarBackground: "FBF1C7",
+            headerBackground: "F2E5BC",
+            footerBackground: "FBF1C7",
+            surfaceBackground: "FBF1C7",
+            accent: "AF3A03",
+            paneFocus: "AF3A03",
+            divider: "D5C4A1",
+            statusRunning: "79740E",
+            statusWaiting: "076678",
+            statusInactive: "7C6F64"
+        ))
+    ]
+}

--- a/Nex/Theme/ChromeStyleTheme.swift
+++ b/Nex/Theme/ChromeStyleTheme.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// A shareable bundle of the user's custom chrome styling: the per-appearance
+/// colour overrides (both the light *and* dark buckets), the sidebar colour
+/// intensity / fill-stroke opacities, and the sparkline styling. Serialises to
+/// a `.nextheme` JSON file or a single-line copy-pasteable code, so a look can
+/// be shared between installs.
+///
+/// Deliberately excludes the recipient's light/dark mode and terminal
+/// background: importing a theme restyles the chrome without forcing those.
+struct ChromeStyleTheme: Codable, Equatable {
+    /// Bumped when the serialised shape changes incompatibly. Decoders reject a
+    /// version newer than they understand rather than silently dropping fields.
+    static let currentVersion = 1
+
+    /// Prefix on the share-code form so a pasted blob is recognisable and can be
+    /// stripped before base64-decoding.
+    static let codePrefix = "nex-theme:"
+
+    var version: Int
+    /// Optional label (the file name on export); echoed back on import.
+    var name: String?
+
+    /// `"<light|dark>:<ChromeColorKey>"` → `"RRGGBB"`, carrying both buckets.
+    var colorOverrides: [String: String]
+
+    var sidebarColorIntensity: Double
+    var sidebarAvatarFillOpacity: Double
+    var sidebarAvatarStrokeOpacity: Double
+    var sidebarGroupFillOpacity: Double
+    var sidebarGroupStrokeOpacity: Double
+
+    var sparklineColorHex: String
+    var sparklineWidth: Double
+    var sparklineStyle: String
+}
+
+extension ChromeStyleTheme {
+    // MARK: - File form (pretty JSON)
+
+    /// Pretty-printed JSON for the `.nextheme` file form.
+    func jsonData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(self)
+    }
+
+    /// Decode from `.nextheme` (or any theme JSON) data, rejecting a version
+    /// produced by a newer Nex than this one understands.
+    init(jsonData data: Data) throws {
+        let decoded = try JSONDecoder().decode(ChromeStyleTheme.self, from: data)
+        guard decoded.version <= Self.currentVersion else {
+            throw ChromeStyleThemeError.unsupportedVersion(decoded.version)
+        }
+        self = decoded
+    }
+
+    // MARK: - Code form (prefixed base64 of compact JSON)
+
+    /// A single-line, copy-pasteable code: `nex-theme:<base64(compact JSON)>`.
+    func shareCode() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(self)
+        return Self.codePrefix + data.base64EncodedString()
+    }
+
+    /// Decode from a share code. Accepts the prefixed base64 form, a bare
+    /// base64 blob, or the raw JSON file contents pasted directly — so any
+    /// export form round-trips. Anything else throws `invalidCode`.
+    init(shareCode code: String) throws {
+        let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        var body = trimmed
+        if body.hasPrefix(Self.codePrefix) {
+            body.removeFirst(Self.codePrefix.count)
+        }
+        body = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let data = Data(base64Encoded: body) {
+            try self.init(jsonData: data)
+            return
+        }
+        if trimmed.first == "{", let data = trimmed.data(using: .utf8) {
+            try self.init(jsonData: data)
+            return
+        }
+        throw ChromeStyleThemeError.invalidCode
+    }
+}
+
+enum ChromeStyleThemeError: Error, Equatable {
+    case invalidCode
+    case unsupportedVersion(Int)
+
+    /// User-facing message for the Settings status line.
+    var message: String {
+        switch self {
+        case .invalidCode:
+            "That doesn't look like a Nex theme."
+        case .unsupportedVersion(let version):
+            "This theme was made with a newer version of Nex (v\(version))."
+        }
+    }
+}

--- a/Nex/Theme/ChromeTheme.swift
+++ b/Nex/Theme/ChromeTheme.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Dedicated warm app-chrome palette, intentionally independent of the
@@ -75,6 +76,91 @@ struct ChromeTheme: Equatable {
         activeAgent: .hex(0xD3A329),
         groupBandOpacity: 0.22
     )
+
+    /// Returns a copy with the given user overrides layered on top of the
+    /// preset. The `accent` override also drives the selection stroke/fill and
+    /// the "awaiting input" status colour, since they're all the one highlight.
+    func applying(_ overrides: [ChromeColorKey: Color]) -> ChromeTheme {
+        guard !overrides.isEmpty else { return self }
+        let newAccent = overrides[.accent] ?? accent
+        return ChromeTheme(
+            windowBackground: overrides[.windowBackground] ?? windowBackground,
+            sidebarBackground: overrides[.sidebarBackground] ?? sidebarBackground,
+            surfaceBackground: overrides[.surfaceBackground] ?? surfaceBackground,
+            headerBackground: overrides[.headerBackground] ?? headerBackground,
+            footerBackground: overrides[.footerBackground] ?? footerBackground,
+            textPrimary: textPrimary,
+            textSecondary: textSecondary,
+            textTertiary: textTertiary,
+            divider: overrides[.divider] ?? divider,
+            selectionFill: overrides[.accent].map { $0.opacity(0.18) } ?? selectionFill,
+            selectionStroke: newAccent,
+            accent: newAccent,
+            statusRunning: statusRunning,
+            statusWaiting: overrides[.accent] ?? statusWaiting,
+            statusDone: statusDone,
+            activeAgent: activeAgent,
+            groupBandOpacity: groupBandOpacity
+        )
+    }
+
+    /// One-stop resolution used by both `RootChromeView` and `ChromeThemed`:
+    /// pick the preset for the (resolved) appearance, then layer the user's
+    /// per-appearance colour overrides from `SettingsFeature`.
+    static func resolve(
+        appearance: ChromeAppearance,
+        system: ColorScheme,
+        overrides: [String: String]
+    ) -> ChromeTheme {
+        let base = appearance.theme(system: system)
+        guard !overrides.isEmpty else { return base }
+        let concrete = appearance.concrete(system: system)
+        var parsed: [ChromeColorKey: Color] = [:]
+        for key in ChromeColorKey.allCases {
+            if let hex = overrides["\(concrete):\(key.rawValue)"], let color = Color(chromeHex: hex) {
+                parsed[key] = color
+            }
+        }
+        return base.applying(parsed)
+    }
+}
+
+/// The chrome colours a user can override in Settings → Appearance. Each maps
+/// to one (or, for `accent`, a small cluster of) `ChromeTheme` field(s).
+enum ChromeColorKey: String, CaseIterable, Identifiable {
+    case windowBackground
+    case sidebarBackground
+    case footerBackground
+    case headerBackground
+    case surfaceBackground
+    case accent
+    case divider
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .windowBackground: "Window gaps"
+        case .sidebarBackground: "Sidebar"
+        case .footerBackground: "Status bar / footer"
+        case .headerBackground: "Pane header / title bar"
+        case .surfaceBackground: "Surface (Settings, sheets, palette)"
+        case .accent: "Highlight (selection / focus)"
+        case .divider: "Dividers / borders"
+        }
+    }
+
+    func value(in theme: ChromeTheme) -> Color {
+        switch self {
+        case .windowBackground: theme.windowBackground
+        case .sidebarBackground: theme.sidebarBackground
+        case .footerBackground: theme.footerBackground
+        case .headerBackground: theme.headerBackground
+        case .surfaceBackground: theme.surfaceBackground
+        case .accent: theme.accent
+        case .divider: theme.divider
+        }
+    }
 }
 
 /// User preference for the chrome palette. `.system` follows the macOS
@@ -107,6 +193,16 @@ enum ChromeAppearance: String, CaseIterable, Equatable {
         case .light: .light
         case .dark: .dark
         case .system: system == .dark ? .dark : .light
+        }
+    }
+
+    /// The concrete light/dark bucket colour overrides are stored under, so a
+    /// custom colour only applies to the appearance it was picked for.
+    func concrete(system: ColorScheme) -> String {
+        switch self {
+        case .light: "light"
+        case .dark: "dark"
+        case .system: system == .dark ? "dark" : "light"
         }
     }
 }
@@ -142,6 +238,24 @@ extension Color {
             blue: Double(value & 0xFF) / 255.0,
             opacity: 1.0
         )
+    }
+
+    /// Parse a `"RRGGBB"` (or `"#RRGGBB"`) string into an opaque colour.
+    init?(chromeHex: String) {
+        var string = chromeHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if string.hasPrefix("#") { string.removeFirst() }
+        guard string.count == 6, let value = UInt32(string, radix: 16) else { return nil }
+        self = .hex(value)
+    }
+
+    /// Serialise to an uppercase `"RRGGBB"` string for persistence. Returns nil
+    /// only if the colour can't be expressed in sRGB.
+    var chromeHexString: String? {
+        guard let c = NSColor(self).usingColorSpace(.sRGB) else { return nil }
+        let r = Int((c.redComponent * 255).rounded())
+        let g = Int((c.greenComponent * 255).rounded())
+        let b = Int((c.blueComponent * 255).rounded())
+        return String(format: "%02X%02X%02X", r, g, b)
     }
 }
 

--- a/Nex/Theme/ChromeTheme.swift
+++ b/Nex/Theme/ChromeTheme.swift
@@ -264,4 +264,8 @@ extension EnvironmentValues {
     /// rendered before `RootChromeView` injects a value still read a concrete
     /// theme.
     @Entry var chromeTheme: ChromeTheme = .light
+
+    /// Multiplier on the opacity of the sidebar's WorkspaceColour-tinted
+    /// elements (group bands + workspace avatars). 1 = preset intensity.
+    @Entry var sidebarColorIntensity: Double = 1.0
 }

--- a/Nex/Theme/ChromeTheme.swift
+++ b/Nex/Theme/ChromeTheme.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Dedicated warm app-chrome palette, intentionally independent of the
+/// Ghostty terminal theme. Drives the sidebar, window title bar, pane
+/// headers, and the bottom status bar so the chrome reads as a single
+/// designed surface regardless of which terminal theme the user runs.
+///
+/// Resolved (never stored in TCA state) from `ChromeAppearance` + the
+/// system colour scheme and injected via `EnvironmentValues.chromeTheme`.
+struct ChromeTheme: Equatable {
+    // Surfaces
+    let windowBackground: Color
+    let sidebarBackground: Color
+    let surfaceBackground: Color
+    let headerBackground: Color
+    let footerBackground: Color
+    // Text
+    let textPrimary: Color
+    let textSecondary: Color
+    let textTertiary: Color
+    // Structure
+    let divider: Color
+    let selectionFill: Color
+    let selectionStroke: Color
+    let accent: Color
+    // Semantic status (chrome-specific; not the system .green/.blue used before)
+    let statusRunning: Color
+    let statusWaiting: Color
+    let statusDone: Color
+    let activeAgent: Color
+    /// Opacity applied to a group's colour for its full-width header band.
+    /// Light needs more to read as a pastel; dark needs less over near-black.
+    let groupBandOpacity: Double
+
+    /// Surfaces sampled from the "Refined" mockups: neutral light (not a warm
+    /// cream) and a near-black, cool dark (not warm brown).
+    static let light = ChromeTheme(
+        windowBackground: .hex(0xEAE8E2),
+        sidebarBackground: .hex(0xEFEEE9),
+        surfaceBackground: .hex(0xFFFFFF),
+        // Pane headers are intentionally a touch lighter than the
+        // sidebar/footer/title-bar tone, sitting between it and the pane body.
+        headerBackground: .hex(0xF7F6F2),
+        footerBackground: .hex(0xEFEEE9),
+        textPrimary: .hex(0x2B2B2E),
+        textSecondary: .hex(0x6B6C70),
+        textTertiary: .hex(0x9A9A96),
+        divider: .hex(0xDEDCD5),
+        selectionFill: Color.hex(0x5E8AC4).opacity(0.16),
+        selectionStroke: .hex(0x5E8AC4),
+        accent: .hex(0x5E8AC4),
+        statusRunning: .hex(0x4FA46B),
+        statusWaiting: .hex(0x5E8AC4),
+        statusDone: .hex(0x9A9A96),
+        activeAgent: .hex(0xA97C17),
+        groupBandOpacity: 0.30
+    )
+
+    static let dark = ChromeTheme(
+        windowBackground: .hex(0x0A0A0C),
+        sidebarBackground: .hex(0x0C0C10),
+        surfaceBackground: .hex(0x101013),
+        headerBackground: .hex(0x13131A),
+        footerBackground: .hex(0x0C0C10),
+        textPrimary: .hex(0xE6E6EA),
+        textSecondary: .hex(0x9A9AA0),
+        textTertiary: .hex(0x6A6A72),
+        divider: .hex(0x24242B),
+        selectionFill: Color.hex(0x5276B8).opacity(0.24),
+        selectionStroke: .hex(0x5276B8),
+        accent: .hex(0x6F9BD8),
+        statusRunning: .hex(0x5FBE89),
+        statusWaiting: .hex(0x6F9BD8),
+        statusDone: .hex(0x8A8A92),
+        activeAgent: .hex(0xD3A329),
+        groupBandOpacity: 0.22
+    )
+}
+
+/// User preference for the chrome palette. `.system` follows the macOS
+/// appearance; `.light`/`.dark` force the chrome (and the whole window,
+/// via `.preferredColorScheme`) regardless of the system setting.
+enum ChromeAppearance: String, CaseIterable, Equatable {
+    case system
+    case light
+    case dark
+
+    var displayName: String {
+        switch self {
+        case .system: "System"
+        case .light: "Light"
+        case .dark: "Dark"
+        }
+    }
+
+    /// `nil` for `.system` so we don't override the window's colour scheme.
+    var explicitScheme: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+
+    func theme(system: ColorScheme) -> ChromeTheme {
+        switch self {
+        case .light: .light
+        case .dark: .dark
+        case .system: system == .dark ? .dark : .light
+        }
+    }
+}
+
+/// Abbreviate the user's home directory to `~` in a path. Shared by the
+/// status bar and pane header so they agree on display form.
+func chromeHomeAbbreviated(_ path: String) -> String {
+    let home = NSHomeDirectory()
+    if path == home { return "~" }
+    if path.hasPrefix(home + "/") { return "~" + path.dropFirst(home.count) }
+    return path
+}
+
+/// "4m 9s"-style elapsed label shared by the status bar and pane-header
+/// agent badges. Clamps negatives to zero.
+func chromeElapsedLabel(from start: Date, to now: Date) -> String {
+    let total = max(0, Int(now.timeIntervalSince(start)))
+    let hours = total / 3600
+    let minutes = (total % 3600) / 60
+    let seconds = total % 60
+    if hours > 0 { return "\(hours)h \(minutes)m" }
+    if minutes > 0 { return "\(minutes)m \(seconds)s" }
+    return "\(seconds)s"
+}
+
+extension Color {
+    /// Build an opaque sRGB colour from a packed 0xRRGGBB literal.
+    static func hex(_ value: UInt32) -> Color {
+        Color(
+            .sRGB,
+            red: Double((value >> 16) & 0xFF) / 255.0,
+            green: Double((value >> 8) & 0xFF) / 255.0,
+            blue: Double(value & 0xFF) / 255.0,
+            opacity: 1.0
+        )
+    }
+}
+
+extension EnvironmentValues {
+    /// Active chrome palette. Defaults to `.light` so previews and any view
+    /// rendered before `RootChromeView` injects a value still read a concrete
+    /// theme.
+    @Entry var chromeTheme: ChromeTheme = .light
+}

--- a/Nex/Theme/ChromeTheme.swift
+++ b/Nex/Theme/ChromeTheme.swift
@@ -83,8 +83,10 @@ struct ChromeTheme: Equatable {
     )
 
     /// Returns a copy with the given user overrides layered on top of the
-    /// preset. The `accent` override also drives the selection stroke/fill and
-    /// the "awaiting input" status colour, since they're all the one highlight.
+    /// preset. The `accent` override also drives the selection stroke/fill,
+    /// since they're the one sidebar highlight. The agent status colours are
+    /// independently overridable (`statusRunning` / `statusWaiting` /
+    /// `statusDone`).
     func applying(_ overrides: [ChromeColorKey: Color]) -> ChromeTheme {
         guard !overrides.isEmpty else { return self }
         let newAccent = overrides[.accent] ?? accent
@@ -102,9 +104,9 @@ struct ChromeTheme: Equatable {
             selectionStroke: newAccent,
             accent: newAccent,
             paneFocus: overrides[.paneFocus] ?? paneFocus,
-            statusRunning: statusRunning,
-            statusWaiting: overrides[.accent] ?? statusWaiting,
-            statusDone: statusDone,
+            statusRunning: overrides[.statusRunning] ?? statusRunning,
+            statusWaiting: overrides[.statusWaiting] ?? statusWaiting,
+            statusDone: overrides[.statusDone] ?? statusDone,
             activeAgent: activeAgent,
             groupBandOpacity: groupBandOpacity
         )
@@ -142,8 +144,23 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
     case accent
     case paneFocus
     case divider
+    // Agent status colours — rendered everywhere agent status appears (status
+    // bar, sidebar dots, pane-header badges, title-bar dot, menu-bar icon +
+    // popover). Grouped into their own Settings section via `isAgentStatus`.
+    case statusRunning
+    case statusWaiting
+    case statusDone
 
     var id: String { rawValue }
+
+    /// Agent status colours are shown in a separate "Agent status" Settings
+    /// section from the chrome surface colours.
+    var isAgentStatus: Bool {
+        switch self {
+        case .statusRunning, .statusWaiting, .statusDone: true
+        default: false
+        }
+    }
 
     var displayName: String {
         switch self {
@@ -155,6 +172,9 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
         case .accent: "Sidebar highlight"
         case .paneFocus: "Pane focus"
         case .divider: "Dividers / borders"
+        case .statusRunning: "Running"
+        case .statusWaiting: "Awaiting input"
+        case .statusDone: "Done"
         }
     }
 
@@ -168,6 +188,9 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
         case .accent: theme.accent
         case .paneFocus: theme.paneFocus
         case .divider: theme.divider
+        case .statusRunning: theme.statusRunning
+        case .statusWaiting: theme.statusWaiting
+        case .statusDone: theme.statusDone
         }
     }
 }

--- a/Nex/Theme/ChromeTheme.swift
+++ b/Nex/Theme/ChromeTheme.swift
@@ -30,7 +30,7 @@ struct ChromeTheme: Equatable {
     // Semantic status (chrome-specific; not the system .green/.blue used before)
     let statusRunning: Color
     let statusWaiting: Color
-    let statusDone: Color
+    let statusInactive: Color
     let activeAgent: Color
     /// Opacity applied to a group's colour for its full-width header band.
     /// Light needs more to read as a pastel; dark needs less over near-black.
@@ -56,7 +56,7 @@ struct ChromeTheme: Equatable {
         paneFocus: .hex(0x5E8AC4),
         statusRunning: .hex(0x4FA46B),
         statusWaiting: .hex(0x5E8AC4),
-        statusDone: .hex(0x9A9A96),
+        statusInactive: .hex(0x9A9A96),
         activeAgent: .hex(0xA97C17),
         groupBandOpacity: 0.30
     )
@@ -77,7 +77,7 @@ struct ChromeTheme: Equatable {
         paneFocus: .hex(0x6F9BD8),
         statusRunning: .hex(0x5FBE89),
         statusWaiting: .hex(0x6F9BD8),
-        statusDone: .hex(0x8A8A92),
+        statusInactive: .hex(0x8A8A92),
         activeAgent: .hex(0xD3A329),
         groupBandOpacity: 0.22
     )
@@ -86,7 +86,7 @@ struct ChromeTheme: Equatable {
     /// preset. The `accent` override also drives the selection stroke/fill,
     /// since they're the one sidebar highlight. The agent status colours are
     /// independently overridable (`statusRunning` / `statusWaiting` /
-    /// `statusDone`).
+    /// `statusInactive`).
     func applying(_ overrides: [ChromeColorKey: Color]) -> ChromeTheme {
         guard !overrides.isEmpty else { return self }
         let newAccent = overrides[.accent] ?? accent
@@ -106,7 +106,7 @@ struct ChromeTheme: Equatable {
             paneFocus: overrides[.paneFocus] ?? paneFocus,
             statusRunning: overrides[.statusRunning] ?? statusRunning,
             statusWaiting: overrides[.statusWaiting] ?? statusWaiting,
-            statusDone: overrides[.statusDone] ?? statusDone,
+            statusInactive: overrides[.statusInactive] ?? statusInactive,
             activeAgent: activeAgent,
             groupBandOpacity: groupBandOpacity
         )
@@ -149,7 +149,7 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
     // popover). Grouped into their own Settings section via `isAgentStatus`.
     case statusRunning
     case statusWaiting
-    case statusDone
+    case statusInactive
 
     var id: String { rawValue }
 
@@ -157,7 +157,7 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
     /// section from the chrome surface colours.
     var isAgentStatus: Bool {
         switch self {
-        case .statusRunning, .statusWaiting, .statusDone: true
+        case .statusRunning, .statusWaiting, .statusInactive: true
         default: false
         }
     }
@@ -174,7 +174,7 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
         case .divider: "Dividers / borders"
         case .statusRunning: "Running"
         case .statusWaiting: "Awaiting input"
-        case .statusDone: "Done"
+        case .statusInactive: "Inactive"
         }
     }
 
@@ -190,7 +190,7 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
         case .divider: theme.divider
         case .statusRunning: theme.statusRunning
         case .statusWaiting: theme.statusWaiting
-        case .statusDone: theme.statusDone
+        case .statusInactive: theme.statusInactive
         }
     }
 }

--- a/Nex/Theme/ChromeTheme.swift
+++ b/Nex/Theme/ChromeTheme.swift
@@ -268,4 +268,23 @@ extension EnvironmentValues {
     /// Multiplier on the opacity of the sidebar's WorkspaceColour-tinted
     /// elements (group bands + workspace avatars). 1 = preset intensity.
     @Entry var sidebarColorIntensity: Double = 1.0
+
+    /// Per-element fill/stroke opacities for the sidebar's groups and icons.
+    /// `sidebarColorIntensity` multiplies these.
+    @Entry var sidebarFillStroke = SidebarFillStroke()
+}
+
+/// Customisable fill and stroke (border) opacities for the sidebar's group
+/// bands and workspace/icon avatars. A negative `groupFill` means "use the
+/// preset `ChromeTheme.groupBandOpacity`" (which differs by appearance).
+struct SidebarFillStroke: Equatable {
+    var avatarFill: Double = 0.20
+    var avatarStroke: Double = 0.45
+    var groupFill: Double = -1
+    var groupStroke: Double = 0.0
+
+    /// Resolved group-band fill, falling back to the per-appearance preset.
+    func resolvedGroupFill(preset: Double) -> Double {
+        groupFill < 0 ? preset : groupFill
+    }
 }

--- a/Nex/Theme/ChromeTheme.swift
+++ b/Nex/Theme/ChromeTheme.swift
@@ -24,6 +24,9 @@ struct ChromeTheme: Equatable {
     let selectionFill: Color
     let selectionStroke: Color
     let accent: Color
+    /// Border drawn around the focused pane. Separate from the sidebar
+    /// highlight (`accent`) so the two can be themed independently.
+    let paneFocus: Color
     // Semantic status (chrome-specific; not the system .green/.blue used before)
     let statusRunning: Color
     let statusWaiting: Color
@@ -50,6 +53,7 @@ struct ChromeTheme: Equatable {
         selectionFill: Color.hex(0x5E8AC4).opacity(0.16),
         selectionStroke: .hex(0x5E8AC4),
         accent: .hex(0x5E8AC4),
+        paneFocus: .hex(0x5E8AC4),
         statusRunning: .hex(0x4FA46B),
         statusWaiting: .hex(0x5E8AC4),
         statusDone: .hex(0x9A9A96),
@@ -70,6 +74,7 @@ struct ChromeTheme: Equatable {
         selectionFill: Color.hex(0x5276B8).opacity(0.24),
         selectionStroke: .hex(0x5276B8),
         accent: .hex(0x6F9BD8),
+        paneFocus: .hex(0x6F9BD8),
         statusRunning: .hex(0x5FBE89),
         statusWaiting: .hex(0x6F9BD8),
         statusDone: .hex(0x8A8A92),
@@ -96,6 +101,7 @@ struct ChromeTheme: Equatable {
             selectionFill: overrides[.accent].map { $0.opacity(0.18) } ?? selectionFill,
             selectionStroke: newAccent,
             accent: newAccent,
+            paneFocus: overrides[.paneFocus] ?? paneFocus,
             statusRunning: statusRunning,
             statusWaiting: overrides[.accent] ?? statusWaiting,
             statusDone: statusDone,
@@ -134,6 +140,7 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
     case headerBackground
     case surfaceBackground
     case accent
+    case paneFocus
     case divider
 
     var id: String { rawValue }
@@ -145,7 +152,8 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
         case .footerBackground: "Status bar / footer"
         case .headerBackground: "Pane header / title bar"
         case .surfaceBackground: "Surface (Settings, sheets, palette)"
-        case .accent: "Highlight (selection / focus)"
+        case .accent: "Sidebar highlight"
+        case .paneFocus: "Pane focus"
         case .divider: "Dividers / borders"
         }
     }
@@ -158,6 +166,7 @@ enum ChromeColorKey: String, CaseIterable, Identifiable {
         case .headerBackground: theme.headerBackground
         case .surfaceBackground: theme.surfaceBackground
         case .accent: theme.accent
+        case .paneFocus: theme.paneFocus
         case .divider: theme.divider
         }
     }

--- a/NexTests/ChromeIndicatorRefreshTests.swift
+++ b/NexTests/ChromeIndicatorRefreshTests.swift
@@ -1,0 +1,54 @@
+import ComposableArchitecture
+import Foundation
+@testable import Nex
+import Testing
+
+/// Chrome appearance / colour / theme changes recolour the agent-status dots.
+/// The SwiftUI chrome re-reads them from the environment automatically, but the
+/// imperative AppKit menu-bar icon + popover are only refreshed when the reducer
+/// dispatches `.updateExternalIndicators`. These assert that each chrome-mutating
+/// settings action triggers that refresh — and so guards against the case being
+/// shadowed (and thus dead) behind the catch-all `case .settings:`.
+@MainActor
+struct ChromeIndicatorRefreshTests {
+    private func store() -> TestStoreOf<AppReducer> {
+        let store = TestStore(initialState: AppReducer.State()) { AppReducer() } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.userDefaults = .ephemeral()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+        return store
+    }
+
+    @Test func setChromeColorRefreshesIndicators() async {
+        let store = store()
+        await store.send(.settings(.setChromeColor(key: "dark:statusRunning", hex: "FF0000")))
+        await store.receive(\.updateExternalIndicators)
+        await store.finish()
+    }
+
+    @Test func setChromeAppearanceRefreshesIndicators() async {
+        let store = store()
+        await store.send(.settings(.setChromeAppearance(.dark)))
+        await store.receive(\.updateExternalIndicators)
+        await store.finish()
+    }
+
+    @Test func resetChromeColorsRefreshesIndicators() async {
+        let store = store()
+        await store.send(.settings(.resetChromeColors))
+        await store.receive(\.updateExternalIndicators)
+        await store.finish()
+    }
+
+    @Test func applyStyleThemeRefreshesIndicators() async {
+        let store = store()
+        // A preset/imported theme can recolour the status dots, so it must
+        // refresh the AppKit indicators too (the gap that adding it to the
+        // refresh list closes).
+        let theme = BuiltInChromeTheme.all[0].styleTheme
+        await store.send(.settings(.applyStyleTheme(theme)))
+        await store.receive(\.updateExternalIndicators)
+        await store.finish()
+    }
+}

--- a/NexTests/ChromeStyleThemeTests.swift
+++ b/NexTests/ChromeStyleThemeTests.swift
@@ -1,0 +1,179 @@
+import ComposableArchitecture
+import Foundation
+@testable import Nex
+import Testing
+
+@MainActor
+struct ChromeStyleThemeTests {
+    private func sample(name: String? = "Sunset") -> ChromeStyleTheme {
+        ChromeStyleTheme(
+            version: ChromeStyleTheme.currentVersion,
+            name: name,
+            colorOverrides: ["light:accent": "FF8800", "dark:accent": "FFAA33", "dark:sidebarBackground": "101014"],
+            sidebarColorIntensity: 1.4,
+            sidebarAvatarFillOpacity: 0.33,
+            sidebarAvatarStrokeOpacity: 0.5,
+            sidebarGroupFillOpacity: 0.25,
+            sidebarGroupStrokeOpacity: 0.1,
+            sparklineColorHex: "00FF99",
+            sparklineWidth: 40,
+            sparklineStyle: "dots"
+        )
+    }
+
+    // MARK: - File (JSON) round-trip
+
+    @Test func jsonRoundTrips() throws {
+        let theme = sample()
+        let restored = try ChromeStyleTheme(jsonData: theme.jsonData())
+        #expect(restored == theme)
+    }
+
+    @Test func jsonDataIsHumanReadable() throws {
+        let json = try String(data: sample().jsonData(), encoding: .utf8) ?? ""
+        // Pretty-printed + sorted, so a shared file diffs cleanly.
+        #expect(json.contains("\n"))
+        #expect(json.contains("\"sparklineStyle\" : \"dots\""))
+    }
+
+    // MARK: - Share code round-trip
+
+    @Test func shareCodeRoundTrips() throws {
+        let theme = sample()
+        let code = try theme.shareCode()
+        #expect(code.hasPrefix(ChromeStyleTheme.codePrefix))
+        let restored = try ChromeStyleTheme(shareCode: code)
+        #expect(restored == theme)
+    }
+
+    @Test func shareCodeAcceptsBareBase64WithoutPrefix() throws {
+        let theme = sample()
+        let code = try theme.shareCode()
+        let bare = String(code.dropFirst(ChromeStyleTheme.codePrefix.count))
+        let restored = try ChromeStyleTheme(shareCode: bare)
+        #expect(restored == theme)
+    }
+
+    @Test func shareCodeAcceptsRawJSONPastedDirectly() throws {
+        let theme = sample()
+        let json = try String(data: theme.jsonData(), encoding: .utf8) ?? ""
+        let restored = try ChromeStyleTheme(shareCode: json)
+        #expect(restored == theme)
+    }
+
+    @Test func shareCodeToleratesSurroundingWhitespace() throws {
+        let theme = sample()
+        let code = try "  \n" + (theme.shareCode()) + "\n  "
+        let restored = try ChromeStyleTheme(shareCode: code)
+        #expect(restored == theme)
+    }
+
+    @Test func invalidShareCodeThrows() {
+        #expect(throws: ChromeStyleThemeError.invalidCode) {
+            _ = try ChromeStyleTheme(shareCode: "not a theme at all")
+        }
+    }
+
+    // MARK: - Version guard
+
+    @Test func newerVersionIsRejected() throws {
+        var future = sample()
+        future.version = ChromeStyleTheme.currentVersion + 1
+        let data = try future.jsonData()
+        #expect(throws: ChromeStyleThemeError.unsupportedVersion(future.version)) {
+            _ = try ChromeStyleTheme(jsonData: data)
+        }
+    }
+
+    // MARK: - Capture from settings state
+
+    @Test func capturesStylingFromSettingsState() {
+        var state = SettingsFeature.State()
+        state.chromeColorOverrides = ["light:accent": "112233"]
+        state.sidebarColorIntensity = 1.7
+        state.sidebarAvatarFillOpacity = 0.31
+        state.sidebarGroupStrokeOpacity = 0.12
+        state.sparklineColorHex = "ABCDEF"
+        state.sparklineWidth = 36
+        state.sparklineStyle = "dots"
+        // Fields the theme must NOT carry (recipient keeps their own).
+        state.chromeAppearance = .dark
+        state.backgroundOpacity = 0.5
+
+        let theme = ChromeStyleTheme(capturing: state, name: "Mine")
+        #expect(theme.name == "Mine")
+        #expect(theme.version == ChromeStyleTheme.currentVersion)
+        #expect(theme.colorOverrides == ["light:accent": "112233"])
+        #expect(theme.sidebarColorIntensity == 1.7)
+        #expect(theme.sidebarAvatarFillOpacity == 0.31)
+        #expect(theme.sidebarGroupStrokeOpacity == 0.12)
+        #expect(theme.sparklineColorHex == "ABCDEF")
+        #expect(theme.sparklineWidth == 36)
+        #expect(theme.sparklineStyle == "dots")
+    }
+
+    @Test func captureThenApplyIsIdentity() async {
+        // A theme captured from a styled state, applied onto a fresh state,
+        // reproduces the same styling fields.
+        var styled = SettingsFeature.State()
+        styled.chromeColorOverrides = ["dark:divider": "222228"]
+        styled.sidebarColorIntensity = 0.6
+        styled.sparklineStyle = "dots"
+        let theme = ChromeStyleTheme(capturing: styled)
+
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.applyStyleTheme(theme)) { state in
+            #expect(state.chromeColorOverrides == ["dark:divider": "222228"])
+            #expect(state.sidebarColorIntensity == 0.6)
+            #expect(state.sparklineStyle == "dots")
+        }
+    }
+
+    // MARK: - Apply action
+
+    @Test func applyStyleThemeOverwritesStylingFields() async {
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.applyStyleTheme(sample())) { state in
+            #expect(state.chromeColorOverrides["light:accent"] == "FF8800")
+            #expect(state.chromeColorOverrides["dark:sidebarBackground"] == "101014")
+            #expect(state.sidebarColorIntensity == 1.4)
+            #expect(state.sidebarAvatarFillOpacity == 0.33)
+            #expect(state.sidebarAvatarStrokeOpacity == 0.5)
+            #expect(state.sidebarGroupFillOpacity == 0.25)
+            #expect(state.sidebarGroupStrokeOpacity == 0.1)
+            #expect(state.sparklineColorHex == "00FF99")
+            #expect(state.sparklineWidth == 40)
+            #expect(state.sparklineStyle == "dots")
+        }
+    }
+
+    @Test func applyStyleThemeLeavesAppearanceAndTerminalUntouched() async {
+        var initial = SettingsFeature.State()
+        initial.chromeAppearance = .dark
+        initial.backgroundOpacity = 0.4
+        let store = TestStore(initialState: initial) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.applyStyleTheme(sample())) { state in
+            // The recipient's mode + terminal background are not overridden.
+            #expect(state.chromeAppearance == .dark)
+            #expect(state.backgroundOpacity == 0.4)
+        }
+    }
+}

--- a/NexTests/ChromeStyleThemeTests.swift
+++ b/NexTests/ChromeStyleThemeTests.swift
@@ -1,6 +1,7 @@
 import ComposableArchitecture
 import Foundation
 @testable import Nex
+import SwiftUI
 import Testing
 
 @MainActor
@@ -156,6 +157,56 @@ struct ChromeStyleThemeTests {
             #expect(state.sparklineColorHex == "00FF99")
             #expect(state.sparklineWidth == 40)
             #expect(state.sparklineStyle == "dots")
+        }
+    }
+
+    // MARK: - Built-in preset themes
+
+    @Test func atLeastFivePresetsExistWithUniqueNames() {
+        #expect(BuiltInChromeTheme.all.count >= 5)
+        let names = BuiltInChromeTheme.all.map(\.name)
+        #expect(Set(names).count == names.count)
+    }
+
+    @Test func everyPresetColourParsesAndUsesItsNativeBucket() {
+        for preset in BuiltInChromeTheme.all {
+            let bucket = preset.appearance == .light ? "light" : "dark"
+            let overrides = preset.styleTheme.colorOverrides
+            // One entry per ChromeColorKey, all in the native bucket, all valid hex.
+            #expect(overrides.count == ChromeColorKey.allCases.count)
+            for (key, hex) in overrides {
+                #expect(key.hasPrefix("\(bucket):"), "\(preset.name) key \(key) wrong bucket")
+                #expect(Color(chromeHex: hex) != nil, "\(preset.name) bad hex \(hex)")
+            }
+            // The sparkline picks up the accent.
+            #expect(preset.styleTheme.sparklineColorHex == preset.palette.accent)
+        }
+    }
+
+    @Test func presetKeysCoverEveryChromeColorKey() {
+        for preset in BuiltInChromeTheme.all {
+            let bucket = preset.appearance == .light ? "light" : "dark"
+            let keys = Set(preset.styleTheme.colorOverrides.keys)
+            for colorKey in ChromeColorKey.allCases {
+                #expect(keys.contains("\(bucket):\(colorKey.rawValue)"),
+                        "\(preset.name) missing \(colorKey.rawValue)")
+            }
+        }
+    }
+
+    @Test func applyingDraculaWritesItsDarkPalette() async throws {
+        let dracula = try #require(BuiltInChromeTheme.all.first { $0.name == "Dracula" })
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.applyStyleTheme(dracula.styleTheme)) { state in
+            #expect(state.chromeColorOverrides["dark:accent"] == "BD93F9")
+            #expect(state.chromeColorOverrides["dark:sidebarBackground"] == "282A36")
+            #expect(state.sparklineColorHex == "BD93F9")
         }
     }
 

--- a/NexTests/DiffHTMLRendererTests.swift
+++ b/NexTests/DiffHTMLRendererTests.swift
@@ -103,13 +103,17 @@ struct DiffHTMLRendererTests {
         #expect(html.contains("<html class=\"light\">"))
     }
 
-    @Test func backgroundColorEmittedAsRGBA() {
+    @Test func bodyBackgroundIsTransparent() {
+        // The body background is transparent so the pane's SwiftUI background
+        // (the shared terminal surface) shows through the web view — rather than
+        // the renderer painting a second opaque layer of its own.
         let html = DiffHTMLRenderer.renderToHTML(
             diffText: "+x",
             backgroundColor: NSColor(red: 1, green: 0, blue: 0, alpha: 1),
             backgroundOpacity: 0.5
         )
-        #expect(html.contains("rgba(255, 0, 0, 0.5)"))
+        #expect(html.contains("background-color: transparent;"))
+        #expect(!html.contains("rgba(255, 0, 0, 0.5)"))
     }
 
     // MARK: - Sticky / collapsible file headers

--- a/NexTests/LabelMigrationTests.swift
+++ b/NexTests/LabelMigrationTests.swift
@@ -1,0 +1,68 @@
+import ComposableArchitecture
+import Foundation
+@testable import Nex
+import Testing
+
+/// Existing free-form workspace labels (which predate the label-presets
+/// feature) must be back-filled into presets on launch, so they survive being
+/// unapplied from a workspace.
+@MainActor
+struct LabelMigrationTests {
+    private func workspace(labels: [String]) -> WorkspaceFeature.State {
+        var ws = WorkspaceFeature.State(name: "WS")
+        ws.labels = labels
+        return ws
+    }
+
+    private func store(_ state: AppReducer.State) -> TestStoreOf<AppReducer> {
+        let store = TestStore(initialState: state) { AppReducer() } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+        return store
+    }
+
+    @Test func existingLabelsBackFillToDefaultPresets() async {
+        var initial = AppReducer.State()
+        initial.workspaces = [workspace(labels: ["Alpha", "Beta"])]
+        initial.didRestoreWorkspaces = true // workspaces already restored
+
+        let store = store(initial)
+        // Presets load (none stored) → triggers the migration.
+        await store.send(.labelPresetsLoaded([]))
+        await store.receive(\.migrateLabelsToPresets) { state in
+            #expect(state.labelPresets.map(\.name) == ["Alpha", "Beta"])
+            #expect(state.labelPresets.allSatisfy { $0.color == .named(.gray) })
+        }
+        await store.finish()
+    }
+
+    @Test func existingPresetsAreNeitherOverwrittenNorDuplicated() async {
+        var initial = AppReducer.State()
+        initial.workspaces = [workspace(labels: ["Alpha", "Beta"])]
+        initial.didRestoreWorkspaces = true
+
+        let store = store(initial)
+        // "Alpha" already has a blue preset → only "Beta" is back-filled.
+        await store.send(.labelPresetsLoaded([LabelPreset(name: "Alpha", color: .named(.blue))]))
+        await store.receive(\.migrateLabelsToPresets) { state in
+            #expect(state.labelPresets.count == 2)
+            #expect(state.labelPresets.first { $0.name == "Alpha" }?.color == .named(.blue))
+            #expect(state.labelPresets.first { $0.name == "Beta" }?.color == .named(.gray))
+        }
+        await store.finish()
+    }
+
+    @Test func migrationWaitsForBothLoads() async {
+        var initial = AppReducer.State()
+        initial.workspaces = [workspace(labels: ["Alpha"])]
+        // didRestoreWorkspaces stays false: presets loading alone must not migrate.
+
+        let store = store(initial)
+        await store.send(.labelPresetsLoaded([]))
+        await store.receive(\.migrateLabelsToPresets) { state in
+            #expect(state.labelPresets.isEmpty)
+        }
+        await store.finish()
+    }
+}

--- a/NexTests/LabelMigrationTests.swift
+++ b/NexTests/LabelMigrationTests.swift
@@ -68,4 +68,29 @@ struct LabelMigrationTests {
         }
         await store.finish()
     }
+
+    /// A fresh install marks the migration done immediately (see the empty
+    /// `stateLoaded` path). This asserts the safety that buys: once the flag is
+    /// set, a later launch whose workspaces now carry the user's *own* labels
+    /// must NOT back-fill them into gray presets (which would also resurrect any
+    /// preset they deleted in the meantime).
+    @Test func migrationIsSkippedOnceMarkedDone() async {
+        let defaults = UserDefaultsClient.ephemeral()
+        defaults.setBool(true, LabelPresetsStorage.migratedKey)
+        var initial = AppReducer.State()
+        initial.workspaces = [workspace(labels: ["Alpha", "Beta"])]
+        initial.didRestoreWorkspaces = true
+
+        let store = TestStore(initialState: initial) { AppReducer() } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.userDefaults = defaults
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.labelPresetsLoaded([]))
+        await store.receive(\.migrateLabelsToPresets) { state in
+            #expect(state.labelPresets.isEmpty)
+        }
+        await store.finish()
+    }
 }

--- a/NexTests/LabelMigrationTests.swift
+++ b/NexTests/LabelMigrationTests.swift
@@ -17,6 +17,9 @@ struct LabelMigrationTests {
     private func store(_ state: AppReducer.State) -> TestStoreOf<AppReducer> {
         let store = TestStore(initialState: state) { AppReducer() } withDependencies: {
             $0.surfaceManager = SurfaceManager()
+            // Isolated so the one-shot migration flag starts unset per test (the
+            // shared testValue dict otherwise leaks the flag across tests).
+            $0.userDefaults = .ephemeral()
         }
         store.exhaustivity = .off(showSkippedAssertions: false)
         return store


### PR DESCRIPTION
## Refined warm-chrome UI reskin

Rebuilds Nex's chrome to match the "Refined" mockups — a warm light/dark palette applied across the sidebar, a custom window title bar, and a new bottom status bar — plus the features and polish that came out of iterating on it. The terminal panes are untouched (they keep the Ghostty theme); only the chrome is reskinned.

### Chrome palette & theming
- New `ChromeTheme` (warm light/dark presets) injected app-wide via `ChromeThemed`, independent of the terminal theme.
- **Appearance** preference (System / Light / Dark). Resolved to a **concrete** scheme driven by `NSApp.effectiveAppearance` rather than `.preferredColorScheme(nil)` — the latter didn't reliably revert a forced window, which split surfaces vs text on a System swap.
- **Customisable** in Settings → Appearance: chrome surface colours (per light/dark palette), sidebar colour intensity, sidebar fill/stroke, and a separate **Agent status** section (Running / Awaiting-input / Done) applied across every surface that shows agent status — footer, sidebar dots, pane-header badges, title-bar dot, and the menu-bar icon + popover.

### Sidebar
- Letter-avatar workspace icons, full-width tinted group bands with disclosure chevrons, preset-coloured label chips.
- Filter field restyled as a rounded elevated pill.
- Thin overlay scrollbar (regardless of the system "always show scroll bars" setting).

### Title bar
- `.hiddenTitleBar` custom bar: centred `● workspace · N panes · ⊥ branch`, traffic lights vertically centred.
- Right-hand controls (••• menu with Settings… / Restart Socket Server, sidebar toggle) are a **native titlebar accessory** — content drawn under the transparent titlebar is click-shadowed, so the accessory is the supported way to keep them clickable.

### Status bar / footer
- New footer: focused-pane context (cwd · branch · agent · elapsed) on the left; cross-workspace `running / waiting / done` counts + clock on the right.
- **System stats**: optional CPU / memory / load / network / disk-IO / disk-space, each toggleable, with optional inline sparklines (line or stacked-dots, customisable colour/width, now filled under the line) and hover detail graphs.
- Agent counts open **detail popovers**: running/waiting list their panes (click to jump); done lists recently-finished agents (workspace · pane · time).

### Labels
- Existing free-form workspace labels are **back-filled** into presets once (so they survive being unapplied), via a one-shot persisted marker.

### Notable fixes (several surfaced by an adversarial multi-agent review of this branch)
- Footer network/disk rates no longer spike to ~1.8e19 on a counter wrap / interface drop.
- Scrollbar re-assert moved off the SwiftUI update path (no `@State` write during update).
- Menu-bar status colours re-pushed on theme change; selecting a pane focuses it even when it's in the already-active workspace.

---

### Verification
- **Build green**, full suite passing (**1106 tests**), incl. new `LabelMigrationTests`.
- Branch validated iteratively in a macOS VM (cua/lume) and on the host across the session.

### Manual test checklist (GUI/runtime behaviour tests can't cover)
- [x] **Surface teardown:** splitting panes and switching workspaces does not kill live PTYs (the `VStack` / `RootChromeView` / `WindowTitleBar` restructure preserves the pane-grid subtree identity).
- [x] **Release re-render:** footer counts, the system-stats gauge, and the title-bar status dot update in a **Release** build (`WithPerceptionTracking` is a no-op there).
- [x] Title-bar ••• menu (Settings… / Restart Socket Server) + sidebar toggle are clickable.
- [x] Appearance System ↔ Light ↔ Dark swaps stay consistent (surfaces + text + Settings tab strip).
- [x] Agent-status colours propagate to all six surfaces; footer count popovers navigate/focus correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
