### PR TITLE
feat(sidebar): label multiple selected workspaces at once

### DIFF
--- a/Nex/AppReducer+Domain.swift
+++ b/Nex/AppReducer+Domain.swift
@@ -155,6 +155,7 @@ extension AppReducer {
              .clearWorkspaceSelection,
              .selectAllWorkspaces,
              .setBulkColor,
+             .setBulkLabel,
              .requestBulkDelete,
              .confirmBulkDelete,
              .cancelBulkDelete,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -362,6 +362,7 @@ struct AppReducer {
         case clearWorkspaceSelection
         case selectAllWorkspaces
         case setBulkColor(WorkspaceColor)
+        case setBulkLabel(label: String, apply: Bool)
         case requestBulkDelete
         case confirmBulkDelete
         case cancelBulkDelete
@@ -1373,6 +1374,21 @@ struct AppReducer {
             case .setBulkColor(let color):
                 for id in state.selectedWorkspaceIDs {
                     state.workspaces[id: id]?.color = color
+                }
+                return .send(.persistState)
+
+            case .setBulkLabel(let label, let apply):
+                let normalized = WorkspaceFeature.normalizeLabel(label)
+                guard !normalized.isEmpty else { return .none }
+                for id in state.selectedWorkspaceIDs {
+                    guard state.workspaces[id: id] != nil else { continue }
+                    if apply {
+                        if !(state.workspaces[id: id]?.labels.contains(normalized) ?? false) {
+                            state.workspaces[id: id]?.labels.append(normalized)
+                        }
+                    } else {
+                        state.workspaces[id: id]?.labels.removeAll { $0 == normalized }
+                    }
                 }
                 return .send(.persistState)
 

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -851,6 +851,7 @@ struct WorkspaceListView: View {
                     }
                 }
             }
+            bulkLabelsMenu(selection: selection)
             Button("Group \(selection.count) Workspaces...") {
                 store.send(.requestBulkCreateGroup)
             }
@@ -924,6 +925,96 @@ struct WorkspaceListView: View {
                 }
             }
         }
+    }
+
+    /// Bulk "Label ▸" submenu shown when 2+ workspaces are selected. Each
+    /// preset renders its all/some/none state across the whole selection
+    /// (checkmark / dash / plain); clicking applies-to-all when not every
+    /// selected workspace carries it, otherwise removes-from-all. Free-form
+    /// labels present on any selected workspace are surfaced below a divider
+    /// so they can be toggled too. "Manage Labels…" opens Settings → Labels.
+    ///
+    /// Counts are computed over the full selection — including workspaces
+    /// hidden inside a collapsed group, which are absent from the sidebar
+    /// order — so the menu stays consistent with `.setBulkLabel`, which
+    /// mutates every live `selectedWorkspaceIDs` entry.
+    private func bulkLabelsMenu(selection: Set<UUID>) -> some View {
+        // Selected workspaces in sidebar order, with any live members hidden
+        // from the sidebar (e.g. collapsed-group children) appended so the
+        // free-form gather and the counts cover the whole selection.
+        let visible = workspaceIDs(sortedBySidebar: selection)
+        let hidden = selection.subtracting(visible)
+            .filter { store.workspaces[id: $0] != nil }
+            .sorted { $0.uuidString < $1.uuidString }
+        let orderedSelection = visible + hidden
+        let total = orderedSelection.count
+
+        func appliedCount(_ label: String) -> Int {
+            orderedSelection.reduce(0) {
+                $0 + ((store.workspaces[id: $1]?.labels.contains(label) ?? false) ? 1 : 0)
+            }
+        }
+
+        // Free-form (non-preset) labels present on any selected workspace,
+        // deduped in sidebar order.
+        let presetNames = Set(store.presets.labelPresets.map(\.name))
+        var seen = Set<String>()
+        var freeform: [String] = []
+        for id in orderedSelection {
+            for label in store.workspaces[id: id]?.labels ?? [] where !presetNames.contains(label) {
+                if seen.insert(label).inserted { freeform.append(label) }
+            }
+        }
+
+        return Menu("Label \(selection.count) Workspaces") {
+            ForEach(store.presets.labelPresets) { preset in
+                let count = appliedCount(preset.name)
+                let all = total > 0 && count == total
+                let isMixed = count > 0 && count < total
+                Button {
+                    store.send(.setBulkLabel(label: preset.name, apply: !all))
+                } label: {
+                    Label {
+                        Text(preset.name)
+                    } icon: {
+                        preset.color.color.menuSwatch(checked: all, mixed: isMixed)
+                    }
+                }
+                .accessibilityValue(Text(bulkLabelStateDescription(all: all, mixed: isMixed)))
+            }
+            if !freeform.isEmpty {
+                Divider()
+                ForEach(freeform, id: \.self) { label in
+                    // Free-form labels are gathered from the selection, so
+                    // they're always on ≥1 workspace: "all" or mixed, never none.
+                    let all = total > 0 && appliedCount(label) == total
+                    Button {
+                        store.send(.setBulkLabel(label: label, apply: !all))
+                    } label: {
+                        Label(label, systemImage: all ? "checkmark" : "minus")
+                    }
+                    .accessibilityValue(Text(bulkLabelStateDescription(all: all, mixed: !all)))
+                }
+            }
+            Divider()
+            Button("Manage Labels\u{2026}") {
+                WebPaneChrome.pendingSettingsTab = .labels
+                openSettings()
+                NotificationCenter.default.post(
+                    name: WebPaneChrome.openSettingsTabNotification,
+                    object: SettingsTab.labels
+                )
+            }
+        }
+    }
+
+    /// VoiceOver value for a bulk-label row: the checked/mixed state lives in
+    /// the swatch/symbol image, which carries no text of its own, so surface
+    /// it here for assistive tech.
+    private func bulkLabelStateDescription(all: Bool, mixed: Bool) -> String {
+        if all { return "Applied to all" }
+        if mixed { return "Applied to some" }
+        return "Not applied"
     }
 
     /// "Labels ▸" submenu attached to a workspace row's context menu.

--- a/Nex/Models/LabelPreset.swift
+++ b/Nex/Models/LabelPreset.swift
@@ -176,8 +176,11 @@ extension Color {
     /// A non-template swatch image for showing a real colour inside a macOS
     /// `Menu`: SF Symbols are templated (monochrome) in menus, so a coloured
     /// dot drawn as a non-template `NSImage` is the reliable way to show
-    /// true colours. Draws a white/black checkmark when `checked`.
-    func menuSwatch(diameter: CGFloat = 11, checked: Bool = false) -> Image {
+    /// true colours. Draws a white/black checkmark when `checked`, or a dash
+    /// when `mixed` (indeterminate) — used by the bulk-label menu when only
+    /// some of the selected workspaces carry the label. `checked` wins if both
+    /// are set.
+    func menuSwatch(diameter: CGFloat = 11, checked: Bool = false, mixed: Bool = false) -> Image {
         let ns = NSColor(self).usingColorSpace(.sRGB) ?? NSColor(self)
         // Pull out Sendable components so the drawing closure captures no
         // non-Sendable NSColor (Swift 6 strict concurrency).
@@ -199,6 +202,14 @@ extension Color {
                 mark.lineWidth = 1.5
                 mark.lineCapStyle = .round
                 mark.lineJoinStyle = .round
+                NSColor(white: dark ? 0 : 1, alpha: 1).setStroke()
+                mark.stroke()
+            } else if mixed {
+                let mark = NSBezierPath()
+                mark.move(to: NSPoint(x: rect.width * 0.30, y: rect.height * 0.50))
+                mark.line(to: NSPoint(x: rect.width * 0.70, y: rect.height * 0.50))
+                mark.lineWidth = 1.5
+                mark.lineCapStyle = .round
                 NSColor(white: dark ? 0 : 1, alpha: 1).setStroke()
                 mark.stroke()
             }

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -1528,6 +1528,83 @@ struct AppReducerTests {
         }
     }
 
+    @Test func setBulkLabelAppliesToAllSelectedWithoutDuplicating() async {
+        var ws1 = Self.makeWorkspace(id: Self.wsID1, name: "WS1", paneID: Self.paneID1)
+        ws1.labels = ["urgent"] // already carries it — must not be duplicated
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "WS2", paneID: Self.paneID2)
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2]
+        appState.activeWorkspaceID = Self.wsID1
+        appState.selectedWorkspaceIDs = [Self.wsID1, Self.wsID2]
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.setBulkLabel(label: "urgent", apply: true)) { state in
+            #expect(state.workspaces[id: Self.wsID1]?.labels == ["urgent"])
+            #expect(state.workspaces[id: Self.wsID2]?.labels == ["urgent"])
+        }
+    }
+
+    @Test func setBulkLabelRemovesFromAllSelected() async {
+        var ws1 = Self.makeWorkspace(id: Self.wsID1, name: "WS1", paneID: Self.paneID1)
+        ws1.labels = ["urgent", "keep"]
+        var ws2 = Self.makeWorkspace(id: Self.wsID2, name: "WS2", paneID: Self.paneID2)
+        ws2.labels = ["urgent"]
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2]
+        appState.activeWorkspaceID = Self.wsID1
+        appState.selectedWorkspaceIDs = [Self.wsID1, Self.wsID2]
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.setBulkLabel(label: "urgent", apply: false)) { state in
+            #expect(state.workspaces[id: Self.wsID1]?.labels == ["keep"])
+            #expect(state.workspaces[id: Self.wsID2]?.labels == [])
+        }
+    }
+
+    @Test func setBulkLabelIgnoresBlankLabel() async {
+        var ws1 = Self.makeWorkspace(id: Self.wsID1, name: "WS1", paneID: Self.paneID1)
+        ws1.labels = ["urgent"]
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "WS2", paneID: Self.paneID2)
+        var appState = AppReducer.State()
+        appState.workspaces = [ws1, ws2]
+        appState.activeWorkspaceID = Self.wsID1
+        appState.selectedWorkspaceIDs = [Self.wsID1, Self.wsID2]
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        // Whitespace-only label normalizes to empty and is a no-op.
+        await store.send(.setBulkLabel(label: "   ", apply: true))
+    }
+
     @Test func requestBulkDeletePresentsConfirmation() async {
         let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "WS1", paneID: Self.paneID1)
         let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "WS2", paneID: Self.paneID2)


### PR DESCRIPTION
## Summary
- Add a **"Label N Workspaces"** submenu to the multi-workspace context menu (after "Color"), bringing labels to parity with the existing bulk Color / Group / Move-to-Group actions.
- Each preset shows a three-state indicator: **checkmark** when every selected workspace carries the label, a **dash** when only some do, plain when none. Clicking applies-to-all unless all already have it, in which case it removes-from-all. Free-form (non-preset) labels present on the selection are surfaced below a divider and toggle the same way.
- New app action `setBulkLabel(label:apply:)` mirrors `setBulkColor`'s direct-mutation + `.persistState` path (skips stale IDs, dedupes on add).
- `menuSwatch` gains an optional `mixed` param that draws the dash.

Closes #202

## Reviewer notes
- **Nice-to-have #2 (inline create-and-apply a brand-new label) is deliberately out of scope** per user decision — new labels are created via "Manage Labels…" (Settings), exactly like the single-workspace label menu.
- Counts are computed over the **full live selection**, including workspaces hidden inside a collapsed group (absent from the sidebar order), so the menu stays consistent with the reducer.
- Applied one should-fix from parallel review: an `.accessibilityValue` ("Applied to all/some", "Not applied") on each row so VoiceOver can announce the state that otherwise lives only in the swatch image.

## Validation
- Validated in a sandboxed macOS VM via cua/lume.
- Per-issue assertions (all passed): launch (1 initial pane) → create 3 colour-coded workspaces via CLI → assert 4 distinct workspaces render → socket round-trip sanity.
- **Note:** bulk-label is GUI-only (no `nex` CLI verb), so the VM assertions cover build + launch + multi-workspace sidebar render; the context-menu interaction itself was exercised manually via VNC on the kept-alive VM.
- Unit tests: `setBulkLabelAppliesToAllSelectedWithoutDuplicating`, `setBulkLabelRemovesFromAllSelected`, `setBulkLabelIgnoresBlankLabel`.
- Screenshots: `/Users/ben/code/cua/out/branches/feat-bulk-label-workspaces/issue-202/`

## Test plan
- [ ] Multi-select workspaces (Cmd-click); right-click → "Label N Workspaces" appears after "Color".
- [ ] Apply a preset label to all selected; pills render on every row.
- [ ] Re-open menu: applied preset shows a checkmark; toggling removes it from all.
- [ ] Mixed state: apply to a subset, then select all — the label shows a dash; clicking applies to all.
- [ ] A free-form label present on some of the selection is toggleable from the bulk menu.
- [ ] "Manage Labels…" opens Settings → Labels.
- [ ] A collapsed-group member included in the selection is still affected (counts stay correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)