### PR TITLE
fix(chrome): restore double-click-to-zoom on the hidden titlebar (#199)

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		BAEEBBBC67C9969D0553D084 /* ChromeIndicatorRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0461B8E2ED8F50BA8AF0DF /* ChromeIndicatorRefreshTests.swift */; };
 		BF19A66EC95FA4FB46CA400D /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F228193206574DB257C8B3FB /* AppKit.framework */; };
 		C052FE23BF089795BB04E10E /* RenamePaneSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191592BF0EBCEC22DF9F5745 /* RenamePaneSheet.swift */; };
+		C0741544E700ECB9D719CB64 /* TitlebarDoubleClickActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA151EED6939BCA9792BBF1 /* TitlebarDoubleClickActionTests.swift */; };
 		C0DDF7284D01523225E5EEE7 /* GhosttyConfigClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47FF7FB9A9C29221EAD089E /* GhosttyConfigClient.swift */; };
 		C14C8EEDD9146F537341D02E /* SocketParsingOutsideNexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 150E85D36973D18EFF0C764C /* SocketParsingOutsideNexTests.swift */; };
 		C1FC2BD79FF0D9DC86910028 /* WebPaneInspectorScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2BAD220346CCE551765FCD9 /* WebPaneInspectorScript.swift */; };
@@ -378,6 +379,7 @@
 		DC371B0DE7B02828E9EDFE8E /* ClipboardImageHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardImageHelper.swift; sourceTree = "<group>"; };
 		DDD03468B083223FF50F68E0 /* GhosttySurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurface.swift; sourceTree = "<group>"; };
 		DE56BB11F5C7C34821411297 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		DEA151EED6939BCA9792BBF1 /* TitlebarDoubleClickActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlebarDoubleClickActionTests.swift; sourceTree = "<group>"; };
 		E01C66D4D59D04F6372D8AD7 /* WorkspaceDropTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDropTargetTests.swift; sourceTree = "<group>"; };
 		E0625B2E7935BDDF63DC5D19 /* RingBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingBufferTests.swift; sourceTree = "<group>"; };
 		E08D39F8F87D7505CD32D25D /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
@@ -546,6 +548,7 @@
 				AC84F1EBC8A83D60127093E9 /* SocketParsingTests.swift */,
 				1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */,
 				09D2D521EEDB4FE47843C382 /* SyncInputTests.swift */,
+				DEA151EED6939BCA9792BBF1 /* TitlebarDoubleClickActionTests.swift */,
 				9AA64A9054515A57ED6B2ECA /* WebPaneActuatorActionTests.swift */,
 				9F338E618A147E5BAAFF5FE5 /* WebPaneActuatorSelectorTests.swift */,
 				12DB8491263633C87CA73D00 /* WebPaneActuatorWaitTests.swift */,
@@ -1003,6 +1006,7 @@
 				2B4533964D77117EE6D98690 /* SocketParsingTests.swift in Sources */,
 				EF4258CFC52EB748609C7F18 /* SurfaceViewKeyboardTests.swift in Sources */,
 				ECC9AA8342DF3710795427C7 /* SyncInputTests.swift in Sources */,
+				C0741544E700ECB9D719CB64 /* TitlebarDoubleClickActionTests.swift in Sources */,
 				04A463E95398A50F5AD5AA2B /* WebPaneActuatorActionTests.swift in Sources */,
 				E5D6BDD247E0BE03F097B4A2 /* WebPaneActuatorSelectorTests.swift in Sources */,
 				B0FA5E756635F6DFC402CD7C /* WebPaneActuatorWaitTests.swift in Sources */,

--- a/Nex/Chrome/WindowTitleBar.swift
+++ b/Nex/Chrome/WindowTitleBar.swift
@@ -33,11 +33,12 @@ struct WindowTitleBar: View {
             ZStack {
                 // Match the bottom status bar's background (sidebar/footer
                 // tone). `WindowDragRegion` lets empty parts of the bar drag
-                // the window (via `performDrag`) — scoped to the bar so it
-                // doesn't make the sidebar a drag handle the way
-                // `isMovableByWindowBackground` did. The interactive controls
-                // are a native titlebar accessory (see the type doc), not
-                // content here, so the drag region can span the full width.
+                // the window (single click) and zoom/minimise it (double
+                // click) — scoped to the bar so it doesn't make the sidebar a
+                // drag handle the way `isMovableByWindowBackground` did. The
+                // interactive controls are a native titlebar accessory (see the
+                // type doc), not content here, so the drag region can span the
+                // full width.
                 theme.footerBackground
                 WindowDragRegion()
                 identityCluster(workspace)
@@ -87,6 +88,11 @@ struct WindowTitleBar: View {
         // narrow window.
         .padding(.leading, 80)
         .padding(.trailing, 86)
+        // The identity is purely decorative; let clicks fall through to the
+        // `WindowDragRegion` behind it so dragging and double-click zoom work
+        // when the pointer is over the workspace name, matching native title
+        // bars (issue #199).
+        .allowsHitTesting(false)
     }
 
     private var separator: some View {
@@ -105,6 +111,26 @@ struct WindowTitleBar: View {
     }
 }
 
+/// The window action bound to a title-bar double-click, mirroring the macOS
+/// "Double-click a window's title bar to" setting (System Settings → Desktop &
+/// Dock). A pure value type so the preference→action mapping is unit-testable
+/// without a live window.
+enum TitlebarDoubleClickAction {
+    case zoom
+    case minimize
+    case doNothing
+
+    /// Resolve from the `AppleActionOnDoubleClick` value in `NSGlobalDomain`.
+    /// Unset or unrecognised falls back to `.zoom` (the macOS factory default).
+    static func resolve(from raw: String?) -> TitlebarDoubleClickAction {
+        switch raw {
+        case "Minimize": .minimize
+        case "None": .doNothing
+        default: .zoom // "Maximize" or unset/unknown
+        }
+    }
+}
+
 /// A transparent, hit-testable backing view that lets the window be dragged
 /// from the non-interactive parts of the custom title bar. Scoped to the
 /// title bar (not the whole window) so it doesn't hijack sidebar drag-to-
@@ -118,11 +144,79 @@ private struct WindowDragRegion: NSViewRepresentable {
     func updateNSView(_: NSView, context _: Context) {}
 
     private final class DragView: NSView {
-        /// `mouseDownCanMoveWindow` is unreliable for a SwiftUI-embedded view,
-        /// so initiate the drag explicitly. `performDrag` also handles the
-        /// double-click-to-zoom/minimise titlebar conventions.
+        /// Drag the window from empty title-bar regions. `performDrag` is only
+        /// initiated on a single click; a double-click is left untouched so the
+        /// `TitlebarDoubleClickMonitor` (and macOS) can act on it. Note that
+        /// under `.hiddenTitleBar` the native transparent titlebar usually wins
+        /// the top strip's events and moves the window itself, so this is a
+        /// belt-and-braces drag path rather than the sole one.
         override func mouseDown(with event: NSEvent) {
-            window?.performDrag(with: event)
+            if event.clickCount == 1 {
+                window?.performDrag(with: event)
+            }
+        }
+    }
+}
+
+/// Restores macOS double-click-to-zoom on the hidden titlebar (issue #199).
+///
+/// Under `.windowStyle(.hiddenTitleBar)` the window is draggable from the
+/// title-bar strip (the transparent native titlebar / movable-background owns
+/// those events), but the *double-click* titlebar convention is lost: a
+/// content view placed there never receives the click, and a
+/// movable-background region drags without zooming. Rather than fight the
+/// event routing, a local `NSEvent` monitor observes `leftMouseDown` before
+/// the window dispatches it, and on a double-click in the empty title-bar
+/// region performs the action from the user's `AppleActionOnDoubleClick`
+/// preference (Zoom / Minimise / Do Nothing), matching a native title bar.
+@MainActor
+final class TitlebarDoubleClickMonitor {
+    private var monitor: Any?
+
+    /// Height of the custom title bar (`WindowTitleBar`), in points.
+    private static let titleBarHeight: CGFloat = 32
+    /// Leading inset that clears the traffic lights.
+    private static let leadingInset: CGFloat = 80
+    /// Trailing inset that clears the ••• menu / sidebar-toggle accessory.
+    private static let trailingInset: CGFloat = 86
+
+    func start() {
+        guard monitor == nil else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+            Self.handle(event)
+            return event
+        }
+    }
+
+    func stop() {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+    }
+
+    private static func handle(_ event: NSEvent) {
+        guard event.clickCount == 2, let window = event.window else { return }
+        // Only the main window uses `.hiddenTitleBar` (transparent titlebar +
+        // full-size content view); Settings / Help keep a native titlebar that
+        // already zooms, so leave those alone.
+        guard window.titlebarAppearsTransparent,
+              window.styleMask.contains(.fullSizeContentView)
+        else { return }
+
+        let loc = event.locationInWindow
+        let height = window.contentView?.bounds.height ?? window.frame.height
+        let width = window.frame.width
+        // Top `titleBarHeight` strip, excluding the traffic-light and trailing
+        // control gutters so double-clicking a control never zooms.
+        guard loc.y >= height - titleBarHeight,
+              loc.x >= leadingInset,
+              loc.x <= width - trailingInset
+        else { return }
+
+        let raw = UserDefaults.standard.string(forKey: "AppleActionOnDoubleClick")
+        switch TitlebarDoubleClickAction.resolve(from: raw) {
+        case .zoom: window.performZoom(nil)
+        case .minimize: window.performMiniaturize(nil)
+        case .doNothing: break
         }
     }
 }

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -11,6 +11,7 @@ struct NexApp: App {
     }
 
     @State private var shortcutMonitor: PaneShortcutMonitor?
+    @State private var titlebarZoomMonitor: TitlebarDoubleClickMonitor?
     // Holds the loaded ghostty config so the `\.ghosttyConfig` environment
     // reflects the real terminal background once it's read in `.onAppear`.
     // Injecting `.liveValue` directly captured the pre-load default
@@ -122,11 +123,11 @@ struct NexApp: App {
                         // NB: do NOT set `isMovableByWindowBackground` — it turns
                         // the whole window (incl. the sidebar) into a drag handle,
                         // which hijacks sidebar row/group reordering. With
-                        // `.hiddenTitleBar` the titlebar region the custom title
-                        // bar overlaps is already window-draggable (its
-                        // non-interactive SwiftUI content reports
-                        // mouseDownCanMoveWindow), so the bar still moves the
-                        // window without breaking sidebar drags.
+                        // `.hiddenTitleBar` the custom title bar's
+                        // `WindowDragRegion` drives both window dragging and
+                        // double-click zoom/minimise explicitly (see
+                        // `WindowTitleBar.swift`), scoped to the bar so the
+                        // sidebar drags stay intact.
                     }
 
                     // Global hotkey callback — registration happens from the
@@ -174,6 +175,11 @@ struct NexApp: App {
                     let monitor = PaneShortcutMonitor(store: store)
                     monitor.start()
                     shortcutMonitor = monitor
+
+                    // Restore double-click-to-zoom on the hidden titlebar (#199).
+                    let zoomMonitor = TitlebarDoubleClickMonitor()
+                    zoomMonitor.start()
+                    titlebarZoomMonitor = zoomMonitor
                 }
         }
         .windowStyle(.hiddenTitleBar)

--- a/NexTests/TitlebarDoubleClickActionTests.swift
+++ b/NexTests/TitlebarDoubleClickActionTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+@testable import Nex
+import Testing
+
+struct TitlebarDoubleClickActionTests {
+    @Test func maximizeResolvesToZoom() {
+        #expect(TitlebarDoubleClickAction.resolve(from: "Maximize") == .zoom)
+    }
+
+    @Test func minimizeResolvesToMinimize() {
+        #expect(TitlebarDoubleClickAction.resolve(from: "Minimize") == .minimize)
+    }
+
+    @Test func noneResolvesToDoNothing() {
+        #expect(TitlebarDoubleClickAction.resolve(from: "None") == .doNothing)
+    }
+
+    @Test func nilDefaultsToZoom() {
+        // Unset preference: macOS factory default is Zoom.
+        #expect(TitlebarDoubleClickAction.resolve(from: nil) == .zoom)
+    }
+
+    @Test func unknownValueDefaultsToZoom() {
+        #expect(TitlebarDoubleClickAction.resolve(from: "Fill") == .zoom)
+        #expect(TitlebarDoubleClickAction.resolve(from: "") == .zoom)
+    }
+}


### PR DESCRIPTION
## Summary
- Restores the standard macOS double-click-to-zoom gesture on Nex's `.hiddenTitleBar` window (issue #199).
- Adds `TitlebarDoubleClickMonitor`: a local `NSEvent` monitor that observes `leftMouseDown` before the window dispatches it, and on a double-click in the empty title-bar region performs the user's `AppleActionOnDoubleClick` action (Zoom / Minimise / Do Nothing), excluding the traffic-light and trailing-control gutters.
- The preference→action mapping is a pure, unit-tested `TitlebarDoubleClickAction.resolve`.
- The identity cluster gets `.allowsHitTesting(false)` so dragging works over the workspace name too.

Closes #199

## Why a monitor (reviewer notes)
- Under `.hiddenTitleBar`, the transparent native titlebar / movable-background owns the top-strip mouse events, so a content view placed there **never receives the click** (verified in-VM: a custom `DragView.mouseDown` was never called). A movable-background region drags but does not zoom. The local event monitor sidesteps the routing entirely and is the reliable way to reintroduce the gesture.
- The "Fill" preference (Ventura+) and any unknown value map to Zoom; there is no clean single-call AppKit "fill" primitive.

## Validation
- Validated in a sandboxed macOS VM via cua/lume (fresh build from this branch).
- Assertions (all passed):
  - App builds, launches, exactly one pane.
  - **Drag positive-control**: dragging the title bar moves the window (62,135 → 92,245) — confirms the click point is a real title-bar region and drag is intact.
  - **Primary**: a title-bar double-click changes the window frame — before `(92,245,900,450)` → after `(0,30,1024,660)` (zoom grew the window by ~67%). Pre-fix the frame was unchanged (gesture ignored).
- Screenshots: `/Users/ben/code/cua/out/branches/issue-199-titlebar-zoom/issue-199/`
- `make check` green (format, lint, build, unit tests incl. `TitlebarDoubleClickActionTests`).

## Test plan
- [x] Double-click an empty part of the title bar → window zooms/expands; double-click again → restores.
- [x] Double-click on the centered workspace name → also zooms.
- [x] Single-click-drag the title bar → window still moves; sidebar drag-to-reorder unaffected.
- [x] Double-click the ••• menu / sidebar-toggle area → does NOT zoom; buttons still work.
- [x] Set System Settings → Desktop & Dock → "Double-click a window's title bar to" = Minimise → double-click minimises instead of zooming.
- [x] Settings / Help windows (native titlebars) still zoom natively and are unaffected by the monitor.