### PR TITLE
refactor(settings): move Status bar controls from General to Appearance

### DIFF
--- a/Nex/Features/Settings/SettingsView.swift
+++ b/Nex/Features/Settings/SettingsView.swift
@@ -222,56 +222,6 @@ private struct GeneralSettingsView: View {
                     }
                 }
 
-                Section("Status bar") {
-                    Toggle("Show system stats", isOn: Binding(
-                        get: { settingsStore.showSystemStats },
-                        set: { settingsStore.send(.setShowSystemStats($0)) }
-                    ))
-                    if settingsStore.showSystemStats {
-                        ForEach(SystemStatKind.allCases) { kind in
-                            Toggle(isOn: Binding(
-                                get: { settingsStore.enabledSystemStats.contains(kind.rawValue) },
-                                set: { settingsStore.send(.setSystemStatEnabled(kind, $0)) }
-                            )) {
-                                Label(kind.displayName, systemImage: kind.systemImage)
-                            }
-                            .padding(.leading, 16)
-                        }
-                        DisclosureGroup("Mini graphs") {
-                            Toggle("Show mini graphs", isOn: Binding(
-                                get: { settingsStore.showSystemStatGraphs },
-                                set: { settingsStore.send(.setShowSystemStatGraphs($0)) }
-                            ))
-                            Picker("Graph style", selection: Binding(
-                                get: { SparklineStyle(rawValue: settingsStore.sparklineStyle) ?? .line },
-                                set: { settingsStore.send(.setSparklineStyle($0.rawValue)) }
-                            )) {
-                                ForEach(SparklineStyle.allCases) { style in
-                                    Text(style.displayName).tag(style)
-                                }
-                            }
-                            ColorPicker("Graph colour", selection: Binding(
-                                get: { Color(chromeHex: settingsStore.sparklineColorHex) ?? chromeTheme.textSecondary },
-                                set: { if let hex = $0.chromeHexString { settingsStore.send(.setSparklineColor(hex)) } }
-                            ), supportsOpacity: false)
-                            HStack {
-                                Text("Graph width")
-                                Slider(value: Binding(
-                                    get: { settingsStore.sparklineWidth },
-                                    set: { settingsStore.send(.setSparklineWidth($0)) }
-                                ), in: 16 ... 80, step: 2)
-                                Text("\(Int(settingsStore.sparklineWidth))")
-                                    .monospacedDigit()
-                                    .frame(width: 32, alignment: .trailing)
-                            }
-                            Button("Reset graph colour") { settingsStore.send(.setSparklineColor("")) }
-                        }
-                    }
-                    Text("Live system metrics on the right of the bottom status bar. Hover any metric for a detail graph over time.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
                 Section("Quit") {
                     Toggle("Confirm before quitting", isOn: Binding(
                         get: { settingsStore.confirmQuitWhenActive },
@@ -479,6 +429,56 @@ private struct AppearanceSettingsView: View {
                     value: $store.backgroundOpacity.sending(\.setBackgroundOpacity),
                     in: 0.1 ... 1.0
                 )
+            }
+
+            Section("Status bar") {
+                Toggle("Show system stats", isOn: Binding(
+                    get: { store.showSystemStats },
+                    set: { store.send(.setShowSystemStats($0)) }
+                ))
+                if store.showSystemStats {
+                    ForEach(SystemStatKind.allCases) { kind in
+                        Toggle(isOn: Binding(
+                            get: { store.enabledSystemStats.contains(kind.rawValue) },
+                            set: { store.send(.setSystemStatEnabled(kind, $0)) }
+                        )) {
+                            Label(kind.displayName, systemImage: kind.systemImage)
+                        }
+                        .padding(.leading, 16)
+                    }
+                    DisclosureGroup("Mini graphs") {
+                        Toggle("Show mini graphs", isOn: Binding(
+                            get: { store.showSystemStatGraphs },
+                            set: { store.send(.setShowSystemStatGraphs($0)) }
+                        ))
+                        Picker("Graph style", selection: Binding(
+                            get: { SparklineStyle(rawValue: store.sparklineStyle) ?? .line },
+                            set: { store.send(.setSparklineStyle($0.rawValue)) }
+                        )) {
+                            ForEach(SparklineStyle.allCases) { style in
+                                Text(style.displayName).tag(style)
+                            }
+                        }
+                        ColorPicker("Graph colour", selection: Binding(
+                            get: { Color(chromeHex: store.sparklineColorHex) ?? chromeTheme.textSecondary },
+                            set: { if let hex = $0.chromeHexString { store.send(.setSparklineColor(hex)) } }
+                        ), supportsOpacity: false)
+                        HStack {
+                            Text("Graph width")
+                            Slider(value: Binding(
+                                get: { store.sparklineWidth },
+                                set: { store.send(.setSparklineWidth($0)) }
+                            ), in: 16 ... 80, step: 2)
+                            Text("\(Int(store.sparklineWidth))")
+                                .monospacedDigit()
+                                .frame(width: 32, alignment: .trailing)
+                        }
+                        Button("Reset graph colour") { store.send(.setSparklineColor("")) }
+                    }
+                }
+                Text("Live system metrics on the right of the bottom status bar. Hover any metric for a detail graph over time.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ The app chrome (sidebar, title bar, pane headers, and the bottom status bar) has
 - **Save and share.** Export your styling as a shareable `.nextheme` file or a copy-paste code, and import either back. The recipient's light/dark mode and terminal background are left untouched.
 - **Preset themes.** One-click palettes modelled on popular editor themes: Dracula, Nord, Gruvbox (dark and light), Tokyo Night, Catppuccin Mocha, and Solarized Light.
 
-The **bottom status bar** shows the focused pane's working directory, git branch and diff stats, and the active agent with elapsed time on the left; on the right it shows live CPU / memory / load sparklines (toggle in **Settings > General**) and running / waiting / inactive agent counts, each of which opens a popover to jump straight to that pane.
+The **bottom status bar** shows the focused pane's working directory, git branch and diff stats, and the active agent with elapsed time on the left; on the right it shows live CPU / memory / load sparklines (toggle in **Settings > Appearance**) and running / waiting / inactive agent counts, each of which opens a popover to jump straight to that pane.
 
 The **terminal** theme and background are configured separately (see `theme` and background opacity below).
 


### PR DESCRIPTION
## Summary
- Move the `Section("Status bar")` (show system stats + per-metric toggles, and the mini-graphs disclosure: show/hide, style, colour, width, reset) out of `GeneralSettingsView` and into `AppearanceSettingsView`, appended after the Terminal section. The controls are purely presentational and belong with the other visual config.
- Rebind the section from the General view's local `settingsStore` to the Appearance view's `store` — both are `store.scope(state: \.settings, action: \.settings)` on the same `AppReducer` store, so every binding resolves to the same `StoreOf<SettingsFeature>`. `chromeTheme` is already an `@Environment` in the Appearance view. No reducer / persistence / wire changes.
- Update the stale README pointer for the sparkline toggle (General → Appearance).

Closes #235

## Reviewer notes
- Audited the remaining General sections (Worktrees, Repositories, Workspaces, Panes/focus-follows-mouse, Quit, Network) — all functional/behavioural, so nothing else moved. This satisfies the acceptance criterion "no appearance-only controls remain under General".
- No tab added/removed, so deep-linking (`SettingsTab`, `WebPaneChrome.openSettingsTabNotification`, `pendingSettingsTab`) is untouched.

## Validation
- `swiftformat --lint` clean, `swiftlint` clean, build succeeded, full test suite `TEST SUCCEEDED` (exit 0).
- Two parallel reviewers (correctness + scope) cleared the code; the only finding (stale README pointer) is fixed.
- Validated in a sandboxed macOS VM via cua/lume (worktree build, ad-hoc signed):
  - Hard assertions: CLI reports `nex 0.30.0`; app launches with exactly 1 pane; socket round-trips (alive); Settings window opens without crashing; app stays responsive.
  - Screenshots confirm: Appearance tab (scrolled to bottom) shows the **Status bar** section right after Terminal's Background Opacity; General tab ends at Panes → Quit → Network with **no** Status bar section.
  - Screenshots: `/Users/ben/code/cua/out/branches/fix-235-move-status-bar-to-appearance/issue-235/`

## Test plan
- [x] Settings ▸ Appearance ▸ scroll to bottom → Status bar section present (Show system stats, CPU/Memory/Load/Network/Disk toggles, Mini graphs).
- [x] Settings ▸ General ▸ scroll through → no Status bar section (Worktrees, Repositories, Workspaces, Panes, Quit, Network only).
- [x] Toggle Show system stats off/on under Appearance → bottom status-bar sparklines respond (live wiring intact).
- [x] Mini graphs: change style / colour / width / reset → status-bar sparklines update.
- [x] Deep-link sanity: a web pane's "Manage favourites…" still opens Settings on the Web tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrMfqnPGQYVqANsDz6f5fu