### PR TITLE
fix(settings): stop truncating the Labels "Add" button to "A..."

### DIFF
--- a/Nex/Features/Settings/LabelPresetsSettingsView.swift
+++ b/Nex/Features/Settings/LabelPresetsSettingsView.swift
@@ -119,8 +119,13 @@ struct LabelPresetsSettingsView: View {
                 .opacity(trimmedNewName.isEmpty ? 0.5 : 1)
                 .frame(width: LabelCol.preview, alignment: .leading)
 
+            // A bordered text button needs its intrinsic width; pinning it
+            // to the narrow `action` column (sized for the preset rows' trash
+            // icon) clips "Add" to "A...". Let it size to content, but keep
+            // the column at least action-wide so it still lines up.
             Button("Add", action: commitNew)
-                .frame(width: LabelCol.action, alignment: .trailing)
+                .fixedSize()
+                .frame(minWidth: LabelCol.action, alignment: .trailing)
                 .disabled(trimmedNewName.isEmpty)
         }
         .padding(12)


### PR DESCRIPTION
## Summary
- The add-label button on the Settings → Labels pane was pinned to the fixed 40pt `LabelCol.action` column (shared with the preset rows' trash icon). A bordered text button needs more chrome than that, so "Add" clipped to "A...".
- Fix: give the button `.fixedSize()` with a `.frame(minWidth: LabelCol.action, alignment: .trailing)` floor, so it renders its full title (and grows gracefully for longer/localized labels) while still lining up with the trash column.

Closes #200

## Reviewer notes
- Two parallel reviews (correctness + scope/edge-cases) both confirmed the fix is sound, correctly scoped, and complete — no functional regression, robust to longer/localized titles, no accessibility change.
- One non-blocking cosmetic note: because the Add button now overflows the 40pt action column, the add row's text-color/preview columns sit a few points left of the preset rows below. Rated cosmetic and partly pre-existing (the add row uses `.padding(12)` while the preset rows live in a `List` with inset style, so the two were never pixel-aligned). Left as-is per the chosen `.fixedSize()` approach; the alternative would be widening `LabelCol.action` for both rows.

## Validation
- Validated in a sandboxed macOS VM via cua/lume (built from the branch worktree, ad-hoc signed).
- Automated guards: build succeeded; app launched; `nex pane list` returned 1 pane; `nex --version` = 0.28.0; no crash from the layout change.
- Visual confirmation (GUI-driven via cua-native keyboard/mouse): opened Settings → Labels and captured the "Add" button rendering its full text in both the disabled (empty name) and enabled (name typed) states — the "A..." truncation is gone.
- Screenshots: `/Users/ben/code/cua/out/branches/fix-labels-add-button-width/issue-200/` (`labels_pane_filled.png`, `addrow_strip_2x.png`, `add_button_4x.png`).

## Test plan
- [x] Open Settings → Labels; the "Add" button reads "Add" in full (not "A...").
- [x] With an empty name field the button is greyed but still reads "Add"; typing a name enables it (full-color "Add").
- [x] Type a name and click Add — a preset row is created; confirm the trash-column alignment looks right.
- [x] Sanity-check the other Settings tabs still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtQvzGPFCestiizxj2AzMM