### PR TITLE
feat(web): add ⌘+/⌘-/⌘0 page zoom shortcuts for web panes

### DIFF
--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -283,6 +283,24 @@ final class PaneShortcutMonitor {
             if urlBarIsEditing { return nil }
             store.send(.webPaneTabCycleFocused(offset: 1))
             return true
+        case (24, true, _), (24, false, true): // ⌘= / ⌘⇧= (⌘+) → zoom in
+            store.send(.workspaces(.element(
+                id: id,
+                action: .webPaneZoom(paneID: focusedID, delta: 0.1)
+            )))
+            return true
+        case (27, true, _): // ⌘- → zoom out
+            store.send(.workspaces(.element(
+                id: id,
+                action: .webPaneZoom(paneID: focusedID, delta: -0.1)
+            )))
+            return true
+        case (29, true, _): // ⌘0 → reset zoom
+            store.send(.workspaces(.element(
+                id: id,
+                action: .webPaneZoom(paneID: focusedID, delta: nil)
+            )))
+            return true
         default:
             return nil
         }
@@ -444,6 +462,21 @@ final class PaneShortcutMonitor {
         case .webTabNext:
             return handleWebAction(activeWorkspaceID: id) { _ in
                 .webPaneTabCycleFocused(offset: 1)
+            }
+
+        case .webZoomIn:
+            return handleWebAction(activeWorkspaceID: id) { paneID in
+                .workspaces(.element(id: id, action: .webPaneZoom(paneID: paneID, delta: 0.1)))
+            }
+
+        case .webZoomOut:
+            return handleWebAction(activeWorkspaceID: id) { paneID in
+                .workspaces(.element(id: id, action: .webPaneZoom(paneID: paneID, delta: -0.1)))
+            }
+
+        case .webZoomReset:
+            return handleWebAction(activeWorkspaceID: id) { paneID in
+                .workspaces(.element(id: id, action: .webPaneZoom(paneID: paneID, delta: nil)))
             }
 
         default:

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -459,6 +459,16 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         return true
     }
 
+    /// Step the tab's page zoom by `delta` (nil resets to 1.0),
+    /// clamped to [0.5, 3.0].
+    @discardableResult
+    func adjustPageZoom(tabID: UUID, delta: CGFloat?) -> Bool {
+        guard let webView = webViews[tabID] else { return false }
+        let target = delta.map { webView.pageZoom + $0 } ?? 1.0
+        webView.pageZoom = min(max(target, 0.5), 3.0)
+        return true
+    }
+
     /// Toggle the Safari Web Inspector docked inside the tab's
     /// `WebPaneTabContainer` via WebKit's private `_inspector` SPI.
     /// Closes the inspector if it's currently visible; otherwise

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -318,6 +318,8 @@ struct WorkspaceFeature {
         case webPaneBack(paneID: UUID)
         case webPaneForward(paneID: UUID)
         case webPaneReload(paneID: UUID, hard: Bool = false)
+        /// Adjust the active tab's page zoom by `delta`; `nil` resets to 1.0.
+        case webPaneZoom(paneID: UUID, delta: CGFloat?)
         /// Mirror coordinator-reported URL/title changes into state so
         /// persistence keeps a fresh URL even when the user navigates
         /// without typing in the URL bar.
@@ -830,6 +832,18 @@ struct WorkspaceFeature {
                 return .run { _ in
                     await MainActor.run {
                         _ = store.coordinator(for: paneID, isPrivate: isPrivate).reload(tabID: tab.id, hard: hard)
+                    }
+                }
+
+            case .webPaneZoom(let paneID, let delta):
+                guard let webState = state.webPanes[paneID],
+                      let tab = webState.activeTab else { return .none }
+                let store = webPaneStore
+                let isPrivate = webState.isPrivate
+                return .run { _ in
+                    await MainActor.run {
+                        _ = store.coordinator(for: paneID, isPrivate: isPrivate)
+                            .adjustPageZoom(tabID: tab.id, delta: delta)
                     }
                 }
 

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -265,6 +265,9 @@ enum NexAction: String, CaseIterable {
     case webTabClose = "web_tab_close"
     case webTabPrev = "web_tab_prev"
     case webTabNext = "web_tab_next"
+    case webZoomIn = "web_zoom_in"
+    case webZoomOut = "web_zoom_out"
+    case webZoomReset = "web_zoom_reset"
 
     case unbind
 
@@ -334,6 +337,9 @@ enum NexAction: String, CaseIterable {
         case .webTabClose: "Web: Close Tab"
         case .webTabPrev: "Web: Previous Tab"
         case .webTabNext: "Web: Next Tab"
+        case .webZoomIn: "Web: Zoom In"
+        case .webZoomOut: "Web: Zoom Out"
+        case .webZoomReset: "Web: Reset Zoom"
         case .unbind: "Unbind"
         }
     }
@@ -363,7 +369,8 @@ enum NexAction: String, CaseIterable {
              .resetMarkdownFontSize, .openDiff:
             "Files"
         case .webFocusURLBar, .webBack, .webForward, .webReload,
-             .webTabNew, .webTabClose, .webTabPrev, .webTabNext:
+             .webTabNew, .webTabClose, .webTabPrev, .webTabNext,
+             .webZoomIn, .webZoomOut, .webZoomReset:
             "Web Pane (active when web pane focused)"
         case .toggleSearch, .closeSearch:
             "Search"


### PR DESCRIPTION
Closes #228.

## What

Browser-style page zoom for web panes: ⌘= / ⌘⇧= (⌘+) zooms in, ⌘- zooms out, ⌘0 resets — active only while a web pane is focused.

## How

- `WebPaneCoordinator.adjustPageZoom(tabID:delta:)` steps the active tab's `WKWebView.pageZoom` by ±0.1, clamped to [0.5, 3.0]; `nil` delta resets to 1.0.
- New `WorkspaceFeature.webPaneZoom(paneID:delta:)` action, handler mirrors `webPaneReload` (guards on the pane's active tab, dispatches to the coordinator on MainActor).
- The web pane priority layer in `PaneShortcutMonitor` intercepts keyCodes 24/27/29 (⌘=, ⌘-, ⌘0) before the normal keybinding lookup, same as the existing ⌘L/⌘R/⌘[/⌘] handling — so the markdown font-size defaults on those keys keep working for every other pane type.
- Adds bindable-but-unbound `web_zoom_in` / `web_zoom_out` / `web_zoom_reset` `NexAction` cases, mirroring `web_back` / `web_forward`.

Deliberately out of scope (per the issue): persisting zoom across restarts and a `nex web zoom` CLI verb.

## Testing

- All Swift sources compile (`xcodebuild … build` reaches the link stage; linking needs the locally-built `lib/libghostty.a` which isn't present on this machine).
- No tests added: NexTests has no analogous coverage for the existing web pane actions (`web_back`/`web_forward`).
- Draft pending a manual smoke test: open a web pane, hit ⌘+/⌘-/⌘0, confirm zoom; confirm ⌘-/⌘0 still adjust font size in markdown panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)