### PR TITLE
fix(workspace): scroll workspaces/groups into view in the sidebar (#187)

### DIFF
--- a/Nex/AppReducer+CommandPalette.swift
+++ b/Nex/AppReducer+CommandPalette.swift
@@ -90,6 +90,10 @@ extension AppReducer {
                 // Set workspace directly to avoid effect indirection
                 state.activeWorkspaceID = item.workspaceID
                 state.workspaces[id: item.workspaceID]?.lastAccessedAt = Date()
+                // Scroll the jumped-to workspace into view — the palette
+                // can target an entry far outside the current scroll
+                // window (issue #187). No-op when already visible.
+                state.sidebarScrollTarget = .workspace(item.workspaceID)
 
                 var effects: [Effect<Action>] = [
                     .send(.persistState),

--- a/Nex/AppReducer+Domain.swift
+++ b/Nex/AppReducer+Domain.swift
@@ -146,6 +146,7 @@ extension AppReducer {
              .toggleSidebar,
              .showNewWorkspaceSheet,
              .dismissNewWorkspaceSheet,
+             .clearSidebarScrollTarget,
              .beginRenameActiveWorkspace,
              .setRenamingWorkspaceID,
              .setRenamingPaneID,

--- a/Nex/AppReducer+Socket.swift
+++ b/Nex/AppReducer+Socket.swift
@@ -261,6 +261,11 @@ extension AppReducer {
                         state.workspaces.append(newWS)
                         state.topLevelOrder.append(.workspace(newID))
                         targetWSID = newID
+                        // Scroll the freshly created (and about-to-be-active)
+                        // destination workspace into view (issue #187). Only
+                        // the auto-create branch: moving into an existing
+                        // workspace is a plain move, out of scope.
+                        state.sidebarScrollTarget = .workspace(newID)
                     }
 
                     guard let targetWSID, targetWSID != sourceWS.id else { return .none }
@@ -847,6 +852,11 @@ extension AppReducer {
         state.workspaces.append(seeded)
         state.topLevelOrder.append(.workspace(newWorkspaceID))
         state.activeWorkspaceID = newWorkspaceID
+        // Scroll the new (now-active) workspace into view (issue #187).
+        // The sidebar re-resolves this to its parent group header at
+        // scroll time if the follow-up `.moveWorkspaceToGroup` lands it
+        // inside a collapsed group.
+        state.sidebarScrollTarget = .workspace(newWorkspaceID)
 
         // Resolve or create the group.
         let targetGroupID: UUID
@@ -947,6 +957,8 @@ extension AppReducer {
         let createdGroup = WorkspaceGroup(id: newID, name: trimmed, color: color)
         state.groups.append(createdGroup)
         state.topLevelOrder.append(.group(newID))
+        // Scroll the new group header into view (issue #187).
+        state.sidebarScrollTarget = .group(newID)
         return .send(.persistState)
     }
 

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -18,6 +18,19 @@ struct AppReducer {
         var renamingWorkspaceID: UUID?
         var renamingPaneID: UUID?
         var renamingGroupID: UUID?
+        /// One-shot "scroll this sidebar entry into view" signal, set
+        /// whenever an entry is created or a workspace is navigated to
+        /// (so it can't be stranded below the fold): every
+        /// workspace/group creation path (GUI + socket), plus activation
+        /// via `setActiveWorkspace` (⌘1-9, ⌘⇧]/[, sidebar/filter clicks,
+        /// the menu-bar popover, notification "Open") and the command
+        /// palette. `WorkspaceListView` observes it, scrolls the entry
+        /// into the viewport (a no-op when it is already fully visible),
+        /// and immediately dispatches `clearSidebarScrollTarget` to
+        /// consume it. Transient UI state — never persisted. Not set by
+        /// state restore on launch or by delete/move reflow, so those
+        /// don't yank the list around.
+        var sidebarScrollTarget: SidebarID?
         var groupDeleteConfirmation: GroupDeleteConfirmation?
         var groupBulkCreatePrompt: GroupBulkCreatePrompt?
         var groupCustomEmojiPrompt: GroupCustomEmojiPrompt?
@@ -353,6 +366,7 @@ struct AppReducer {
         case toggleSidebar
         case showNewWorkspaceSheet(groupID: UUID? = nil)
         case dismissNewWorkspaceSheet
+        case clearSidebarScrollTarget
         case beginRenameActiveWorkspace
         case setRenamingWorkspaceID(UUID?)
         case setRenamingPaneID(UUID?)
@@ -1089,6 +1103,9 @@ struct AppReducer {
                 state.activeWorkspaceID = workspace.id
                 state.isNewWorkspaceSheetPresented = false
                 state.pendingSheetGroupID = nil
+                // Ask the sidebar to scroll the new (now-active) workspace
+                // into view once it lays out (issue #187).
+                state.sidebarScrollTarget = .workspace(workspace.id)
 
                 // Create the initial surface for the default pane
                 let paneID = workspace.panes.first!.id
@@ -1253,6 +1270,11 @@ struct AppReducer {
                    state.groups[id: groupID]?.isCollapsed == true {
                     state.groups[id: groupID]?.isCollapsed = false
                 }
+                // Bring the activated workspace into view — a keyboard
+                // switch (⌘1-9, ⌘⇧]/[), menu-bar/notification jump, or a
+                // click on a partially-clipped row can land on an entry
+                // below the fold (issue #187). No-op when already visible.
+                state.sidebarScrollTarget = .workspace(id)
                 return .merge(
                     .send(.persistState),
                     .send(.refreshGitStatus)
@@ -1297,6 +1319,11 @@ struct AppReducer {
             case .dismissNewWorkspaceSheet:
                 state.isNewWorkspaceSheetPresented = false
                 state.pendingSheetGroupID = nil
+                return .none
+
+            case .clearSidebarScrollTarget:
+                // The sidebar consumed the one-shot scroll signal.
+                state.sidebarScrollTarget = nil
                 return .none
 
             case .beginRenameActiveWorkspace:
@@ -1570,6 +1597,8 @@ struct AppReducer {
                 if autoRename {
                     state.renamingGroupID = newGroup.id
                 }
+                // Scroll the new group header into view (issue #187).
+                state.sidebarScrollTarget = .group(newGroup.id)
                 return .send(.persistState)
 
             case .renameGroup(let id, let name):

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -77,6 +77,14 @@ struct WorkspaceListView: View {
     /// the authoritative scroll offset + viewport height and is driven
     /// directly during auto-scroll for pixel-perfect control.
     @State private var hostScrollView: NSScrollView?
+    /// Sidebar entry queued to be scrolled into view after a create
+    /// (issue #187). Latched from `store.sidebarScrollTarget` in
+    /// `onChange`; held until the newly inserted row measures (its
+    /// height appears in `rowHeights`), then consumed by
+    /// `attemptScrollToPendingTarget`. Local rather than derived so the
+    /// scroll survives the measurement-race retry across preference
+    /// updates.
+    @State private var pendingScrollTarget: SidebarID?
     /// Active auto-scroll loop during a drag near the viewport edges.
     @State private var autoScrollTask: Task<Void, Never>?
     /// Cursor Y in the scroll viewport (viewport-relative), captured on
@@ -125,6 +133,18 @@ struct WorkspaceListView: View {
                 } else {
                     filteredListBody
                 }
+            }
+            // Scroll a freshly created workspace/group into view (#187).
+            // Consume the one-shot signal immediately so it can't re-fire
+            // on unrelated re-renders. Only the main (unfiltered) list has
+            // a live `hostScrollView`; while filtering, drop the request.
+            .onChange(of: store.sidebarScrollTarget) { _, target in
+                guard let target else { return }
+                store.send(.clearSidebarScrollTarget)
+                guard filterText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                else { return }
+                pendingScrollTarget = target
+                attemptScrollToPendingTarget()
             }
             // Bulk-action dialogs and sheets are attached at the body
             // level (not inside `mainListBody`) so they remain mounted
@@ -278,7 +298,13 @@ struct WorkspaceListView: View {
                             // because AppKit reverts it to the wide legacy
                             // scroller as the list re-lays-out.
                             if sv.scrollerStyle != .overlay { sv.scrollerStyle = .overlay }
-                            if hostScrollView !== sv { hostScrollView = sv }
+                            if hostScrollView !== sv {
+                                hostScrollView = sv
+                                // A create that fired before the scroll view
+                                // was captured left a pending target stranded
+                                // — retry now that we have a handle.
+                                if pendingScrollTarget != nil { attemptScrollToPendingTarget() }
+                            }
                         }
                         .frame(height: 0)
 
@@ -350,6 +376,12 @@ struct WorkspaceListView: View {
                         merged[id] = h
                     }
                     rowHeights = merged
+                    // A pending create-scroll waits here for the new row to
+                    // measure. Gate on `merged` (not `rowHeights`) — the
+                    // `@State` write above isn't visible synchronously.
+                    if pendingScrollTarget != nil {
+                        attemptScrollToPendingTarget(heights: merged)
+                    }
                 }
                 .onPreferenceChange(EmptyRowHeightKey.self) { h in
                     if h > 0 { measuredEmptyRowHeight = h }
@@ -2037,6 +2069,129 @@ struct WorkspaceListView: View {
             startAutoScroll(direction: 1)
         } else {
             cancelAutoScroll()
+        }
+    }
+
+    // MARK: - Scroll-created-entry-into-view (issue #187)
+
+    /// Resolve a queued scroll target to the sidebar entry that should
+    /// actually be revealed. A group is scrolled directly. A workspace
+    /// that has a visible row (top level, or inside an expanded group)
+    /// is scrolled directly; one hidden inside a *collapsed* group
+    /// resolves to that group's header instead. Returns nil when a
+    /// workspace has neither a visible row nor a parent group — an
+    /// unreachable state in the non-lazy list, handled defensively so
+    /// the pending target is dropped rather than retried forever.
+    ///
+    /// The socket `workspace-create --group` path can land a new
+    /// workspace in a collapsed group (its `.moveWorkspaceToGroup`
+    /// follow-up only auto-expands when `expandGroupOnWorkspaceDrop` is
+    /// set), unlike the reducer `.createWorkspace(groupID:)` path which
+    /// always expands — hence the header fallback here.
+    private func resolvedScrollTarget(_ target: SidebarID) -> SidebarID? {
+        switch target {
+        case .group:
+            return target
+        case .workspace(let id):
+            if currentRenderedEntries.contains(where: { $0.sidebarID == .workspace(id) }) {
+                return target
+            }
+            if let gid = store.state.groupID(forWorkspace: id) {
+                return .group(gid)
+            }
+            return nil
+        }
+    }
+
+    /// Attempt to consume `pendingScrollTarget`. No-ops (and keeps the
+    /// target pending) until the scroll view is captured and the
+    /// resolved row's height is measured — the newly inserted row
+    /// measures a layout pass after it appears, so this is retried from
+    /// `onPreferenceChange`. `heights` carries the freshly-merged
+    /// measurements when called from there (the `rowHeights` `@State`
+    /// write isn't visible synchronously); it defaults to `rowHeights`
+    /// for the `onChange` / scroll-view-capture entry points.
+    private func attemptScrollToPendingTarget(heights: [SidebarID: CGFloat]? = nil) {
+        guard let pending = pendingScrollTarget, hostScrollView != nil else { return }
+        guard let resolved = resolvedScrollTarget(pending) else {
+            pendingScrollTarget = nil
+            return
+        }
+        let effective = heights ?? rowHeights
+        // Wait for the target row to be measured before revealing it.
+        guard effective[resolved] != nil else { return }
+        pendingScrollTarget = nil
+        // Defer to the next main-actor turn so the reveal runs after the
+        // insert layout + spring settle, and recompute geometry then
+        // from the committed state (the socket-group path briefly leaves
+        // the workspace top-level before its move effect commits).
+        Task { @MainActor in performScrollReveal(to: pending) }
+    }
+
+    /// Reveal the resolved entry for `target`, recomputing its resting
+    /// frame from current state. Safe to call late: bails if the entry
+    /// vanished or its height is no longer known.
+    private func performScrollReveal(to target: SidebarID) {
+        guard let sv = hostScrollView,
+              let resolved = resolvedScrollTarget(target) else { return }
+        let topY: CGFloat
+        let height: CGFloat
+        switch resolved {
+        case .workspace(let id):
+            guard let h = rowHeights[.workspace(id)] else { return }
+            topY = workspaceStartY(id)
+            height = h
+        case .group(let gid):
+            guard let h = rowHeights[.group(gid)] else { return }
+            topY = groupStartY(gid)
+            height = h
+        }
+        // Creation and drag are mutually exclusive, but cancelling any
+        // stray auto-scroll loop keeps the reveal from being fought.
+        cancelAutoScroll()
+        scrollContentToReveal(sv, topY: topY, height: height)
+    }
+
+    /// Scroll `sv` the minimum amount needed to make the content band
+    /// `[topY, topY+height]` fully visible, honouring the top selection
+    /// header and bottom "+ New Workspace" footer (SwiftUI maps those
+    /// `safeAreaInset`s to `NSScrollView.contentInsets`). Already-visible
+    /// entries are left untouched. Clamp bounds mirror `startAutoScroll`.
+    private func scrollContentToReveal(_ sv: NSScrollView, topY: CGFloat, height: CGFloat) {
+        let visible = sv.documentVisibleRect
+        guard visible.height > 0 else { return }
+        let insetTop = sv.contentInsets.top
+        let insetBottom = sv.contentInsets.bottom
+        // Flush any pending layout so `documentView.bounds.height` reflects
+        // the just-inserted row before we derive the scroll ceiling — the
+        // insert's spring animation can otherwise leave AppKit's bounds
+        // lagging, clamping a bottom-appended row short of fully revealed.
+        sv.documentView?.layoutSubtreeIfNeeded()
+        let contentHeight = sv.documentView?.bounds.height ?? 0
+        let minY = -insetTop
+        let maxY = max(minY, contentHeight + insetBottom - visible.height)
+        // Unobscured viewport band, in content coordinates.
+        let bandTop = visible.origin.y + insetTop
+        let bandBottom = visible.origin.y + visible.height - insetBottom
+        let bottomY = topY + height
+        var newY = visible.origin.y
+        if topY < bandTop {
+            newY = topY - insetTop
+        } else if bottomY > bandBottom {
+            newY = bottomY - visible.height + insetBottom
+        } else {
+            return // already fully visible
+        }
+        newY = max(minY, min(maxY, newY))
+        guard abs(newY - visible.origin.y) > 0.5 else { return }
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.22
+            ctx.allowsImplicitAnimation = true
+            sv.contentView.animator().setBoundsOrigin(
+                NSPoint(x: visible.origin.x, y: newY)
+            )
+        } completionHandler: {
+            sv.reflectScrolledClipView(sv.contentView)
         }
     }
 

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -122,6 +122,21 @@ struct AppReducerTests {
         }
     }
 
+    @Test func createWorkspaceSetsSidebarScrollTarget() async {
+        // Issue #187: a fresh workspace queues itself to be scrolled into
+        // view; `clearSidebarScrollTarget` consumes the one-shot signal.
+        let store = makeStore()
+
+        await store.send(.createWorkspace(name: "Test", color: .green)) { state in
+            let newID = state.workspaces.first?.id
+            #expect(newID != nil)
+            #expect(state.sidebarScrollTarget == .workspace(newID!))
+        }
+        await store.send(.clearSidebarScrollTarget) { state in
+            #expect(state.sidebarScrollTarget == nil)
+        }
+    }
+
     @Test func createWorkspaceWithoutColorPicksNonRepeatingColor() async {
         // Seed with an existing workspace whose color is red, then create a new
         // workspace without specifying a color. The reducer should resolve the
@@ -451,6 +466,25 @@ struct AppReducerTests {
 
         await store.send(.setActiveWorkspace(Self.wsID2)) { state in
             #expect(state.activeWorkspaceID == Self.wsID2)
+            // Issue #187: navigating to a workspace scrolls it into view.
+            #expect(state.sidebarScrollTarget == .workspace(Self.wsID2))
+        }
+    }
+
+    @Test func switchToWorkspaceByIndexScrollsTargetIntoView() async {
+        // ⌘1-9 routes through setActiveWorkspace, so the destination
+        // workspace should be queued for scroll-into-view (issue #187).
+        let ws1 = Self.makeWorkspace(id: Self.wsID1, name: "WS1")
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "WS2")
+
+        let store = makeStore(
+            workspaces: [ws1, ws2],
+            activeWorkspaceID: Self.wsID1
+        )
+
+        await store.send(.switchToWorkspaceByIndex(1))
+        await store.receive(.setActiveWorkspace(Self.wsID2)) { state in
+            #expect(state.sidebarScrollTarget == .workspace(Self.wsID2))
         }
     }
 
@@ -919,6 +953,9 @@ struct AppReducerTests {
 
             // Source is empty
             #expect(state.workspaces[id: Self.wsID1]?.panes.count == 0)
+
+            // Issue #187: the freshly created destination scrolls into view.
+            #expect(state.sidebarScrollTarget == .workspace(newWS!.id))
         }
     }
 

--- a/NexTests/CommandPaletteTests.swift
+++ b/NexTests/CommandPaletteTests.swift
@@ -508,6 +508,8 @@ struct CommandPaletteTests {
 
         #expect(store.state.isCommandPaletteVisible == false)
         #expect(store.state.activeWorkspaceID == Self.wsID2)
+        // Issue #187: the jumped-to workspace scrolls into view.
+        #expect(store.state.sidebarScrollTarget == .workspace(Self.wsID2))
     }
 
     @Test func confirmPaneFocusesPaneAndSwitchesWorkspace() async {

--- a/NexTests/WorkspaceGroupCRUDTests.swift
+++ b/NexTests/WorkspaceGroupCRUDTests.swift
@@ -70,6 +70,27 @@ struct WorkspaceGroupCRUDTests {
         }
     }
 
+    @Test func createGroupSetsSidebarScrollTarget() async {
+        // Issue #187: a fresh group should queue itself to be scrolled
+        // into view; `clearSidebarScrollTarget` consumes the signal.
+        let store = makeStore()
+
+        await store.send(.createGroup(name: "Monitors")) { state in
+            #expect(state.sidebarScrollTarget == .group(Self.groupA))
+        }
+        await store.send(.clearSidebarScrollTarget) { state in
+            #expect(state.sidebarScrollTarget == nil)
+        }
+    }
+
+    @Test func createGroupWhitespaceOnlyLeavesScrollTargetNil() async {
+        // The whitespace guard returns before the scroll target is set.
+        let store = makeStore()
+        await store.send(.createGroup(name: "   ")) { state in
+            #expect(state.sidebarScrollTarget == nil)
+        }
+    }
+
     @Test func createGroupTrimsWhitespaceAndSkipsEmpty() async {
         let store = makeStore()
 

--- a/NexTests/WorkspaceGroupSocketTests.swift
+++ b/NexTests/WorkspaceGroupSocketTests.swift
@@ -114,6 +114,38 @@ struct WorkspaceGroupSocketTests {
         }
     }
 
+    @Test func socketGroupCreateSetsSidebarScrollTarget() async {
+        // Issue #187: `nex group create` should scroll the new group
+        // header into view. The socket handler mutates inline, so the
+        // signal is set in the send closure.
+        let store = makeStore()
+
+        await store.send(.socketMessage(.groupCreate(name: "Monitors", color: nil), reply: nil)) { state in
+            let newID = state.groups.first?.id
+            #expect(newID != nil)
+            #expect(state.sidebarScrollTarget == .group(newID!))
+        }
+    }
+
+    @Test func socketWorkspaceCreateWithGroupSetsSidebarScrollTarget() async {
+        // Issue #187: `nex workspace create --group` targets the new
+        // workspace (the sidebar resolves it to the group header if it
+        // lands in a collapsed group).
+        let existing = WorkspaceGroup(id: Self.groupAID, name: "Monitors", childOrder: [])
+        let store = makeStore(groups: [existing], topLevelOrder: [.group(Self.groupAID)])
+
+        await store.send(.socketMessage(.workspaceCreate(
+            name: "Alpha",
+            path: "/tmp",
+            color: .blue,
+            group: "Monitors"
+        ), reply: nil)) { state in
+            let newID = state.workspaces.first?.id
+            #expect(newID != nil)
+            #expect(state.sidebarScrollTarget == .workspace(newID!))
+        }
+    }
+
     @Test func socketGroupRenameByName() async {
         let group = WorkspaceGroup(id: Self.groupAID, name: "Old", childOrder: [])
         let store = makeStore(groups: [group], topLevelOrder: [.group(Self.groupAID)])


### PR DESCRIPTION
## Summary
- When the sidebar overflows, a workspace/group could sit below the fold with no visual confirmation — both on **creation** and on **navigation**. This adds a one-shot `AppReducer.State.sidebarScrollTarget` signal that `WorkspaceListView` observes to scroll the entry fully into view (honouring the top selection-header and bottom "+ New Workspace" footer insets so it isn't clipped, and no-opping when already visible).
- Signal is set by every **creation** path — GUI `.createWorkspace`/`.createGroup`, socket `workspace-create`/`group-create`, and `pane move-to-workspace --create` — and every **navigation** path — `.setActiveWorkspace` (⌘1–9, ⌘⇧]/[, sidebar & filter clicks, menu-bar popover, notification "Open") and the command palette.
- A workspace hidden inside a collapsed group resolves to that group's header. The measurement race (a new row isn't laid out until a pass later) is handled by retrying from `onPreferenceChange` with the freshly-merged heights; the reveal is deferred one main-actor turn and recomputes geometry from committed state.
- State restore on launch and delete/move reflow deliberately do **not** set the signal, so they never yank the list around.

Closes #187

## Reviewer notes
- Original ticket was creation-only; scope was expanded during review to cover any navigation that brings a workspace into view (shortcuts, command palette, etc.), per request.
- Parallel review (correctness + scope) surfaced two items that were applied: `pane move-to-workspace --create` also now sets the target, and `scrollContentToReveal` flushes layout (`layoutSubtreeIfNeeded`) before reading `documentView.bounds.height` so a bottom-appended row reveals fully during the insert animation. `seedTestGroup` (DEBUG-only menu hook) intentionally left uncovered.

## Validation
- Validated in a sandboxed macOS VM via cua/lume (fresh build from the branch).
- Assertions (all green): 30 flood-workspaces created past overflow; newest becomes active; `⌘1` navigation switches the active workspace; group create succeeds.
- Screenshots (`/Users/ben/code/cua/out/branches/fix-187-scroll-new-entry-into-view/issue-187/`):
  - `after_create_workspace.png` — newest **ws-30** scrolled into view at the bottom, above the footer.
  - `after_create_group.png` — new group **ZZ-GROUP-187** header scrolled into view.
  - `after_switch_cmd1.png` — **⌘1** scrolled the list to reveal **Default** at the top (the navigation case).
- Full unit suite green (1149 tests on host; 190 in the affected suites in the worktree); swiftformat/swiftlint clean.

## Test plan
- [x] Fill the sidebar past overflow (`nex workspace create` in a loop), then create one more — the new workspace scrolls into view at the bottom.
- [x] Create a group with the list overflowing — the group header scrolls into view.
- [x] Use ⌘1–9 and ⌘⇧]/⌘⇧[ to switch workspaces — the selected one scrolls into view.
- [x] Command palette (⌘K) → jump to a far-off workspace — it scrolls into view.
- [x] Click a partially-clipped row at the top/bottom edge — it fully reveals.
- [x] Create into a collapsed group via `nex workspace create --group <name>` — the group's header scrolls into view.
- [x] Confirm no scroll jump on app launch / state restore, and none on plain delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X56T5CvvBWXdvr8nfMobbj