### PR TITLE
fix(ghostty): repaint programmatically-spawned panes that render blank (#194)

### DIFF
--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -346,6 +346,10 @@ struct ContentView: View {
                 .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                     NSApp.dockTile.badgeLabel = nil
                     store.send(.updateExternalIndicators)
+                    // Repaint any pane that came up blank while Nex was
+                    // background/occluded (issue #194) — e.g. panes spawned via
+                    // `nex pane create` from an unattended agent.
+                    surfaceManager.resyncVisibleSurfaces()
                     guard let activeID = store.activeWorkspaceID,
                           let workspace = store.workspaces[id: activeID],
                           let focusedID = workspace.focusedPaneID else { return }

--- a/Nex/Ghostty/GhosttyApp.swift
+++ b/Nex/Ghostty/GhosttyApp.swift
@@ -376,7 +376,27 @@ final class GhosttyApp {
             return false
 
         case GHOSTTY_ACTION_RENDER:
-            return false
+            // libghostty processed new PTY output and wants the host to
+            // present a frame. Nex's draw is host-pumped (updateLayer ->
+            // ghostty_surface_draw), so we must re-arm needsDisplay or the
+            // pane never repaints (issue #194): a surface created while its
+            // window was zero-bounds / occluded gets its one and only draw
+            // from AppKit layout callbacks, so without this incoming output
+            // is silently dropped and the body stays blank until focus or
+            // resize. Capture the raw surface pointer as an opaque token and
+            // resolve it to a live SurfaceView on main by pointer identity
+            // (like every other action handler, via SurfaceManager) — never
+            // dereference the incoming pointer in this possibly-off-main
+            // callback, so a RENDER draining for a surface being freed off
+            // the main thread (issue #136 teardown) finds no match and is
+            // safely dropped instead of touching freed memory. AppKit
+            // coalesces repeated needsDisplay into one draw per display cycle.
+            let surface = target.tag == GHOSTTY_TARGET_SURFACE ? target.target.surface : nil
+            guard let surface else { return false }
+            DispatchQueue.main.async {
+                SurfaceManager.liveValue.surfaceView(forRawSurface: surface)?.needsDisplay = true
+            }
+            return true
 
         default:
             return false

--- a/Nex/Ghostty/SurfaceView.swift
+++ b/Nex/Ghostty/SurfaceView.swift
@@ -19,6 +19,13 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
     /// drag resize) into a single set_size so the shell only gets one SIGWINCH.
     private var resizeWorkItem: DispatchWorkItem?
 
+    /// One-shot latch for the initial-size rescue in `layout()` (issue #194).
+    /// Flips true the first time the view lays out with a live window and
+    /// non-zero bounds, at which point we force a `setSize` + draw. Guards
+    /// against re-sizing on every subsequent layout pass (ongoing resizes go
+    /// through `setFrameSize`'s debounce as before).
+    private var hasSyncedInitialSize = false
+
     private static let dropTypes: [NSPasteboard.PasteboardType] = [
         .fileURL,
         .URL,
@@ -164,6 +171,24 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
     override func layout() {
         super.layout()
         syncSublayerFrames()
+
+        // Initial-size rescue (issue #194). A surface created while its window
+        // was zero-bounds or occluded never gets a non-zero setSize or a draw:
+        // the viewDidMoveToWindow async and setFrameSize debounce both
+        // silently no-op on zero bounds / nil window, with no retry queued.
+        // layout() fires when AppKit finally resolves real bounds, so seize
+        // that first non-zero pass to size the surface and request a draw.
+        // Latched so ongoing resizes still flow through setFrameSize's debounce.
+        if !hasSyncedInitialSize, let window, bounds.width > 0, bounds.height > 0 {
+            let scale = window.backingScaleFactor
+            let w = UInt32(bounds.width * scale)
+            let h = UInt32(bounds.height * scale)
+            if w > 0, h > 0 {
+                hasSyncedInitialSize = true
+                ghosttySurface?.setSize(width: w, height: h)
+                needsDisplay = true
+            }
+        }
     }
 
     /// Resize ghostty's Metal sublayer to match the view bounds.
@@ -181,6 +206,25 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
             sublayer.frame = bounds
         }
         CATransaction.commit()
+    }
+
+    /// Force a size + draw re-sync for a surface that is currently in a live
+    /// window (issue #194). Called when the app reactivates / a window becomes
+    /// key so panes created while Nex was background/occluded — which may have
+    /// missed their output-driven and layout-driven draw — repaint. No-op for
+    /// detached surfaces (nil window, e.g. a pane in an inactive workspace);
+    /// those re-sync via viewDidMoveToWindow when reattached.
+    func resyncForRedraw() {
+        guard let window, bounds.width > 0, bounds.height > 0 else { return }
+        syncSublayerFrames()
+        let scale = window.backingScaleFactor
+        let w = UInt32(bounds.width * scale)
+        let h = UInt32(bounds.height * scale)
+        if w > 0, h > 0 {
+            ghosttySurface?.setSize(width: w, height: h)
+        }
+        ghosttySurface?.refresh()
+        needsDisplay = true
     }
 
     // MARK: - NSView overrides

--- a/Nex/Services/SurfaceManager.swift
+++ b/Nex/Services/SurfaceManager.swift
@@ -47,6 +47,21 @@ final class SurfaceManager: Sendable {
         }
     }
 
+    /// Resolve the live `SurfaceView` whose libghostty surface matches
+    /// `rawSurface`, by pointer identity against the registered views —
+    /// mirrors `paneID(for:)` and, crucially, never dereferences
+    /// `rawSurface` itself. Used by the `GHOSTTY_ACTION_RENDER` handler
+    /// (issue #194): a render draining for a surface being freed off the
+    /// main thread (issue #136 teardown) simply finds no match and is
+    /// dropped, avoiding a use-after-free of the C surface struct.
+    func surfaceView(forRawSurface rawSurface: ghostty_surface_t) -> SurfaceView? {
+        lock.withLock {
+            surfaces.first { _, view in
+                view.ghosttySurface?.surface == rawSurface
+            }?.value
+        }
+    }
+
     @MainActor
     func destroySurface(paneID: UUID) {
         let surfaceView = lock.withLock {
@@ -71,6 +86,20 @@ final class SurfaceManager: Sendable {
         for (_, surfaceView) in all {
             guard let rawSurface = surfaceView.detachForTeardown() else { continue }
             GhosttyApp.shared.freeSurfaceAsync(rawSurface, retaining: surfaceView)
+        }
+    }
+
+    /// Re-sync every live surface's size and request a redraw (issue #194).
+    /// Called on app reactivation so panes spawned while Nex was
+    /// background/occluded — which can miss their one output-/layout-driven
+    /// draw and come up with a blank body — repaint. Each surface no-ops
+    /// itself when detached (nil window / zero bounds), so this only touches
+    /// panes currently visible in a window.
+    @MainActor
+    func resyncVisibleSurfaces() {
+        let all = lock.withLock { Array(surfaces.values) }
+        for surface in all {
+            surface.resyncForRedraw()
         }
     }
 


### PR DESCRIPTION
## Summary
- Programmatically-spawned panes (`nex pane create`/`split` from the socket CLI, then an agent launched into them) came up with a blank/black terminal **body** until focus or resize: a fresh libghostty surface got its non-zero size, its Metal-sublayer frame, and its one and only draw exclusively from AppKit layout callbacks, with no output-driven redraw and no post-activation re-sync.
- **Fix 1 (keystone):** `GHOSTTY_ACTION_RENDER` now re-arms `needsDisplay` for the target surface so incoming PTY output drives a redraw instead of being dropped. The render target is resolved to a live `SurfaceView` on the main thread by pointer identity (via `SurfaceManager.surfaceView(forRawSurface:)`) — it never dereferences the incoming pointer in the possibly-off-main callback, so a render draining for a surface being freed off-main (issue #136 teardown) finds no match and is safely dropped.
- **Fix 2:** `SurfaceView.layout()` seizes the first pass with a live window + non-zero bounds to force `setSize` + a draw (one-shot `hasSyncedInitialSize` latch), rescuing surfaces whose initial sizing was silently dropped on zero bounds / nil window.
- **Fix 3:** on `NSApplication.didBecomeActiveNotification`, `SurfaceManager.resyncVisibleSurfaces()` re-sizes, refreshes, and redraws every surface currently in a live window.

Closes #194

## Reviewer notes
- Two-reviewer pass (correctness + scope). Both independently flagged the one real hardening — the RENDER handler was the only action case that synchronously dereferenced the incoming `target.target.surface` pointer (`ghostty_surface_userdata`), a new UAF surface in the #136 teardown race. Fixed by routing resolution through the live registry on main (matches every other action handler). No other material findings.
- **Not included** (declined to keep scope tight): the optional occlusion wiring (`ghostty_surface_set_occlusion`) from the issue's suggestion #4. Wiring it risks telling libghostty a surface is occluded and suppressing the very RENDER events fix 1 relies on. Known residual gap: a *previously-displayed* pane whose window de-occludes while Nex stays non-active (another app's covering window closes, that app still frontmost) won't hit `didBecomeActive`; it won't be blank (libghostty retains its buffer) and repaints on the next output-driven RENDER (fix 1) — just not instantly. An `NSWindow.didChangeOcclusionStateNotification` observer would close it if it ever matters in practice.

## Validation
- `swiftformat --lint` / `swiftlint` clean. **Debug and Release** (`-O`, Swift 6 complete concurrency) builds succeed. Full suite: 1143/1144 pass (the lone failure is the known `RecursiveFSWatcherTests.liveWatcherBatchesRapidWrites` timing flake — passes in isolation; unrelated to this change).
- Sandboxed macOS VM (cua/lume): the fix build launches and renders programmatically-spawned panes correctly (no regression); `pane capture` confirmed every spawned pane's shell ran.
- **The pre-fix bug could not be reproduced in the automated single-screen VM** (three strategies over four builds: naive socket spawn; ⌘H-hide → spawn-while-hidden → reveal, Quartz-confirmed `OFFSCREEN`; batch-create → settle → delayed-output to isolate fix 1). This is a *missing-redraw-trigger* bug, and the VM's continuous compositing + incidental system-UI churn (notification banners, the screen-recording modal) keeps invalidating the window, masking it — consistent with the issue's "intermittent" characterization. So an automated before/after can't discriminate this fix; it rests on the verified root-cause, the review, and the added redraw triggers.

## Test plan
- [x] Fan out review/worker panes from an unattended agent (`nex pane create` + `nex pane send` an agent) while the Nex window is background/occluded/on another Space; confirm every new pane paints its body without needing a click or resize.
- [x] Normal foreground pane create / split / close — no regression, no flicker.
- [x] Drag-resize, maximize (⌘⇧Enter zoom), and workspace switch — panes stay correctly sized and painted.
- [x] Switch away from Nex and back (⌘Tab) with running panes — content stays intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X56T5CvvBWXdvr8nfMobbj