### PR TITLE
feat(pane): add Status submenu to the pane context menu

### DIFF
--- a/Nex/AppReducer+Domain.swift
+++ b/Nex/AppReducer+Domain.swift
@@ -149,6 +149,7 @@ extension AppReducer {
              .beginRenameActiveWorkspace,
              .setRenamingWorkspaceID,
              .setRenamingPaneID,
+             .setPaneStatus,
              .toggleWorkspaceSelection,
              .rangeSelectWorkspace,
              .clearWorkspaceSelection,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -356,6 +356,7 @@ struct AppReducer {
         case beginRenameActiveWorkspace
         case setRenamingWorkspaceID(UUID?)
         case setRenamingPaneID(UUID?)
+        case setPaneStatus(paneID: UUID, status: PaneStatus)
         case toggleWorkspaceSelection(UUID)
         case rangeSelectWorkspace(UUID)
         case clearWorkspaceSelection
@@ -1306,6 +1307,30 @@ struct AppReducer {
             case .setRenamingPaneID(let id):
                 state.renamingPaneID = id
                 return .none
+
+            case .setPaneStatus(let paneID, let status):
+                // Manual status override from the pane context menu. Resolve the
+                // owning workspace (the menu only wires this for shell panes;
+                // guard here too so a stray dispatch can't flip a non-shell
+                // pane). The child `.setPaneStatus` falls through to the
+                // `case .workspaces` catch-all, which already persists, so we
+                // only additionally refresh the menu-bar / dock badge here
+                // (pushed imperatively in updateExternalIndicators, which the
+                // catch-all does not emit). Note: a manual override does not
+                // survive a relaunch — `stateLoaded` resets every non-idle
+                // status to `.idle` (issue #129).
+                guard let workspace = state.workspaceContainingPane(paneID),
+                      workspace.pane(id: paneID)?.type == .shell
+                else {
+                    return .none
+                }
+                return .merge(
+                    .send(.workspaces(.element(
+                        id: workspace.id,
+                        action: .setPaneStatus(paneID: paneID, status: status)
+                    ))),
+                    .send(.updateExternalIndicators)
+                )
 
             case .toggleWorkspaceSelection(let id):
                 guard state.workspaces[id: id] != nil else { return .none }

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -125,6 +125,9 @@ struct ContentView: View {
                                     reply: nil
                                 ))
                             },
+                            onSetPaneStatus: { paneID, status in
+                                store.send(.setPaneStatus(paneID: paneID, status: status))
+                            },
                             isSyncInputActive: workspace.isSyncInputActive,
                             syncInputExcluded: workspace.syncInputExcluded,
                             onToggleSyncExcluded: { paneID in

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -32,6 +32,7 @@ struct PaneGridView: View {
     var otherWorkspaces: [(id: UUID, name: String)] = []
     var onRenamePane: ((UUID) -> Void)?
     var onMovePaneToWorkspace: ((UUID, UUID) -> Void)?
+    var onSetPaneStatus: ((UUID, PaneStatus) -> Void)?
     /// Issue #121 sync-input state. `isSyncInputActive` flips the
     /// workspace toggle (drives the per-pane SYNC badge for every
     /// non-excluded pane); `syncInputExcluded` lists panes opted out.
@@ -186,6 +187,9 @@ struct PaneGridView: View {
                 onMoveToWorkspace: onMovePaneToWorkspace.map { handler in
                     { targetWS in handler(pane.id, targetWS) }
                 },
+                onSetStatus: pane.type == .shell
+                    ? onSetPaneStatus.map { handler in { status in handler(pane.id, status) } }
+                    : nil,
                 isSyncExcluded: syncInputExcluded.contains(pane.id),
                 workspaceSyncActive: isSyncInputActive,
                 onToggleSyncExcluded: onToggleSyncExcluded.map { handler in

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -23,6 +23,10 @@ struct PaneHeaderView: View {
     var otherWorkspaces: [(id: UUID, name: String)] = []
     var onRename: (() -> Void)?
     var onMoveToWorkspace: ((UUID) -> Void)?
+    /// Manually override the pane's agent status from the context menu
+    /// (issue #183). Nil for non-shell panes and when the host hasn't
+    /// wired it (tests, previews).
+    var onSetStatus: ((PaneStatus) -> Void)?
     /// True when sync is on for the workspace but this pane has been
     /// opted out. Used to render the "Include in sync" context menu
     /// entry and the dimmed `SYNC OFF` badge.
@@ -324,6 +328,14 @@ struct PaneHeaderView: View {
         Divider()
         Button("Split Right") { onSplitHorizontal() }
         Button("Split Down") { onSplitVertical() }
+        if let onSetStatus {
+            Divider()
+            Menu("Status") {
+                statusMenuButton("Idle", .idle, onSetStatus)
+                statusMenuButton("Running", .running, onSetStatus)
+                statusMenuButton("Awaiting Input", .waitingForInput, onSetStatus)
+            }
+        }
         if !otherWorkspaces.isEmpty, let onMoveToWorkspace {
             Divider()
             Menu("Move to Workspace") {
@@ -341,6 +353,22 @@ struct PaneHeaderView: View {
         Divider()
         Button("Open in Finder") { openInFinder() }
         Button("Copy Working Directory") { copyWorkingDirectory() }
+    }
+
+    /// A single entry in the Status submenu. The current status is marked
+    /// with a leading checkmark; the others render as plain text.
+    private func statusMenuButton(
+        _ title: String,
+        _ status: PaneStatus,
+        _ onSetStatus: @escaping (PaneStatus) -> Void
+    ) -> some View {
+        Button { onSetStatus(status) } label: {
+            if pane.status == status {
+                Label(title, systemImage: "checkmark")
+            } else {
+                Text(title)
+            }
+        }
     }
 
     private func openInFinder() {

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -262,6 +262,7 @@ struct WorkspaceFeature {
         case agentStarted(paneID: UUID)
         case agentStopped(paneID: UUID)
         case agentError(paneID: UUID)
+        case setPaneStatus(paneID: UUID, status: PaneStatus)
         case sessionStarted(paneID: UUID, sessionID: String)
         case sessionEnded(paneID: UUID, sessionID: String)
         case clearPaneStatus(UUID)
@@ -1282,6 +1283,22 @@ struct WorkspaceFeature {
 
             case .agentError(let paneID):
                 state.mutatePane(id: paneID) { $0.status = .waitingForInput }
+                return .none
+
+            case .setPaneStatus(let paneID, let status):
+                // Manual status override from the pane context menu. Guard to
+                // shell panes (defense-in-depth — the menu is already
+                // shell-only, mirroring .toggleMarkdownEdit's type guard);
+                // status is a shell-only concept. Mirror .agentStarted: start
+                // the elapsed clock on a fresh transition into .running so the
+                // "claude · mm:ss" badge ticks from now.
+                guard state.pane(id: paneID)?.type == .shell else { return .none }
+                state.mutatePane(id: paneID) {
+                    if status == .running, $0.status != .running {
+                        $0.agentStartedAt = now
+                    }
+                    $0.status = status
+                }
                 return .none
 
             case .sessionStarted(let paneID, let sessionID):

--- a/NexTests/AgentLifecycleTests.swift
+++ b/NexTests/AgentLifecycleTests.swift
@@ -237,4 +237,64 @@ struct AgentLifecycleTests {
             state.workspaces[id: wsID]?.panes[id: paneID]?.status = .waitingForInput
         }
     }
+
+    // MARK: - Manual status override (issue #183)
+
+    @Test func setPaneStatusRoutesToOwningWorkspace() async {
+        let paneID1 = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let paneID2 = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        let wsID1 = UUID(uuidString: "10000000-0000-0000-0000-000000000001")!
+        let wsID2 = UUID(uuidString: "10000000-0000-0000-0000-000000000002")!
+
+        let ws1 = WorkspaceFeature.State(
+            id: wsID1, name: "WS1", slug: "ws1", color: .blue,
+            panes: [Pane(id: paneID1)], layout: .leaf(paneID1),
+            focusedPaneID: paneID1, createdAt: Date(), lastAccessedAt: Date()
+        )
+        let ws2 = WorkspaceFeature.State(
+            id: wsID2, name: "WS2", slug: "ws2", color: .red,
+            panes: [Pane(id: paneID2)], layout: .leaf(paneID2),
+            focusedPaneID: paneID2, createdAt: Date(), lastAccessedAt: Date()
+        )
+
+        let store = makeAppStore(
+            workspaces: [ws1, ws2],
+            activeWorkspaceID: wsID1
+        )
+
+        // Override the status of a pane in the *background* workspace — it
+        // must resolve to WS2 by pane id, not the active workspace.
+        await store.send(.setPaneStatus(paneID: paneID2, status: .running))
+
+        await store.receive(
+            .workspaces(.element(id: wsID2, action: .setPaneStatus(paneID: paneID2, status: .running)))
+        ) { state in
+            state.workspaces[id: wsID2]?.panes[id: paneID2]?.status = .running
+            state.workspaces[id: wsID2]?.panes[id: paneID2]?.agentStartedAt = Date(timeIntervalSince1970: 1000)
+        }
+
+        // The deliberate override refreshes external indicators and persists.
+        await store.receive(.updateExternalIndicators)
+        await store.receive(.persistState)
+    }
+
+    @Test func setPaneStatusForUnknownPaneIsIgnored() async {
+        let paneID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let wsID = UUID(uuidString: "10000000-0000-0000-0000-000000000001")!
+        let unknownPaneID = UUID(uuidString: "99999999-9999-9999-9999-999999999999")!
+
+        let ws = WorkspaceFeature.State(
+            id: wsID, name: "WS", slug: "ws", color: .blue,
+            panes: [Pane(id: paneID)], layout: .leaf(paneID),
+            focusedPaneID: paneID, createdAt: Date(), lastAccessedAt: Date()
+        )
+
+        let store = makeAppStore(
+            workspaces: [ws],
+            activeWorkspaceID: wsID
+        )
+
+        // No owning workspace — no effects.
+        await store.send(.setPaneStatus(paneID: unknownPaneID, status: .running))
+    }
 }

--- a/NexTests/WorkspaceFeatureTests.swift
+++ b/NexTests/WorkspaceFeatureTests.swift
@@ -2340,4 +2340,103 @@ struct WorkspaceFeatureTests {
             #expect(state.panes[id: newID]?.workingDirectory == NSHomeDirectory())
         }
     }
+
+    // MARK: - setPaneStatus (issue #183)
+
+    /// The pane context menu's manual status override updates `Pane.status`.
+    @Test func setPaneStatusUpdatesStatus() async {
+        let workspace = WorkspaceFeature.State(name: "Test")
+        let paneID = workspace.panes.first!.id
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.setPaneStatus(paneID: paneID, status: .waitingForInput)) { state in
+            #expect(state.panes[id: paneID]?.status == .waitingForInput)
+        }
+        await store.send(.setPaneStatus(paneID: paneID, status: .idle)) { state in
+            #expect(state.panes[id: paneID]?.status == .idle)
+        }
+    }
+
+    /// Manually marking a pane `.running` starts the elapsed clock so the
+    /// "claude · mm:ss" badge ticks from the moment of the override.
+    @Test func setPaneStatusToRunningStartsClock() async {
+        let now = Date(timeIntervalSince1970: 5000)
+        let workspace = WorkspaceFeature.State(name: "Test")
+        let paneID = workspace.panes.first!.id
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(now)
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.setPaneStatus(paneID: paneID, status: .running)) { state in
+            #expect(state.panes[id: paneID]?.status == .running)
+            #expect(state.panes[id: paneID]?.agentStartedAt == now)
+        }
+    }
+
+    /// A repeated `.running` override doesn't reset the elapsed clock — only a
+    /// fresh non-running → running transition stamps `agentStartedAt`.
+    @Test func setPaneStatusRunningPreservesExistingClock() async {
+        let firstStart = Date(timeIntervalSince1970: 5000)
+        var pane = Pane(id: UUID(uuidString: "00000000-0000-0000-0000-0000000000aa")!)
+        pane.status = .running
+        pane.agentStartedAt = firstStart
+        let workspace = WorkspaceFeature.State(
+            id: UUID(uuidString: "10000000-0000-0000-0000-0000000000aa")!,
+            name: "Test", slug: "test", color: .blue,
+            panes: [pane], layout: .leaf(pane.id),
+            focusedPaneID: pane.id, createdAt: Date(), lastAccessedAt: Date()
+        )
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(Date(timeIntervalSince1970: 9999))
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.setPaneStatus(paneID: pane.id, status: .running)) { state in
+            #expect(state.panes[id: pane.id]?.agentStartedAt == firstStart)
+        }
+    }
+
+    /// The `.shell` gate is defended in the reducer, not just the view — so a
+    /// stray dispatch (e.g. a future CLI verb) targeting a markdown / diff /
+    /// web pane is a no-op rather than mutating a pane that never renders
+    /// status.
+    @Test func setPaneStatusOnNonShellPaneIsNoOp() async {
+        let paneID = UUID(uuidString: "00000000-0000-0000-0000-0000000000bb")!
+        let pane = Pane(id: paneID, type: .markdown)
+        let workspace = WorkspaceFeature.State(
+            id: UUID(uuidString: "10000000-0000-0000-0000-0000000000bb")!,
+            name: "Test", slug: "test", color: .blue,
+            panes: [pane], layout: .leaf(paneID),
+            focusedPaneID: paneID, createdAt: Date(), lastAccessedAt: Date()
+        )
+
+        let store = TestStore(initialState: workspace) {
+            WorkspaceFeature()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        // The reducer guards on pane type, so status stays idle.
+        await store.send(.setPaneStatus(paneID: paneID, status: .running))
+        #expect(store.state.panes[id: paneID]?.status == .idle)
+        #expect(store.state.panes[id: paneID]?.agentStartedAt == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a "Status" submenu (Idle / Running / Awaiting Input) to the right-click context menu of shell panes, with a checkmark on the current status.
- Selecting one dispatches a new `setPaneStatus` reducer action that updates `Pane.status` and refreshes the menu-bar / dock badge via `updateExternalIndicators`; the sidebar reflects it reactively.
- Use cases: recover a pane whose agent crashed without sending `stop`, clear a stale blue badge without focusing the pane, or mark an idle pane as running to keep it visible while babysitting.

Closes #183

## Implementation notes
- New top-level `AppReducer.setPaneStatus` resolves the owning workspace via `workspaceContainingPane` and `.merge`s the child action + `.updateExternalIndicators` (mirroring the socket `agentStarted` path). Persistence rides the existing `case .workspaces` catch-all — no explicit `persistState` needed.
- Gated to `.shell` panes at both the view (menu wired only for shell) and reducer layers (defense-in-depth, mirroring `toggleMarkdownEdit`'s type guard).
- The child handler mirrors `.agentStarted`: a fresh non-running → running transition stamps `agentStartedAt` so the `claude · mm:ss` badge ticks.

## Reviewer notes (parallel review: correctness + scope/edge-cases)
- Applied: menu label is "Awaiting Input" (title-case, sharing vocabulary with the badge/popover) rather than "Waiting for Input"; reducer-level `.shell` guard + a non-shell no-op test; dropped a redundant `.send(.persistState)` and corrected a comment that wrongly claimed the override survives relaunch.
- Known/by-design (not fixed): a manual `.waitingForInput` set on the **currently focused** pane of the **active** workspace self-clears ~600ms after the next focus/app-activate, because the existing focus-driven clearer intentionally resets `.waitingForInput → .idle` (the documented "focus clears the blue badge" behaviour). Background/non-focused panes and the `.running` / `.idle` overrides are stable. A manual-override carve-out was judged scope creep (and wouldn't survive relaunch anyway, see below).
- By-design: a manual override does **not** survive a relaunch — `stateLoaded` resets every non-idle status to `.idle` (issue #129, to avoid the false quit dialog).
- Skipped (nice-to-have): inline-`Picker` for native gutter checkmarks (the `Label`+checkmark pattern has precedent in `WorkspaceListView`); no `claude` badge on an agent-less pane manually flipped to running (deliberate — badge requires a real session; the dot/sidebar/menu-bar still reflect it).

## Validation
- Validated in a sandboxed macOS VM via cua/lume (built ad-hoc-signed from the branch worktree, launched clean).
- Per-issue assertions (all passed), driving `Pane.status` through the built-from-branch reducer + `pane list` reporting (the exact field the menu writes; the GUI menu click itself has no CLI surface by design and was verified manually in the kept-alive VM):
  - TEST 1: fresh pane reports `idle`.
  - TEST 2: `event start` → `running` (status bar shows 1 running, green dot).
  - TEST 3: `event stop` → `waitingForInput` (status bar shows 1 waiting, blue dot).
  - TEST 4: back to `running`; pane survived every transition.
- Screenshots: `/Users/ben/code/cua/out/branches/issue-183-pane-status-menu/issue-183/`
- Unit tests: 6 new tests across `WorkspaceFeatureTests` (status update, running-starts-clock, clock-preserved-on-repeat, non-shell no-op) and `AgentLifecycleTests` (background-workspace routing + effects, unknown-pane no-op). Full suite: 1133 tests pass.

## Test plan
- [x] Right-click a shell pane header → confirm the **Status** submenu (Idle / Running / Awaiting Input) with a checkmark on the current status.
- [x] Select each status; confirm the header dot color, the bottom status-bar counts, the menu-bar popover, and the dock badge update, and the checkmark moves.
- [x] Open a markdown pane (⌘O) and right-click it → confirm the Status submenu is **absent** (shell-only gate).
- [x] Mark an idle background pane as Running → confirm it appears in the menu-bar popover / sidebar without focusing it.
- [x] Set a stuck pane to Idle to clear a stale blue badge without focusing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtQvzGPFCestiizxj2AzMM