### PR TITLE
fix(#227): stop right-click submenus flickering over active panes

### DIFF
--- a/Nex/Features/PaneGrid/PaneGridView.swift
+++ b/Nex/Features/PaneGrid/PaneGridView.swift
@@ -139,72 +139,99 @@ struct PaneGridView: View {
         }
     }
 
+    /// The pane header, rendered as two stacked layers so an open right-click
+    /// submenu (Status / Move to Workspace) survives agent-activity
+    /// re-renders — the pane-header counterpart to the sidebar fix in issue
+    /// #227. Without this, the header re-renders on every status/title tick
+    /// while an agent works, rebuilding its `.contextMenu` NSMenu and
+    /// dismissing whatever submenu the cursor is in.
+    @ViewBuilder
+    private func paneHeaderLayers(pane: Pane) -> some View {
+        let header = makePaneHeader(pane: pane)
+        ZStack {
+            // Menu-host layer: `.equatable()` lets SwiftUI skip re-rendering
+            // (and rebuilding the `.contextMenu`) when only the agent-churny
+            // fields changed — see `PaneHeaderView.==`. Fully interactive
+            // (buttons, focus tap, drag, right-click menu); its frozen visuals
+            // sit hidden behind the opaque live overlay on top.
+            header.equatable()
+            // Live overlay: redraws the status dot / path / agent badge every
+            // tick. Non-hit-testing, so every click (including the right-click
+            // that opens the menu) falls through to the stable host beneath.
+            header.allowsHitTesting(false)
+        }
+    }
+
+    private func makePaneHeader(pane: Pane) -> PaneHeaderView {
+        PaneHeaderView(
+            pane: pane,
+            isFocused: pane.id == focusedPaneID,
+            onFocus: { onFocusPane(pane.id) },
+            onSplitHorizontal: { onSplitPane(pane.id, .horizontal) },
+            onSplitVertical: { onSplitPane(pane.id, .vertical) },
+            onClose: { onClosePane(pane.id) },
+            isZoomed: isZoomed,
+            onToggleZoom: onToggleZoom,
+            isEditing: pane.isEditing,
+            onToggleEdit: pane.type == .markdown ? { onToggleMarkdownEdit(pane.id) } : nil,
+            onCopyMarkdown: pane.type == .markdown
+                ? { postMarkdownCopy(pane.id, kind: .markdown) }
+                : nil,
+            onCopyRichText: pane.type == .markdown
+                ? { postMarkdownCopy(pane.id, kind: .richText) }
+                : nil,
+            onRefreshDiff: pane.type == .diff
+                ? { diffRefreshTokens[pane.id, default: 0] &+= 1 }
+                : nil,
+            onDragChanged: { point in
+                dragSourcePaneID = pane.id
+                let bounds = CGRect(origin: .zero, size: gridSize)
+                let frames = layout.paneFrames(in: bounds)
+                // Hit-test: find which pane contains the cursor
+                var hitTarget: UUID?
+                for (id, rect) in frames {
+                    if id != pane.id, rect.contains(point) {
+                        hitTarget = id
+                        break
+                    }
+                }
+                dragTargetPaneID = hitTarget
+                if let hitTarget, let rect = frames[hitTarget] {
+                    dragDropZone = PaneLayout.DropZone.calculate(at: point, in: rect)
+                } else {
+                    dragDropZone = nil
+                }
+            },
+            onDragEnded: {
+                if let source = dragSourcePaneID,
+                   let target = dragTargetPaneID,
+                   let zone = dragDropZone {
+                    onMovePane?(source, target, zone)
+                }
+                dragSourcePaneID = nil
+                dragTargetPaneID = nil
+                dragDropZone = nil
+            },
+            otherWorkspaces: otherWorkspaces,
+            onRename: onRenamePane.map { handler in { handler(pane.id) } },
+            onMoveToWorkspace: onMovePaneToWorkspace.map { handler in
+                { targetWS in handler(pane.id, targetWS) }
+            },
+            onSetStatus: pane.type == .shell
+                ? onSetPaneStatus.map { handler in { status in handler(pane.id, status) } }
+                : nil,
+            onOpenWebPane: onOpenWebPane.map { handler in { direction in handler(pane.id, direction) } },
+            isSyncExcluded: syncInputExcluded.contains(pane.id),
+            workspaceSyncActive: isSyncInputActive,
+            onToggleSyncExcluded: onToggleSyncExcluded.map { handler in
+                { handler(pane.id) }
+            }
+        )
+    }
+
     private func paneView(pane: Pane, frame: CGRect) -> some View {
         VStack(spacing: 0) {
-            PaneHeaderView(
-                pane: pane,
-                isFocused: pane.id == focusedPaneID,
-                onFocus: { onFocusPane(pane.id) },
-                onSplitHorizontal: { onSplitPane(pane.id, .horizontal) },
-                onSplitVertical: { onSplitPane(pane.id, .vertical) },
-                onClose: { onClosePane(pane.id) },
-                isZoomed: isZoomed,
-                onToggleZoom: onToggleZoom,
-                isEditing: pane.isEditing,
-                onToggleEdit: pane.type == .markdown ? { onToggleMarkdownEdit(pane.id) } : nil,
-                onCopyMarkdown: pane.type == .markdown
-                    ? { postMarkdownCopy(pane.id, kind: .markdown) }
-                    : nil,
-                onCopyRichText: pane.type == .markdown
-                    ? { postMarkdownCopy(pane.id, kind: .richText) }
-                    : nil,
-                onRefreshDiff: pane.type == .diff
-                    ? { diffRefreshTokens[pane.id, default: 0] &+= 1 }
-                    : nil,
-                onDragChanged: { point in
-                    dragSourcePaneID = pane.id
-                    let bounds = CGRect(origin: .zero, size: gridSize)
-                    let frames = layout.paneFrames(in: bounds)
-                    // Hit-test: find which pane contains the cursor
-                    var hitTarget: UUID?
-                    for (id, rect) in frames {
-                        if id != pane.id, rect.contains(point) {
-                            hitTarget = id
-                            break
-                        }
-                    }
-                    dragTargetPaneID = hitTarget
-                    if let hitTarget, let rect = frames[hitTarget] {
-                        dragDropZone = PaneLayout.DropZone.calculate(at: point, in: rect)
-                    } else {
-                        dragDropZone = nil
-                    }
-                },
-                onDragEnded: {
-                    if let source = dragSourcePaneID,
-                       let target = dragTargetPaneID,
-                       let zone = dragDropZone {
-                        onMovePane?(source, target, zone)
-                    }
-                    dragSourcePaneID = nil
-                    dragTargetPaneID = nil
-                    dragDropZone = nil
-                },
-                otherWorkspaces: otherWorkspaces,
-                onRename: onRenamePane.map { handler in { handler(pane.id) } },
-                onMoveToWorkspace: onMovePaneToWorkspace.map { handler in
-                    { targetWS in handler(pane.id, targetWS) }
-                },
-                onSetStatus: pane.type == .shell
-                    ? onSetPaneStatus.map { handler in { status in handler(pane.id, status) } }
-                    : nil,
-                onOpenWebPane: onOpenWebPane.map { handler in { direction in handler(pane.id, direction) } },
-                isSyncExcluded: syncInputExcluded.contains(pane.id),
-                workspaceSyncActive: isSyncInputActive,
-                onToggleSyncExcluded: onToggleSyncExcluded.map { handler in
-                    { handler(pane.id) }
-                }
-            )
+            paneHeaderLayers(pane: pane)
 
             switch pane.type {
             case .shell:

--- a/Nex/Features/PaneGrid/PaneHeaderView.swift
+++ b/Nex/Features/PaneGrid/PaneHeaderView.swift
@@ -414,6 +414,23 @@ struct PaneHeaderView: View {
         NSPasteboard.general.setString(pane.workingDirectory, forType: .string)
     }
 
+    /// Fields that tick continuously while an agent works (status flips,
+    /// terminal-title/activity updates). They drive only the header's live
+    /// visuals — the status dot, path text, and agent badge — and are
+    /// deliberately EXCLUDED from `==` below so an agent tick cannot force a
+    /// re-render of the menu-host copy of this view and rebuild its
+    /// `.contextMenu` NSMenu out from under an open submenu (issue #227,
+    /// pane-header variant). Visual freshness for these fields comes from the
+    /// separate live (non-hit-testing) overlay copy in `PaneGridView`.
+    private static func menuStableProjection(_ pane: Pane) -> Pane {
+        var p = pane
+        p.status = .idle
+        p.title = nil
+        p.agentStartedAt = nil
+        p.lastActivityAt = pane.createdAt
+        return p
+    }
+
     /// Show a popup menu at the current mouse location. Using an
     /// NSMenu rather than SwiftUI's `Menu` lets the button match the
     /// visual size of the surrounding plain Buttons — `Menu` adds
@@ -478,6 +495,36 @@ struct PaneHeaderView: View {
             return "diff: \(scope)"
         }
         return chromeHomeAbbreviated(pane.title ?? pane.workingDirectory)
+    }
+}
+
+// MARK: - Equatable (menu-stability boundary)
+
+/// `@preconcurrency` because `View` is `@MainActor`-isolated and `Equatable`
+/// is not: SwiftUI only ever compares views during a main-actor render pass,
+/// so the conformance is safe, and this silences the Swift 6 actor-isolation
+/// diagnostic (the same pattern the codebase uses for Obj-C conformances).
+extension PaneHeaderView: @preconcurrency Equatable {
+    /// Two header views are "equal" — and SwiftUI may therefore skip
+    /// re-rendering (and rebuilding the `.contextMenu` NSMenu) — whenever
+    /// nothing that changes the menu's structure or the header's chrome has
+    /// changed. High-frequency agent-activity fields (status / title /
+    /// started-at / last-activity) are projected out via
+    /// `menuStableProjection`, so a churning pane no longer dismisses an open
+    /// Status / Move-to-Workspace submenu (issue #227). The stored closures are
+    /// intentionally ignored: they are captured per pane id and stay correct
+    /// even when a comparison skips a re-render. `PaneGridView` renders a second
+    /// live, non-hit-testing copy on top so the status dot / path / badge still
+    /// update in real time.
+    static func == (lhs: PaneHeaderView, rhs: PaneHeaderView) -> Bool {
+        menuStableProjection(lhs.pane) == menuStableProjection(rhs.pane)
+            && lhs.isFocused == rhs.isFocused
+            && lhs.isZoomed == rhs.isZoomed
+            && lhs.isEditing == rhs.isEditing
+            && lhs.isSyncExcluded == rhs.isSyncExcluded
+            && lhs.workspaceSyncActive == rhs.workspaceSyncActive
+            && lhs.otherWorkspaces.map(\.id) == rhs.otherWorkspaces.map(\.id)
+            && lhs.otherWorkspaces.map(\.name) == rhs.otherWorkspaces.map(\.name)
     }
 }
 

--- a/Nex/Features/Workspace/WorkspaceListView.swift
+++ b/Nex/Features/Workspace/WorkspaceListView.swift
@@ -766,29 +766,24 @@ struct WorkspaceListView: View {
     @ViewBuilder
     private func filteredWorkspaceRow(workspaceID: UUID) -> some View {
         if let workspaceStore = store.scope(state: \.workspaces[id: workspaceID], action: \.workspaces[id: workspaceID]) {
-            let waiting = workspaceStore.panes.count(where: { $0.status == .waitingForInput })
-            let running = workspaceStore.panes.contains { $0.status == .running }
             let parentGroupName = store.state.groupID(forWorkspace: workspaceID)
                 .flatMap { store.groups[id: $0]?.name }
 
             VStack(alignment: .leading, spacing: 0) {
-                WorkspaceRowView(
-                    name: workspaceStore.name,
-                    color: workspaceStore.color,
+                // Pane-status reads are scoped inside `WorkspaceRowContainer`
+                // so a churning pane doesn't re-render this row's body and
+                // rebuild the `.contextMenu` attached below (issue #227).
+                // Negative index suppresses the `⌘N` badge in
+                // `WorkspaceRowView` (the badge is gated on `index < 9 &&
+                // index >= 0`). The filter walks workspaces inside collapsed
+                // groups too, where the badge would either be wrong or
+                // meaningless, so we hide it wholesale in filtered rows.
+                WorkspaceRowContainer(
+                    workspaceStore: workspaceStore,
                     isActive: workspaceID == store.activeWorkspaceID,
-                    // Negative index suppresses the `⌘N` badge in
-                    // `WorkspaceRowView` (the badge is gated on `index <
-                    // 9 && index >= 0`). The filter walks workspaces
-                    // inside collapsed groups too, where the badge would
-                    // either be wrong or meaningless, so we hide it
-                    // wholesale in filtered rows.
                     index: -1,
-                    icon: workspaceStore.icon,
-                    waitingPaneCount: waiting,
-                    hasRunningPanes: running,
                     isSelected: store.selectedWorkspaceIDs.contains(workspaceID),
                     leadingInset: 0,
-                    labels: workspaceStore.labels,
                     labelStyles: labelPresetStyles
                 )
 
@@ -1327,20 +1322,18 @@ struct WorkspaceListView: View {
             let previewNestedInGroup = isDragging && dragPreviewGroupID != nil
             let effectiveDepth = previewNestedInGroup ? max(depth, 1) : depth
 
-            WorkspaceRowView(
-                name: workspaceStore.name,
-                color: workspaceStore.color,
+            // Per-pane status reads are scoped inside `WorkspaceRowContainer`
+            // (a real `View`) so an agent tick doesn't re-render this row's
+            // enclosing body and rebuild the `.contextMenu` below (issue #227).
+            WorkspaceRowContainer(
+                workspaceStore: workspaceStore,
                 isActive: workspaceID == store.activeWorkspaceID,
                 index: flatIndex,
-                icon: workspaceStore.icon,
-                waitingPaneCount: workspaceStore.panes.count(where: { $0.status == .waitingForInput }),
-                hasRunningPanes: workspaceStore.panes.contains { $0.status == .running },
                 isSelected: store.selectedWorkspaceIDs.contains(workspaceID),
                 // Use a single interpolated value so the depth change
                 // slides smoothly. 24pt matches the old layout's
                 // 16pt Spacer + 8pt HStack spacing.
                 leadingInset: effectiveDepth > 0 ? 24 : 0,
-                labels: workspaceStore.labels,
                 labelStyles: labelPresetStyles
             )
             .padding(.horizontal, 8)
@@ -2365,6 +2358,45 @@ struct WorkspaceListView: View {
 /// observation boundary, so agent activity inside a group no longer
 /// re-renders the whole sidebar and dismisses an open context-menu
 /// submenu (issue #124). See `groupHeaderEntry` for the full rationale.
+/// Scopes a workspace row's per-pane observation into its own `View`, so a
+/// pane-status tick (agent running / waiting) in *any* workspace re-renders
+/// only that one row rather than the whole sidebar list. Mirrors
+/// `GroupHeaderRowContainer`. This is the observation boundary that keeps an
+/// open right-click context menu (and its nested submenus, e.g. "Label") from
+/// being rebuilt — and therefore dismissed by AppKit — whenever a foreground
+/// *or background* pane churns (issue #227). Reading `waitingPaneCount` /
+/// `hasRunningPanes` inline in the list body instead leaks the observation into
+/// the top-level body: a `WithPerceptionTracking` wrapper there is NOT enough
+/// because in release builds it compiles to a transparent pass-through, so only
+/// a separate `View` actually scopes the reads. The `.contextMenu` stays on the
+/// parent's modifier chain, decoupled from these reads.
+private struct WorkspaceRowContainer: View {
+    let workspaceStore: StoreOf<WorkspaceFeature>
+    let isActive: Bool
+    let index: Int
+    let isSelected: Bool
+    let leadingInset: CGFloat
+    let labelStyles: [String: ResolvedLabelStyle]
+
+    var body: some View {
+        WithPerceptionTracking {
+            WorkspaceRowView(
+                name: workspaceStore.name,
+                color: workspaceStore.color,
+                isActive: isActive,
+                index: index,
+                icon: workspaceStore.icon,
+                waitingPaneCount: workspaceStore.panes.count(where: { $0.status == .waitingForInput }),
+                hasRunningPanes: workspaceStore.panes.contains { $0.status == .running },
+                isSelected: isSelected,
+                leadingInset: leadingInset,
+                labels: workspaceStore.labels,
+                labelStyles: labelStyles
+            )
+        }
+    }
+}
+
 private struct GroupHeaderRowContainer: View {
     let store: StoreOf<AppReducer>
     let group: WorkspaceGroup


### PR DESCRIPTION
## Summary
- Right-click context submenus dismissed themselves while any pane's agent was working, because per-pane status/title ticks re-rendered the view hosting the `.contextMenu` and rebuilt its NSMenu out from under an open submenu. Fixed on both surfaces the issue reports:
  - **Sidebar workspace rows** (`WorkspaceListView`): moved the churning pane-status reads into a dedicated `WorkspaceRowContainer` View so a tick re-renders only that one row, not the whole list — the parent that holds the `.contextMenu` no longer re-renders on churn. Mirrors the earlier group-header fix (#124).
  - **Pane header** (`PaneHeaderView` / `PaneGridView`): the header both renders live status/title and hosts its `.contextMenu` on the same view. Render it as two layers — an `Equatable` menu-host whose `==` projects out the high-frequency fields (status/title/agentStartedAt/lastActivityAt) so SwiftUI skips the re-render that rebuilds the NSMenu, beneath a live non-hit-testing overlay that keeps the status dot / path / badge current. Right-clicks fall through the overlay to the stable host, so an open Status / Move-to-Workspace submenu survives the churn.

Closes #227

## Reviewer notes
- The `PaneHeaderView: @preconcurrency Equatable` conformance is required because `View` is `@MainActor` and `Equatable` isn't; SwiftUI only compares views during a main-actor render pass, so it's sound (same pattern the codebase uses elsewhere).
- Out of scope: web-pane chrome / repo-registry menus have no aggregate all-workspaces list body and aren't subject to this class of bug.

## Validation
- Validated in sandboxed macOS VMs via cua/lume, before (pre-fix, reproduces flicker) vs after (combined fix).
- Per-issue assertions (`validate_issue_227.py`): built + launched from the branch; created a background `BusyWS` workspace, drove its pane to `running` (the app-wide status tick that storms the sidebar re-render), and asserted every row/pane survives the churn and the transition back — no crash, no state loss. Screenshots captured before / during churn / after.
- Manual VM check (the flicker itself, not shell-assertable): with a looped `nex event start/stop` churning BusyWS, both the sidebar `Label` submenu and the pane-header `Status` submenu stay open and stable, and header buttons / click-to-focus still work.
- `make check`: app + test targets compile, format/lint clean, 1262/1264 tests pass; the 2 failures are `RecursiveFSWatcherTests` (DispatchSource 1s-timeout FS-watch tests) which fail identically on the baseline under build/VM load — environmental, unrelated to this view change.

## Test plan
- [x] Right-click a workspace row while another workspace's agent is streaming; hover Label / Color / Move to Group — submenu stays open.
- [x] Right-click a pane header whose own agent is running; hover Status / Move to Workspace — submenu stays open.
- [x] Sidebar rows still show live running/waiting dots; renames, color, labels, selection, ⌘N badges, drag-reorder unaffected.
- [x] Pane header split / close / globe buttons, double-click zoom, click-to-focus, and drag-to-reorder all still work.