### PR TITLE
fix(workspace): sanitize worktree names and surface creation failures (#218)

### DIFF
--- a/Nex/AppReducer+Domain.swift
+++ b/Nex/AppReducer+Domain.swift
@@ -87,6 +87,7 @@ extension AppReducer {
              .createWorktree,
              .worktreeCreated,
              .worktreeCreationFailed,
+             .dismissWorktreeCreationError,
              .removeWorktreeAssociation,
              .autoLinkRepoForPane,
              .autoLinkResolved,

--- a/Nex/AppReducer+RepoGit.swift
+++ b/Nex/AppReducer+RepoGit.swift
@@ -105,21 +105,39 @@ extension AppReducer {
             case .createWorktree(let workspaceID, let repoID, let worktreeName, let branchName):
                 guard let repo = state.repoRegistry[id: repoID],
                       state.workspaces[id: workspaceID] != nil else { return .none }
+                // Sanitize before the raw name reaches the filesystem path or
+                // the git ref — verbatim spaces/unsafe chars otherwise make
+                // `git worktree add` fail silently (issue #218). This is the
+                // single source of truth; the sheet's live preview shows the
+                // same sanitized result. A name that sanitizes to nothing
+                // usable surfaces the failure rather than shelling out.
+                guard let folderName = WorkspaceFeature.State.sanitizedGitName(from: worktreeName) else {
+                    return .send(.worktreeCreationFailed(
+                        workspaceID: workspaceID,
+                        error: "\"\(worktreeName)\" isn't a usable worktree name. Use letters, numbers, or - _ / . characters."
+                    ))
+                }
+                guard let safeBranch = WorkspaceFeature.State.sanitizedGitName(from: branchName) else {
+                    return .send(.worktreeCreationFailed(
+                        workspaceID: workspaceID,
+                        error: "\"\(branchName)\" isn't a usable branch name. Use letters, numbers, or - _ / . characters."
+                    ))
+                }
                 let basePath = state.settings.resolvedWorktreeBasePath(forRepoPath: repo.path)
-                let worktreePath = "\(basePath)/\(worktreeName)"
+                let worktreePath = "\(basePath)/\(folderName)"
                 return .run { send in
                     do {
-                        try await gitService.createWorktree(repo.path, worktreePath, branchName)
+                        try await gitService.createWorktree(repo.path, worktreePath, safeBranch)
                         await send(.worktreeCreated(
                             workspaceID: workspaceID,
                             repoID: repoID,
                             worktreePath: worktreePath,
-                            branchName: branchName
+                            branchName: safeBranch
                         ))
                     } catch {
                         await send(.worktreeCreationFailed(
                             workspaceID: workspaceID,
-                            error: error.localizedDescription
+                            error: worktreeErrorMessage(error)
                         ))
                     }
                 }
@@ -145,8 +163,14 @@ extension AppReducer {
                     ))
                 )
 
-            case .worktreeCreationFailed:
-                // UI can observe this for error display
+            case .worktreeCreationFailed(_, let error):
+                // Surface the failure so it isn't swallowed (issue #218). The
+                // inspector binds an alert to this transient error string.
+                state.worktreeCreationError = error
+                return .none
+
+            case .dismissWorktreeCreationError:
+                state.worktreeCreationError = nil
                 return .none
 
             case .removeWorktreeAssociation(let workspaceID, let associationID, let deleteWorktree):
@@ -519,4 +543,20 @@ extension AppReducer {
         }
         .cancellable(id: AutoUnlinkDebounceID.workspace(workspaceID), cancelInFlight: true)
     }
+}
+
+/// Turn a worktree-creation error into a message worth showing the user.
+/// `GitServiceError` is not `LocalizedError`, so `localizedDescription`
+/// yields the useless "operation couldn't be completed" string and drops the
+/// `stderr` git printed. Surfacing the raw stderr instead is what makes the
+/// alert actionable — e.g. "fatal: '<path>' already exists" or "is already
+/// checked out" — for the residual failures sanitization can't prevent
+/// (issue #218). Mirrors `GraftService.describeSyncError`.
+func worktreeErrorMessage(_ error: Error) -> String {
+    if let git = error as? GitServiceError,
+       case .commandFailed(_, _, let stderr) = git,
+       let stderr, !stderr.isEmpty {
+        return stderr.split(separator: "\n").first.map(String.init) ?? stderr
+    }
+    return error.localizedDescription
 }

--- a/Nex/AppReducer+RepoGit.swift
+++ b/Nex/AppReducer+RepoGit.swift
@@ -552,11 +552,28 @@ extension AppReducer {
 /// alert actionable — e.g. "fatal: '<path>' already exists" or "is already
 /// checked out" — for the residual failures sanitization can't prevent
 /// (issue #218). Mirrors `GraftService.describeSyncError`.
+///
+/// `git worktree add` prints an informational "Preparing worktree (…)"
+/// progress line to stderr *before* the real "fatal: …" line, so the first
+/// line is misleading (it hid the "already exists" reason in testing). Prefer
+/// git's actual diagnostic — the last `fatal:` / `error:` line — and fall back
+/// to the last non-empty line, then the whole stderr.
 func worktreeErrorMessage(_ error: Error) -> String {
-    if let git = error as? GitServiceError,
-       case .commandFailed(_, _, let stderr) = git,
-       let stderr, !stderr.isEmpty {
-        return stderr.split(separator: "\n").first.map(String.init) ?? stderr
+    guard let git = error as? GitServiceError,
+          case .commandFailed(_, _, let stderr) = git,
+          let stderr, !stderr.isEmpty
+    else {
+        return error.localizedDescription
     }
-    return error.localizedDescription
+    let lines = stderr
+        .split(separator: "\n")
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
+    if let diagnostic = lines.last(where: {
+        let lower = $0.lowercased()
+        return lower.hasPrefix("fatal:") || lower.hasPrefix("error:")
+    }) {
+        return diagnostic
+    }
+    return lines.last ?? stderr
 }

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -43,6 +43,10 @@ struct AppReducer {
         var repoRegistry: IdentifiedArrayOf<Repo> = []
         var gitStatuses: [UUID: RepoGitStatus] = [:]
         var isInspectorVisible: Bool = false
+        /// Transient (never persisted) message for a failed worktree
+        /// creation. The inspector binds an alert to it; cleared via
+        /// `.dismissWorktreeCreationError`. See issue #218.
+        var worktreeCreationError: String?
         var configHotkey = ConfigHotkeyFeature.State()
 
         /// Per-web-pane monotonic counter used as the URL bar focus
@@ -452,6 +456,7 @@ struct AppReducer {
         case createWorktree(workspaceID: UUID, repoID: UUID, worktreeName: String, branchName: String)
         case worktreeCreated(workspaceID: UUID, repoID: UUID, worktreePath: String, branchName: String)
         case worktreeCreationFailed(workspaceID: UUID, error: String)
+        case dismissWorktreeCreationError
         case removeWorktreeAssociation(workspaceID: UUID, associationID: UUID, deleteWorktree: Bool)
 
         // Auto-detected repo associations

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -227,6 +227,29 @@ struct WorkspaceFeature {
             let suffix = id.uuidString.prefix(8).lowercased()
             return base.isEmpty ? suffix : "\(base)-\(suffix)"
         }
+
+        /// Sanitize a user-entered worktree/branch name into a value that is
+        /// safe to use *both* as a filesystem path component and a git branch
+        /// ref. Unlike `makeSlug`, this preserves valid ref characters — slashes
+        /// (for `feature/foo` namespacing), dots, underscores, hyphens, and case
+        /// — so an already-valid name is a fixed point. Spaces and everything
+        /// else git rejects (`~^:?*[\@{` control chars, …) collapse to a single
+        /// hyphen; runs of `-`/`/`/`.` collapse and leading/trailing separators
+        /// are trimmed. Returns `nil` when nothing usable remains (input was
+        /// only whitespace or symbols).
+        ///
+        /// This is best-effort: it neutralises the common failures (notably
+        /// spaces, issue #218) but does not enforce every `git check-ref-format`
+        /// rule (e.g. a mid-path component beginning with `.`). Callers pair it
+        /// with a surfaced error so any residual git rejection is still visible.
+        static func sanitizedGitName(from name: String) -> String? {
+            var slug = name.replacing(/[^A-Za-z0-9\/._-]+/, with: "-")
+            slug = slug.replacing(/-{2,}/, with: "-")
+            slug = slug.replacing(/\/{2,}/, with: "/")
+            slug = slug.replacing(/\.{2,}/, with: ".")
+            slug = slug.trimmingCharacters(in: CharacterSet(charactersIn: "-/._ "))
+            return slug.isEmpty ? nil : slug
+        }
     }
 
     enum Action: Equatable {

--- a/Nex/Features/Workspace/WorkspaceInspectorView.swift
+++ b/Nex/Features/Workspace/WorkspaceInspectorView.swift
@@ -124,6 +124,22 @@ struct WorkspaceInspectorView: View {
                         } : nil
                     )
                 }
+                .alert(
+                    "Couldn’t create worktree",
+                    isPresented: Binding(
+                        get: { store.worktreeCreationError != nil },
+                        set: { presenting in
+                            if !presenting { store.send(.dismissWorktreeCreationError) }
+                        }
+                    ),
+                    presenting: store.worktreeCreationError
+                ) { _ in
+                    Button("OK", role: .cancel) {
+                        store.send(.dismissWorktreeCreationError)
+                    }
+                } message: { error in
+                    Text(error)
+                }
             }
         }
     }
@@ -442,9 +458,18 @@ struct CreateWorktreeSheet: View {
     @State private var branchEdited = false
     @Environment(\.chromeTheme) private var chromeTheme
 
+    /// The sanitized folder/branch names that will actually be created —
+    /// nil when the input has nothing usable left after sanitization.
+    private var sanitizedName: String? {
+        WorkspaceFeature.State.sanitizedGitName(from: worktreeName)
+    }
+
+    private var sanitizedBranch: String? {
+        WorkspaceFeature.State.sanitizedGitName(from: branchName)
+    }
+
     private var isValid: Bool {
-        !worktreeName.trimmingCharacters(in: .whitespaces).isEmpty
-            && !branchName.trimmingCharacters(in: .whitespaces).isEmpty
+        sanitizedName != nil && sanitizedBranch != nil
     }
 
     var body: some View {
@@ -486,10 +511,17 @@ struct CreateWorktreeSheet: View {
                     .onSubmit { if isValid { onCreate() } }
             }
 
-            Text("\(worktreeBasePath)/\(worktreeName.isEmpty ? "<name>" : worktreeName)")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            // Live preview of what will actually be created. Names are
+            // sanitized (spaces/unsafe chars → hyphens) so the user sees the
+            // real folder + branch up front instead of a silent git failure
+            // on an invalid ref (issue #218).
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(worktreeBasePath)/\(sanitizedName ?? "<name>")")
+                Text("branch: \(sanitizedBranch ?? "<branch>")")
+            }
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             HStack {
                 Button("Cancel", action: onCancel)

--- a/NexTests/WorktreeOperationTests.swift
+++ b/NexTests/WorktreeOperationTests.swift
@@ -132,9 +132,11 @@ struct WorktreeOperationTests {
 
     @Test func createWorktreeSurfacesGitStderrNotOpaqueDescription() async {
         // A residual git failure (path exists, branch checked out elsewhere)
-        // must surface git's stderr — not the useless localizedDescription of
-        // a non-LocalizedError `GitServiceError`. Guards the safety net that
-        // the sanitize-first design leans on (issue #218).
+        // must surface git's real diagnostic — not the useless
+        // localizedDescription of a non-LocalizedError `GitServiceError`, and
+        // not git's leading "Preparing worktree (…)" progress line, which
+        // precedes the actual "fatal: …" on stderr and once hid the "already
+        // exists" reason from the alert (issue #218).
         let repoID = UUID()
         let wsID = UUID()
 
@@ -148,10 +150,13 @@ struct WorktreeOperationTests {
         } withDependencies: {
             $0.surfaceManager = SurfaceManager()
             $0.gitService.createWorktree = { _, _, _ in
+                // Real `git worktree add -b` failure shape: progress line
+                // first, the fatal diagnostic second.
                 throw GitServiceError.commandFailed(
                     command: "git worktree add",
                     exitCode: 128,
-                    stderr: "fatal: '/code/repo/../wt/my-worktree' already exists"
+                    stderr: "Preparing worktree (new branch '2')\n"
+                        + "fatal: '/code/repo/../wt/2' already exists"
                 )
             }
         }
@@ -160,12 +165,12 @@ struct WorktreeOperationTests {
         await store.send(.createWorktree(
             workspaceID: wsID,
             repoID: repoID,
-            worktreeName: "my worktree",
-            branchName: "my worktree"
+            worktreeName: "2",
+            branchName: "2"
         ))
 
         await store.receive(\.worktreeCreationFailed) { state in
-            #expect(state.worktreeCreationError == "fatal: '/code/repo/../wt/my-worktree' already exists")
+            #expect(state.worktreeCreationError == "fatal: '/code/repo/../wt/2' already exists")
         }
     }
 

--- a/NexTests/WorktreeOperationTests.swift
+++ b/NexTests/WorktreeOperationTests.swift
@@ -5,6 +5,170 @@ import Testing
 
 @MainActor
 struct WorktreeOperationTests {
+    // MARK: - Name sanitization (issue #218)
+
+    @Test func sanitizedGitNameReplacesSpacesAndTrims() {
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "my worktree") == "my-worktree")
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "  hello  ") == "hello")
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "a  b   c") == "a-b-c")
+    }
+
+    @Test func sanitizedGitNameIsFixedPointOnValidRefs() {
+        // Already-valid names must survive unchanged — slashes for
+        // namespacing, dots, underscores, hyphens, and case are all preserved.
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "feature/test") == "feature/test")
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "my-tree") == "my-tree")
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "Feature/Foo_1.2") == "Feature/Foo_1.2")
+    }
+
+    @Test func sanitizedGitNameNeutralisesUnsafeChars() {
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "a~b^c:d?e*f[g") == "a-b-c-d-e-f-g")
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "foo//bar") == "foo/bar")
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "foo..bar") == "foo.bar")
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "/leading/trailing/") == "leading/trailing")
+    }
+
+    @Test func sanitizedGitNameReturnsNilWhenNothingUsable() {
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "") == nil)
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "   ") == nil)
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "!!!") == nil)
+        #expect(WorkspaceFeature.State.sanitizedGitName(from: "-/-") == nil)
+    }
+
+    @Test func createWorktreeSanitizesUnsafeNameBeforeGit() async {
+        let repoID = UUID()
+        let wsID = UUID()
+        let assocID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
+        var initialState = AppReducer.State()
+        initialState.repoRegistry.append(Repo(id: repoID, path: "/code/repo", name: "repo"))
+        initialState.workspaces.append(WorkspaceFeature.State(id: wsID, name: "Dev"))
+        initialState.activeWorkspaceID = wsID
+
+        // Capture what actually reaches git — it must be sanitized, never raw.
+        let received = LockIsolated<(path: String, branch: String)?>(nil)
+        let store = TestStore(initialState: initialState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .constant(assocID)
+            $0.gitService.createWorktree = { _, path, branch in
+                received.setValue((path, branch))
+            }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.gitService.getCurrentBranch = { _ in nil }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createWorktree(
+            workspaceID: wsID,
+            repoID: repoID,
+            worktreeName: "my worktree",
+            branchName: "my worktree"
+        ))
+
+        let basePath = SettingsFeature.State().resolvedWorktreeBasePath(forRepoPath: "/code/repo")
+        let expectedPath = "\(basePath)/my-worktree"
+        #expect(received.value?.path == expectedPath)
+        #expect(received.value?.branch == "my-worktree")
+
+        await store.receive(.worktreeCreated(
+            workspaceID: wsID,
+            repoID: repoID,
+            worktreePath: expectedPath,
+            branchName: "my-worktree"
+        )) { state in
+            #expect(state.workspaces[id: wsID]?.repoAssociations.first?.worktreePath == expectedPath)
+            #expect(state.workspaces[id: wsID]?.repoAssociations.first?.branchName == "my-worktree")
+        }
+    }
+
+    @Test func createWorktreeRejectsUnusableNameWithoutShellingOut() async {
+        let repoID = UUID()
+        let wsID = UUID()
+
+        var initialState = AppReducer.State()
+        initialState.repoRegistry.append(Repo(id: repoID, path: "/code/repo", name: "repo"))
+        initialState.workspaces.append(WorkspaceFeature.State(id: wsID, name: "Dev"))
+        initialState.activeWorkspaceID = wsID
+
+        let gitCalled = LockIsolated(false)
+        let store = TestStore(initialState: initialState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.gitService.createWorktree = { _, _, _ in gitCalled.setValue(true) }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createWorktree(
+            workspaceID: wsID,
+            repoID: repoID,
+            worktreeName: "!!!",
+            branchName: "!!!"
+        ))
+
+        await store.receive(\.worktreeCreationFailed) { state in
+            #expect(state.worktreeCreationError != nil)
+        }
+        #expect(gitCalled.value == false)
+    }
+
+    @Test func worktreeCreationFailureSurfacesAndDismisses() async {
+        let store = TestStore(initialState: AppReducer.State()) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.worktreeCreationFailed(workspaceID: UUID(), error: "boom")) { state in
+            state.worktreeCreationError = "boom"
+        }
+        await store.send(.dismissWorktreeCreationError) { state in
+            state.worktreeCreationError = nil
+        }
+    }
+
+    @Test func createWorktreeSurfacesGitStderrNotOpaqueDescription() async {
+        // A residual git failure (path exists, branch checked out elsewhere)
+        // must surface git's stderr — not the useless localizedDescription of
+        // a non-LocalizedError `GitServiceError`. Guards the safety net that
+        // the sanitize-first design leans on (issue #218).
+        let repoID = UUID()
+        let wsID = UUID()
+
+        var initialState = AppReducer.State()
+        initialState.repoRegistry.append(Repo(id: repoID, path: "/code/repo", name: "repo"))
+        initialState.workspaces.append(WorkspaceFeature.State(id: wsID, name: "Dev"))
+        initialState.activeWorkspaceID = wsID
+
+        let store = TestStore(initialState: initialState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.gitService.createWorktree = { _, _, _ in
+                throw GitServiceError.commandFailed(
+                    command: "git worktree add",
+                    exitCode: 128,
+                    stderr: "fatal: '/code/repo/../wt/my-worktree' already exists"
+                )
+            }
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.createWorktree(
+            workspaceID: wsID,
+            repoID: repoID,
+            worktreeName: "my worktree",
+            branchName: "my worktree"
+        ))
+
+        await store.receive(\.worktreeCreationFailed) { state in
+            #expect(state.worktreeCreationError == "fatal: '/code/repo/../wt/my-worktree' already exists")
+        }
+    }
+
     @Test func createWorktreeSuccess() async {
         let repoID = UUID()
         let wsID = UUID()


### PR DESCRIPTION
## Summary
- Fix worktree creation failing **silently** on unsafe names (e.g. `my worktree` with a space): the sheet dismissed with no worktree and no error.
- Add `WorkspaceFeature.State.sanitizedGitName(from:)` — slugifies unsafe characters (spaces, `~^:?*[\@{` …) to hyphens while preserving valid git-ref characters (`/ . _ -` and case), so an already-valid name like `feature/foo` is a fixed point; returns nil when nothing usable remains.
- `.createWorktree` sanitizes both names before shelling out to git and bails to `.worktreeCreationFailed` if either sanitizes to nothing.
- Surface failures: a transient `worktreeCreationError` drives a `.alert` in the inspector. Residual git failures show git's real `fatal:`/`error:` line (path exists, branch checked out elsewhere), not the opaque non-`LocalizedError` description — and not git's leading "Preparing worktree (…)" progress line.
- The create sheet shows a live preview of the sanitized folder + branch and requires both names to sanitize non-nil before enabling **Create**.

Closes #218

## Reviewer notes
- **Deferred (out of scope):** collisions have no uniqueness suffix — two names that slugify to the same folder now surface a clear `already exists` error rather than a silent failure, and a random suffix would undercut the "preview shows what will be created" goal. The sheet also dismisses before the async git result, so a residual-failure retry means retyping (the alert still shows). `scripts/new-worktree.sh` is untouched — it's a dev build helper, not the in-app flow, and already fails loudly.
- Parallel correctness + scope review flagged the opaque-error-message gap; that's fixed here (surface git stderr). A follow-up manual test surfaced git's progress line masking the fatal line — fixed in the second commit.

## Validation
- Validated in a sandboxed macOS VM via cua/lume (build + launch + `nex doctor` all-pass — confirms the new `State` field, `.dismissWorktreeCreationError` case + routing, and `.alert` wiring cause no launch/dispatch regression).
- Correctness proven by TCA/unit tests (`make check`): `sanitizedGitName` (spaces→hyphens, `feature/test` fixed point, unsafe-char neutralization, nil cases), sanitize-before-git, nil-rejection-without-shelling-out, and git-`fatal:`-line surfacing (real multi-line `worktree add -b` failure shape).
- Screenshots: `/Users/ben/code/cua/out/branches/fix-worktree-unsafe-names-218/issue-218/`
- Manually re-tested in-VM: create `2`, then `2` again → alert reads `fatal: '…/2' already exists`.

## Test plan
- [x] Inspector → Repositories → Add → New Worktree; type `my worktree` → live preview shows `…/my-worktree` and `branch: my-worktree`, Create enabled → creates successfully.
- [x] Create the same name again → alert "Couldn't create worktree" shows git's `fatal: … already exists`.
- [x] Type only symbols (`!!!`) → Create stays disabled, preview shows `<name>`.
- [x] A valid name with a slash (`feature/x`) is preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X56T5CvvBWXdvr8nfMobbj