### PR TITLE
fix(web): move web back/forward to ⌘←/⌘→ so ⌘[/⌘] switch panes (#229)

### DIFF
--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -191,11 +191,13 @@ final class PaneShortcutMonitor {
         if store.configHotkey.globalHotkey == trigger { return false }
 
         // Web pane priority layer: when the focused pane is a `.web`
-        // pane, consult a hard-coded ⌘L / ⌘R / ⌘[ / ⌘] map *before*
+        // pane, consult a hard-coded ⌘L / ⌘R / ⌘← / ⌘→ map *before*
         // falling through to the normal keybinding lookup. This way
         // the global defaults (close pane / focus prev / focus next /
         // markdown font) keep working for every other pane type while
-        // web panes get browser-style shortcuts.
+        // web panes get browser-style shortcuts. Back/forward use ⌘← /
+        // ⌘→ (not ⌘[ / ⌘]) so ⌘[ / ⌘] stay free for focus prev/next
+        // even inside a web pane (issue #229).
         if let consumed = handleWebPanePriorityShortcut(
             event: event,
             trigger: trigger,
@@ -215,7 +217,7 @@ final class PaneShortcutMonitor {
     /// Web pane priority layer. Returns:
     /// - `true`  - event consumed by a web action
     /// - `false` - event consumed by an intentional fall-through
-    ///   (e.g. URL bar editing + ⌘[ shouldn't trip back)
+    ///   (e.g. URL bar editing + ⌘← shouldn't trip back)
     /// - `nil`   - not applicable, the main layer should run
     private func handleWebPanePriorityShortcut(
         event _: NSEvent,
@@ -230,9 +232,9 @@ final class PaneShortcutMonitor {
         // ⌘ alone, no shift / ctrl / option.
         let isPlainCommand = trigger.modifiers == .command
         let isCmdShift = trigger.modifiers == [.command, .shift]
-        // ⌘[ / ⌘] — only intercept when the URL bar isn't editing.
-        // The bar is an NSTextField, which becomes the window's
-        // firstResponder via its NSText editor when typing.
+        // ⌘← / ⌘→ (back/forward) — only intercept when the URL bar
+        // isn't editing. The bar is an NSTextField, which becomes the
+        // window's firstResponder via its NSText editor when typing.
         let urlBarIsEditing: Bool = {
             guard let keyWindow = NSApp.keyWindow,
                   let responder = keyWindow.firstResponder else { return false }
@@ -249,14 +251,14 @@ final class PaneShortcutMonitor {
                 action: .webPaneReload(paneID: focusedID, hard: false)
             )))
             return true
-        case (33, true, _): // ⌘[
-            if urlBarIsEditing { return nil } // fall through to focusPreviousPane
+        case (123, true, _): // ⌘← → back
+            if urlBarIsEditing { return nil } // fall through so ⌘← moves the text cursor
             store.send(.workspaces(.element(
                 id: id,
                 action: .webPaneBack(paneID: focusedID)
             )))
             return true
-        case (30, true, _): // ⌘]
+        case (124, true, _): // ⌘→ → forward
             if urlBarIsEditing { return nil }
             store.send(.workspaces(.element(
                 id: id,

--- a/Nex/Features/WebPane/WebPaneChrome.swift
+++ b/Nex/Features/WebPane/WebPaneChrome.swift
@@ -156,7 +156,7 @@ struct WebPaneChrome: View {
             .buttonStyle(.plain)
             .disabled(!canGoBack)
             .opacity(canGoBack ? 0.8 : 0.3)
-            .help("Back (⌘[)")
+            .help("Back (⌘←)")
 
             Button(action: onForward) {
                 Image(systemName: "chevron.right")
@@ -167,7 +167,7 @@ struct WebPaneChrome: View {
             .buttonStyle(.plain)
             .disabled(!canGoForward)
             .opacity(canGoForward ? 0.8 : 0.3)
-            .help("Forward (⌘])")
+            .help("Forward (⌘→)")
 
             Button(action: onReload) {
                 Image(systemName: isLoading ? "xmark" : "arrow.clockwise")

--- a/Nex/Models/KeyBinding.swift
+++ b/Nex/Models/KeyBinding.swift
@@ -254,8 +254,9 @@ enum NexAction: String, CaseIterable {
     // fresh web pane from anywhere. The rest ship unbound; the
     // priority layer in `PaneShortcutMonitor` dispatches them directly
     // when the focused pane is a web pane, so the global ⌘L / ⌘R /
-    // ⌘[ / ⌘] / ⌘T / ⌘W / ⌘⇧[ / ⌘⇧] defaults are preserved for every
-    // other pane type.
+    // ⌘← / ⌘→ / ⌘T / ⌘W / ⌘⇧[ / ⌘⇧] defaults are preserved for every
+    // other pane type. (Back/forward moved off ⌘[ / ⌘] to ⌘← / ⌘→ so
+    // ⌘[ / ⌘] stay on focus prev/next even in a web pane — issue #229.)
     case openWebPane = "open_web_pane"
     case webFocusURLBar = "web_focus_url_bar"
     case webBack = "web_back"

--- a/NexTests/PaneShortcutMonitorTests.swift
+++ b/NexTests/PaneShortcutMonitorTests.swift
@@ -157,6 +157,123 @@ struct PaneShortcutMonitorTests {
         #expect(store.workspaces[id: Self.wsID]?.focusedPaneID == Self.paneID1)
     }
 
+    // MARK: - Web pane priority layer (issue #229)
+
+    /// Two-pane workspace where one pane is a web pane. The leaf order
+    /// (first/second) drives focus-prev/next traversal, so callers place
+    /// the web pane in the leaf position the test needs.
+    private static func makeWebAndShellWorkspace(
+        firstPaneID: UUID,
+        secondPaneID: UUID,
+        webPaneID: UUID,
+        focusedPaneID: UUID
+    ) -> WorkspaceFeature.State {
+        WorkspaceFeature.State(
+            id: wsID, name: "Test", slug: "test", color: .blue,
+            panes: [
+                Pane(id: firstPaneID, type: firstPaneID == webPaneID ? .web : .shell),
+                Pane(id: secondPaneID, type: secondPaneID == webPaneID ? .web : .shell)
+            ],
+            layout: .split(.horizontal, ratio: 0.5, first: .leaf(firstPaneID), second: .leaf(secondPaneID)),
+            focusedPaneID: focusedPaneID, createdAt: Date(), lastAccessedAt: Date()
+        )
+    }
+
+    @Test func cmdOpenBracketInWebPaneFocusesPreviousPane() {
+        // Issue #229: ⌘[ used to be swallowed by the web priority layer
+        // (back). It now falls through to focus-previous even inside a
+        // web pane. Web pane is the focused second leaf; ⌘[ moves to the
+        // first (shell) leaf.
+        let ws = Self.makeWebAndShellWorkspace(
+            firstPaneID: Self.paneID1, secondPaneID: Self.paneID2,
+            webPaneID: Self.paneID2, focusedPaneID: Self.paneID2
+        )
+        let (store, monitor) = makeStoreAndMonitor(
+            workspaces: [ws], activeWorkspaceID: Self.wsID
+        )
+
+        let handled = monitor.handleKeyEvent(keyEvent(keyCode: 33, modifierFlags: .command))
+
+        #expect(handled == true)
+        #expect(store.workspaces[id: Self.wsID]?.focusedPaneID == Self.paneID1)
+    }
+
+    @Test func cmdCloseBracketInWebPaneFocusesNextPane() {
+        // Web pane is the focused first leaf; ⌘] moves to the second
+        // (shell) leaf instead of triggering forward.
+        let ws = Self.makeWebAndShellWorkspace(
+            firstPaneID: Self.paneID1, secondPaneID: Self.paneID2,
+            webPaneID: Self.paneID1, focusedPaneID: Self.paneID1
+        )
+        let (store, monitor) = makeStoreAndMonitor(
+            workspaces: [ws], activeWorkspaceID: Self.wsID
+        )
+
+        let handled = monitor.handleKeyEvent(keyEvent(keyCode: 30, modifierFlags: .command))
+
+        #expect(handled == true)
+        #expect(store.workspaces[id: Self.wsID]?.focusedPaneID == Self.paneID2)
+    }
+
+    @Test func cmdLeftArrowInWebPaneIsConsumedForBack() {
+        // ⌘← is the new back binding: the priority layer consumes it and
+        // does NOT change pane focus.
+        let ws = Self.makeWebAndShellWorkspace(
+            firstPaneID: Self.paneID1, secondPaneID: Self.paneID2,
+            webPaneID: Self.paneID2, focusedPaneID: Self.paneID2
+        )
+        let (store, monitor) = makeStoreAndMonitor(
+            workspaces: [ws], activeWorkspaceID: Self.wsID
+        )
+
+        let handled = monitor.handleKeyEvent(
+            keyEvent(keyCode: 123, modifierFlags: [.command, .numericPad, .function])
+        )
+
+        #expect(handled == true)
+        #expect(store.workspaces[id: Self.wsID]?.focusedPaneID == Self.paneID2)
+    }
+
+    @Test func cmdRightArrowInWebPaneIsConsumedForForward() {
+        // ⌘→ is the new forward binding: consumed, focus unchanged.
+        let ws = Self.makeWebAndShellWorkspace(
+            firstPaneID: Self.paneID1, secondPaneID: Self.paneID2,
+            webPaneID: Self.paneID1, focusedPaneID: Self.paneID1
+        )
+        let (store, monitor) = makeStoreAndMonitor(
+            workspaces: [ws], activeWorkspaceID: Self.wsID
+        )
+
+        let handled = monitor.handleKeyEvent(
+            keyEvent(keyCode: 124, modifierFlags: [.command, .numericPad, .function])
+        )
+
+        #expect(handled == true)
+        #expect(store.workspaces[id: Self.wsID]?.focusedPaneID == Self.paneID1)
+    }
+
+    @Test func cmdArrowInShellPaneIsNotConsumed() {
+        // The web back/forward binding is web-pane-only. In a shell pane
+        // plain ⌘← / ⌘→ have no default binding, so the monitor must
+        // defer (return false) and leave line-navigation to the terminal
+        // — no regression for non-web panes.
+        let ws = Self.makeTwoPaneWorkspace() // both shell, focus paneID1
+        let (store, monitor) = makeStoreAndMonitor(
+            workspaces: [ws], activeWorkspaceID: Self.wsID
+        )
+
+        let handledLeft = monitor.handleKeyEvent(
+            keyEvent(keyCode: 123, modifierFlags: [.command, .numericPad, .function])
+        )
+        let handledRight = monitor.handleKeyEvent(
+            keyEvent(keyCode: 124, modifierFlags: [.command, .numericPad, .function])
+        )
+
+        #expect(handledLeft == false)
+        #expect(handledRight == false)
+        #expect(store.workspaces[id: Self.wsID]?.focusedPaneID == Self.paneID1)
+    }
+
     // MARK: - Open web pane (menu bar action)
 
     @Test func cmdShiftOIsNotConsumedByMonitor() {


### PR DESCRIPTION
## Summary
- Web panes captured ⌘[ / ⌘] for browser back/forward in the `PaneShortcutMonitor` priority layer, so once focus landed in a web pane the default focus-previous/next-pane shortcuts couldn't switch away (#229).
- Moved web back/forward onto the other standard browser bindings, **⌘← / ⌘→** (keyCodes 123/124), and let **⌘[ / ⌘]** fall through to `focusPreviousPane` / `focusNextPane` even inside a web pane. This is the issue commenter's preferred option.
- Updated the priority-layer switch + URL-bar-editing fall-through, the back/forward tooltips (`Back (⌘←)` / `Forward (⌘→)`), and the `NexAction` / priority-layer comments. Plain ⌘←/⌘→ stay unbound for non-web panes, so terminal line-navigation is untouched.

Closes #229

## Reviewer notes
- **Known tradeoff (kept intentionally):** ⌘←/⌘→ are macOS "start/end of line" in text fields. The priority layer only guards Nex's own URL bar (`NSText` first responder), not focus inside an in-page WKWebView `<input>`/`<textarea>`, so typing in a page form and pressing ⌘← triggers browser Back. This is inherent to the requested arrow-key binding and cannot be resolved synchronously in the NSEvent monitor (an `document.activeElement` check is async). It is consistent with how the same monitor already pre-empts ⌘R / ⌘T / ⌘W / ⌘L in web panes regardless of in-page focus. Flagged by both review passes; left as-is per the chosen design.

## Validation
- Validated in a sandboxed macOS VM via cua/lume (built ad-hoc-signed from the branch worktree; Nex 0.30.0).
- **TEST 1 (deterministic):** `nex web open example.com` added a web pane; the original shell pane survived (2 panes) — web-pane machinery works in this build.
- **TEST 2 (keyboard probe):** drove **⌘[** in the focused web pane → focus moved web→shell, i.e. ⌘[ now switches panes instead of being swallowed for Back. Confirmed via `pane list --json` `is_focused`.
- Unit tests: 5 new `PaneShortcutMonitorTests` — ⌘[/⌘] focus prev/next inside a web pane, ⌘←/⌘→ consumed for back/forward, and plain ⌘←/⌘→ NOT consumed in a shell pane (no line-nav regression). `make check`-level format/lint/build/tests green.
- Screenshots: `/Users/ben/code/cua/out/branches/fix-229-web-cmd-arrow-nav/issue-229/`

## Test plan
- [x] Focus a web pane, press ⌘[ / ⌘] → focus moves to the adjacent pane. ⌘⌥← / ⌘⌥→ still switch too.
- [x] In a web pane with history, ⌘← → Back, ⌘→ → Forward.
- [x] Focus the URL bar (⌘L), press ⌘← / ⌘→ → moves the text cursor, does not navigate.
- [x] Non-web (shell/markdown) pane: plain ⌘← / ⌘→ do nothing app-level (line-nav unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrMfqnPGQYVqANsDz6f5fu