### PR TITLE
Discoverable app-level entry points to open a web pane (#206)

### DIFF
--- a/Nex/AppReducer+WebPane.swift
+++ b/Nex/AppReducer+WebPane.swift
@@ -28,7 +28,7 @@ extension AppReducer {
         Reduce { state, action in
             guard Self.domain(of: action) == .webPane else { return .none }
             switch action {
-            case .openWebPanePath(let url, _):
+            case .openWebPanePath(let url, let fromPaneID, let direction):
                 guard let activeID = state.activeWorkspaceID else { return .none }
                 let newPaneID = uuid()
                 // Blank URL → focus the fresh pane's URL bar so the user
@@ -48,7 +48,12 @@ extension AppReducer {
                         tabID: uuid(),
                         url: url,
                         reusePaneID: nil,
-                        isPrivate: false
+                        isPrivate: false,
+                        // fromPaneID = the pane whose header button /
+                        // context menu was used; nil (menu bar / ⌘⇧O)
+                        // splits the focused pane.
+                        sourcePaneID: fromPaneID,
+                        direction: direction
                     )
                 )))
 

--- a/Nex/AppReducer+WebPane.swift
+++ b/Nex/AppReducer+WebPane.swift
@@ -30,10 +30,21 @@ extension AppReducer {
             switch action {
             case .openWebPanePath(let url, _):
                 guard let activeID = state.activeWorkspaceID else { return .none }
+                let newPaneID = uuid()
+                // Blank URL → focus the fresh pane's URL bar so the user
+                // can type immediately (mirrors `webPaneOpenNewTab` for
+                // blank tabs). A preset URL is loading content, so leave
+                // focus to the WKWebView. The webview's
+                // `claimFirstResponder` yields whenever the URL field is
+                // already first responder, so this token bump wins the
+                // focus race regardless of async ordering.
+                if url.isEmpty {
+                    state.webPaneURLFocusTokens[newPaneID, default: 0] &+= 1
+                }
                 return .send(.workspaces(.element(
                     id: activeID,
                     action: .openWebPane(
-                        paneID: uuid(),
+                        paneID: newPaneID,
                         tabID: uuid(),
                         url: url,
                         reusePaneID: nil,

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -442,8 +442,10 @@ struct AppReducer {
         case openFile
         case openFileAtPath(String, fromPaneID: UUID?)
         case openDiffPath(repoPath: String, targetPath: String?, fromPaneID: UUID?)
-        /// Open a web pane in the active workspace.
-        case openWebPanePath(url: String, fromPaneID: UUID?)
+        /// Open a web pane in the active workspace. `fromPaneID` is the
+        /// pane to split off (header button / context menu, issue #206);
+        /// nil splits the focused pane. `direction` picks right vs down.
+        case openWebPanePath(url: String, fromPaneID: UUID?, direction: PaneLayout.SplitDirection = .horizontal)
         /// Bump the URL bar focus token for a web pane (⌘L).
         case webPaneFocusURLBar(paneID: UUID)
         /// Open a new tab in an existing web pane. `url == nil` →

--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -23,6 +23,12 @@ struct NexCommands: Commands {
                 store.send(.openFile)
             }
 
+            menuButton("New Web Pane", action: .openWebPane) {
+                // Fresh web pane on a blank URL with the URL bar
+                // focused — same reducer path as the ⌘⇧O keybinding.
+                store.send(.openWebPanePath(url: "", fromPaneID: nil))
+            }
+
             menuButton("Command Palette", action: .commandPalette) {
                 store.send(.toggleCommandPalette)
             }

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -128,8 +128,10 @@ struct ContentView: View {
                             onSetPaneStatus: { paneID, status in
                                 store.send(.setPaneStatus(paneID: paneID, status: status))
                             },
-                            onOpenWebPane: {
-                                store.send(.openWebPanePath(url: "", fromPaneID: nil))
+                            onOpenWebPane: { paneID, direction in
+                                store.send(.openWebPanePath(
+                                    url: "", fromPaneID: paneID, direction: direction
+                                ))
                             },
                             isSyncInputActive: workspace.isSyncInputActive,
                             syncInputExcluded: workspace.syncInputExcluded,

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -128,6 +128,9 @@ struct ContentView: View {
                             onSetPaneStatus: { paneID, status in
                                 store.send(.setPaneStatus(paneID: paneID, status: status))
                             },
+                            onOpenWebPane: {
+                                store.send(.openWebPanePath(url: "", fromPaneID: nil))
+                            },
                             isSyncInputActive: workspace.isSyncInputActive,
                             syncInputExcluded: workspace.syncInputExcluded,
                             onToggleSyncExcluded: { paneID in

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -33,11 +33,11 @@ struct PaneGridView: View {
     var onRenamePane: ((UUID) -> Void)?
     var onMovePaneToWorkspace: ((UUID, UUID) -> Void)?
     var onSetPaneStatus: ((UUID, PaneStatus) -> Void)?
-    /// Open a fresh web pane from a pane-header context menu (issue
-    /// #206). Wired by `ContentView`. No source pane is threaded: the
-    /// reducer opens in the active workspace (which is always the one
-    /// on screen), matching the menu-bar "New Web Pane" item.
-    var onOpenWebPane: (() -> Void)?
+    /// Open a fresh web pane split off a specific pane (issue #206) —
+    /// the header globe button and the "New Web Pane" context-menu
+    /// entry. Args: source pane id + split direction (`.horizontal` =
+    /// right, `.vertical` = down). Wired by `ContentView`.
+    var onOpenWebPane: ((UUID, PaneLayout.SplitDirection) -> Void)?
     /// Issue #121 sync-input state. `isSyncInputActive` flips the
     /// workspace toggle (drives the per-pane SYNC badge for every
     /// non-excluded pane); `syncInputExcluded` lists panes opted out.
@@ -195,7 +195,7 @@ struct PaneGridView: View {
                 onSetStatus: pane.type == .shell
                     ? onSetPaneStatus.map { handler in { status in handler(pane.id, status) } }
                     : nil,
-                onOpenWebPane: onOpenWebPane,
+                onOpenWebPane: onOpenWebPane.map { handler in { direction in handler(pane.id, direction) } },
                 isSyncExcluded: syncInputExcluded.contains(pane.id),
                 workspaceSyncActive: isSyncInputActive,
                 onToggleSyncExcluded: onToggleSyncExcluded.map { handler in

--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -33,6 +33,11 @@ struct PaneGridView: View {
     var onRenamePane: ((UUID) -> Void)?
     var onMovePaneToWorkspace: ((UUID, UUID) -> Void)?
     var onSetPaneStatus: ((UUID, PaneStatus) -> Void)?
+    /// Open a fresh web pane from a pane-header context menu (issue
+    /// #206). Wired by `ContentView`. No source pane is threaded: the
+    /// reducer opens in the active workspace (which is always the one
+    /// on screen), matching the menu-bar "New Web Pane" item.
+    var onOpenWebPane: (() -> Void)?
     /// Issue #121 sync-input state. `isSyncInputActive` flips the
     /// workspace toggle (drives the per-pane SYNC badge for every
     /// non-excluded pane); `syncInputExcluded` lists panes opted out.
@@ -190,6 +195,7 @@ struct PaneGridView: View {
                 onSetStatus: pane.type == .shell
                     ? onSetPaneStatus.map { handler in { status in handler(pane.id, status) } }
                     : nil,
+                onOpenWebPane: onOpenWebPane,
                 isSyncExcluded: syncInputExcluded.contains(pane.id),
                 workspaceSyncActive: isSyncInputActive,
                 onToggleSyncExcluded: onToggleSyncExcluded.map { handler in

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -27,6 +27,9 @@ struct PaneHeaderView: View {
     /// (issue #183). Nil for non-shell panes and when the host hasn't
     /// wired it (tests, previews).
     var onSetStatus: ((PaneStatus) -> Void)?
+    /// Open a fresh web pane in this pane's workspace (issue #206).
+    /// Nil when the host hasn't wired it (tests, previews).
+    var onOpenWebPane: (() -> Void)?
     /// True when sync is on for the workspace but this pane has been
     /// opted out. Used to render the "Include in sync" context menu
     /// entry and the dimmed `SYNC OFF` badge.
@@ -328,6 +331,9 @@ struct PaneHeaderView: View {
         Divider()
         Button("Split Right") { onSplitHorizontal() }
         Button("Split Down") { onSplitVertical() }
+        if let onOpenWebPane {
+            Button("New Web Pane") { onOpenWebPane() }
+        }
         if let onSetStatus {
             Divider()
             Menu("Status") {

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -27,9 +27,12 @@ struct PaneHeaderView: View {
     /// (issue #183). Nil for non-shell panes and when the host hasn't
     /// wired it (tests, previews).
     var onSetStatus: ((PaneStatus) -> Void)?
-    /// Open a fresh web pane in this pane's workspace (issue #206).
-    /// Nil when the host hasn't wired it (tests, previews).
-    var onOpenWebPane: (() -> Void)?
+    /// Open a fresh web pane split off THIS pane (issue #206). The
+    /// argument is the split direction: `.horizontal` = right,
+    /// `.vertical` = down. Used by the header globe button (click vs
+    /// ⇧-click) and the "New Web Pane" context-menu entry. Nil when the
+    /// host hasn't wired it (tests, previews).
+    var onOpenWebPane: ((PaneLayout.SplitDirection) -> Void)?
     /// True when sync is on for the workspace but this pane has been
     /// opted out. Used to render the "Include in sync" context menu
     /// entry and the dimmed `SYNC OFF` badge.
@@ -238,6 +241,25 @@ struct PaneHeaderView: View {
             .opacity(0.6)
             .help("Split down (⌘⇧D)")
 
+            if let onOpenWebPane {
+                Button {
+                    // Click → split right; ⇧-click → split down. Read
+                    // the modifier from the click event that drives this
+                    // action (reliable at NSButton action time).
+                    let down = NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false
+                    onOpenWebPane(down ? .vertical : .horizontal)
+                } label: {
+                    Image(systemName: "globe")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20, height: 20)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .opacity(0.6)
+                .help("New web pane (⇧-click splits down)")
+            }
+
             Button(action: onClose) {
                 Image(systemName: "xmark")
                     .font(.system(size: 9, weight: .semibold))
@@ -332,7 +354,7 @@ struct PaneHeaderView: View {
         Button("Split Right") { onSplitHorizontal() }
         Button("Split Down") { onSplitVertical() }
         if let onOpenWebPane {
-            Button("New Web Pane") { onOpenWebPane() }
+            Button("New Web Pane") { onOpenWebPane(.horizontal) }
         }
         if let onSetStatus {
             Divider()

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -281,7 +281,12 @@ struct WorkspaceFeature {
             tabID: UUID,
             url: String,
             reusePaneID: UUID? = nil,
-            isPrivate: Bool = false
+            isPrivate: Bool = false,
+            // Pane to split off (issue #206 header button / context
+            // menu). Nil → split the focused pane. `direction` picks
+            // right (.horizontal) vs down (.vertical).
+            sourcePaneID: UUID? = nil,
+            direction: PaneLayout.SplitDirection = .horizontal
         )
         /// Tell the coordinator to navigate the active tab. The
         /// coordinator updates the WebView; the URL bar follows via
@@ -681,7 +686,7 @@ struct WorkspaceFeature {
                 state.currentLayoutIndex = nil
                 return branchEffect
 
-            case .openWebPane(let newPaneID, let tabID, let url, let reusePaneID, let isPrivate):
+            case .openWebPane(let newPaneID, let tabID, let url, let reusePaneID, let isPrivate, let sourcePaneID, let direction):
                 let normalized = WebPaneCoordinator.normalizeURLInput(url)
                 let tab = WebTab(id: tabID, url: normalized)
                 let newPane = Pane(
@@ -722,7 +727,10 @@ struct WorkspaceFeature {
                     return .none
                 }
 
-                if let sourceID = state.focusedPaneID {
+                // Split off the caller-supplied pane (header button /
+                // context menu, issue #206) when given, else the focused
+                // pane; `direction` picks right vs down.
+                if let sourceID = sourcePaneID ?? state.focusedPaneID {
                     if let saved = state.savedLayout {
                         state.layout = saved
                         state.zoomedPaneID = nil
@@ -730,7 +738,7 @@ struct WorkspaceFeature {
                     }
                     let (newLayout, _) = state.layout.splitting(
                         paneID: sourceID,
-                        direction: .horizontal,
+                        direction: direction,
                         newPaneID: newPaneID
                     )
                     state.layout = newLayout

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -249,10 +249,13 @@ enum NexAction: String, CaseIterable {
     case openDiff = "open_diff"
     case toggleSyncInput = "toggle_sync_input"
 
-    // Web pane actions. All ship unbound; the priority layer in
-    // `PaneShortcutMonitor` dispatches them directly when the focused
-    // pane is a web pane, so the global ⌘L / ⌘R / ⌘[ / ⌘] / ⌘T /
-    // ⌘W / ⌘⇧[ / ⌘⇧] defaults are preserved for every other pane type.
+    // Web pane actions. `openWebPane` is the app-level entry point:
+    // it ships bound to ⌘⇧O and is a menu bar action, so it opens a
+    // fresh web pane from anywhere. The rest ship unbound; the
+    // priority layer in `PaneShortcutMonitor` dispatches them directly
+    // when the focused pane is a web pane, so the global ⌘L / ⌘R /
+    // ⌘[ / ⌘] / ⌘T / ⌘W / ⌘⇧[ / ⌘⇧] defaults are preserved for every
+    // other pane type.
     case openWebPane = "open_web_pane"
     case webFocusURLBar = "web_focus_url_bar"
     case webBack = "web_back"
@@ -269,7 +272,7 @@ enum NexAction: String, CaseIterable {
     /// The NSEvent monitor should not consume events for these.
     var isMenuBarAction: Bool {
         switch self {
-        case .newWorkspace, .openFile, .newGroup,
+        case .newWorkspace, .openFile, .openWebPane, .newGroup,
              .switchToWorkspace1, .switchToWorkspace2, .switchToWorkspace3,
              .switchToWorkspace4, .switchToWorkspace5, .switchToWorkspace6,
              .switchToWorkspace7, .switchToWorkspace8, .switchToWorkspace9,
@@ -340,7 +343,12 @@ enum NexAction: String, CaseIterable {
         switch self {
         case .splitRight, .splitDown, .closePane, .reopenClosedPane, .toggleZoom, .cycleLayout,
              .movePaneLeft, .movePaneRight, .movePaneUp, .movePaneDown, .createScratchpad,
-             .toggleSyncInput:
+             .toggleSyncInput, .openWebPane:
+            // `openWebPane` lives here (not the web-pane group) because
+            // it's a real map-driven, app-wide bindable action shipping
+            // with a ⌘⇧O default — it must appear in Settings so users
+            // can discover/rebind it. The web-pane group below is
+            // hidden (priority-layer driven, not meaningfully rebindable).
             "Pane Management"
         case .focusNextPane, .focusPreviousPane, .commandPalette:
             "Navigation"
@@ -354,7 +362,7 @@ enum NexAction: String, CaseIterable {
         case .openFile, .toggleMarkdownEdit, .increaseMarkdownFontSize, .decreaseMarkdownFontSize,
              .resetMarkdownFontSize, .openDiff:
             "Files"
-        case .openWebPane, .webFocusURLBar, .webBack, .webForward, .webReload,
+        case .webFocusURLBar, .webBack, .webForward, .webReload,
              .webTabNew, .webTabClose, .webTabPrev, .webTabNext:
             "Web Pane (active when web pane focused)"
         case .toggleSearch, .closeSearch:
@@ -489,6 +497,7 @@ struct KeyBindingMap: Equatable {
         // Menu bar actions (Layer 1)
         bindings[KeyTrigger(keyCode: 45, modifiers: .command)] = .newWorkspace // ⌘N
         bindings[KeyTrigger(keyCode: 31, modifiers: .command)] = .openFile // ⌘O
+        bindings[KeyTrigger(keyCode: 31, modifiers: [.command, .shift])] = .openWebPane // ⌘⇧O
         bindings[KeyTrigger(keyCode: 18, modifiers: .command)] = .switchToWorkspace1 // ⌘1
         bindings[KeyTrigger(keyCode: 19, modifiers: .command)] = .switchToWorkspace2 // ⌘2
         bindings[KeyTrigger(keyCode: 20, modifiers: .command)] = .switchToWorkspace3 // ⌘3

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -84,6 +84,30 @@ struct AppReducerTests {
         }
     }
 
+    @Test func openWebPanePathSplitsSourcePaneInGivenDirection() async {
+        // The header globe button / context menu split off a SPECIFIC
+        // pane (issue #206): `fromPaneID` is the split source and
+        // `direction` picks right (.horizontal) vs down (.vertical).
+        // ⇧-click the globe → a vertical split off that pane.
+        let ws = Self.makeWorkspace(id: Self.wsID1, name: "Test", paneID: Self.paneID1)
+        let store = makeStore(workspaces: [ws], activeWorkspaceID: Self.wsID1)
+
+        await store.send(.openWebPanePath(
+            url: "", fromPaneID: Self.paneID1, direction: .vertical
+        ))
+        await store.skipReceivedActions()
+
+        let workspace = store.state.workspaces[id: Self.wsID1]
+        let webPanes = workspace?.panes.filter { $0.type == .web } ?? []
+        #expect(webPanes.count == 1)
+        // The source pane was split vertically (down), not right.
+        if case .split(let dir, _, _, _) = workspace?.layout {
+            #expect(dir == .vertical)
+        } else {
+            Issue.record("Expected a vertical split layout after ⇧-click open")
+        }
+    }
+
     // MARK: - createWorkspace
 
     @Test func createWorkspaceAddsWorkspaceAndActivates() async {

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -58,6 +58,32 @@ struct AppReducerTests {
         )
     }
 
+    // MARK: - openWebPanePath (⌘⇧O / menu / context-menu entry point)
+
+    @Test func openWebPanePathAddsWebPaneAndFocusesURLBar() async {
+        // All three GUI entry points from issue #206 (the ⌘⇧O binding,
+        // the "New Web Pane" menu item, and the pane-header context
+        // menu) converge on `.openWebPanePath(url: "", fromPaneID: nil)`.
+        // Verify it opens a `.web` pane in the active workspace and
+        // bumps the URL-bar focus token for the blank tab.
+        let ws = Self.makeWorkspace(id: Self.wsID1, name: "Test", paneID: Self.paneID1)
+        let store = makeStore(workspaces: [ws], activeWorkspaceID: Self.wsID1)
+
+        await store.send(.openWebPanePath(url: "", fromPaneID: nil))
+        // Drain the forwarded `.workspaces(.openWebPane(...))` action.
+        await store.skipReceivedActions()
+
+        let webPanes = store.state.workspaces[id: Self.wsID1]?
+            .panes.filter { $0.type == .web } ?? []
+        #expect(webPanes.count == 1)
+        // Blank URL → the fresh pane's URL bar is focused (token bumped).
+        if let webPaneID = webPanes.first?.id {
+            #expect(store.state.webPaneURLFocusTokens[webPaneID] == 1)
+        } else {
+            Issue.record("Expected a web pane after openWebPanePath")
+        }
+    }
+
     // MARK: - createWorkspace
 
     @Test func createWorkspaceAddsWorkspaceAndActivates() async {

--- a/NexTests/KeyBindingTests.swift
+++ b/NexTests/KeyBindingTests.swift
@@ -159,7 +159,7 @@ struct NexActionTests {
 
     @Test func menuBarActionsAreCorrect() {
         let menuActions: [NexAction] = [
-            .newWorkspace, .openFile,
+            .newWorkspace, .openFile, .openWebPane,
             .switchToWorkspace1, .switchToWorkspace2, .switchToWorkspace3,
             .switchToWorkspace4, .switchToWorkspace5, .switchToWorkspace6,
             .switchToWorkspace7, .switchToWorkspace8, .switchToWorkspace9,
@@ -207,6 +207,12 @@ struct KeyBindingMapTests {
 
         let escape = KeyTrigger(keyCode: 53)
         #expect(map.action(for: escape) == .closeSearch)
+
+        // ⌘⇧O opens a web pane (issue #206); ⌘O stays markdown.
+        let cmdShiftO = KeyTrigger(keyCode: 31, modifiers: [.command, .shift])
+        #expect(map.action(for: cmdShiftO) == .openWebPane)
+        let cmdO = KeyTrigger(keyCode: 31, modifiers: .command)
+        #expect(map.action(for: cmdO) == .openFile)
     }
 
     @Test func defaultsHaveDualBindingsForFocusNext() {

--- a/NexTests/PaneShortcutMonitorTests.swift
+++ b/NexTests/PaneShortcutMonitorTests.swift
@@ -157,6 +157,23 @@ struct PaneShortcutMonitorTests {
         #expect(store.workspaces[id: Self.wsID]?.focusedPaneID == Self.paneID1)
     }
 
+    // MARK: - Open web pane (menu bar action)
+
+    @Test func cmdShiftOIsNotConsumedByMonitor() {
+        // ⌘⇧O opens a web pane (issue #206), but `openWebPane` is a
+        // menu bar action — SwiftUI Commands owns its dispatch. The
+        // NSEvent monitor must defer (return false) so the shortcut
+        // fires exactly once and never double-dispatches.
+        let ws = Self.makeWorkspace()
+        let (_, monitor) = makeStoreAndMonitor(
+            workspaces: [ws],
+            activeWorkspaceID: Self.wsID
+        )
+
+        let event = keyEvent(keyCode: 31, modifierFlags: [.command, .shift])
+        #expect(monitor.handleKeyEvent(event) == false)
+    }
+
     // MARK: - Split pane
 
     @Test func cmdDSplitsHorizontal() {


### PR DESCRIPTION
## Summary
- Bind `openWebPane` to **⌘⇧O** by default (mirrors ⌘O for markdown; free in the default map, untouched by the web priority layer) and make it a menu-bar action.
- Add a **"New Web Pane"** menu-bar item (shows ⌘⇧O) and a **"New Web Pane"** pane-header context-menu entry.
- Add a **globe icon button** in each pane header, next to the split icons: **click** opens a web pane splitting right, **⇧-click** splits down.
- Recategorise `openWebPane` into "Pane Management" so ⌘⇧O is visible/rebindable in Settings, and focus the URL bar on the fresh blank tab so it doubles as a quick "new web tab".

All surfaces route through the existing `openWebPanePath` → `openWebPane` reducer path (extended with defaulted `sourcePaneID` + `direction`, so existing callers are unchanged).

Closes #206

## Reviewer notes
- Two parallel reviewers found no correctness bug. Their two substantive findings were applied: (1) `openWebPane` was miscategorised into a hidden Settings category, so ⌘⇧O would have been invisible/unrebindable there — now in "Pane Management"; (2) the reducer wasn't focusing the URL bar on a fresh pane despite the issue's stated behavior — now bumps the focus token for blank URLs.
- The ⌘T alternative for the shortcut was rejected in favour of ⌘⇧O to avoid a menu-vs-priority-layer collision (⌘T is claimed by the in-pane new-tab shortcut).
- Issue items 4-6 (command palette, empty-grid affordance, titlebar "+") remain out of scope as noted in the issue.

## Validation
- Validated in a sandboxed macOS VM via cua/lume (fresh clone, built from the branch, ad-hoc signed).
- Assertions: **⌘⇧O opens exactly one `.web` pane** (shell pane survives); the web pane has **a single blank tab**; the **header globe click splits the shell pane right into a new web pane** (1→2 web panes).
- Screenshots (File menu w/ ⌘⇧O, context-menu entry, globe button zoom, click result): `/Users/ben/code/cua/out/branches/open-web-pane-gui/issue-206/`
- Unit tests: `openWebPanePathAddsWebPaneAndFocusesURLBar`, `openWebPanePathSplitsSourcePaneInGivenDirection` (⇧-click direction), `cmdShiftOIsNotConsumedByMonitor`, plus updated keybinding-default / menu-bar-action tests. Full suite 1144 tests green.

## Test plan
- [x] ⌘⇧O opens a web pane with the URL bar focused; type a URL and hit enter
- [x] File → "New Web Pane" shows ⌘⇧O and opens a web pane
- [x] Right-click a pane header (shell / markdown / diff) → "New Web Pane" opens one
- [x] Header globe button: click splits right, ⇧-click splits down
- [x] Settings → Keybindings → Pane Management → "Open Web Pane" is listed and rebindable
- [x] In a focused web pane, ⌘T still opens a new tab (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASTcDqev9eXcPRHXyiHQYT