### PR TITLE
docs: sync CLAUDE.md and nex-agentic skill with 0.31.0 changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ make check
 
 ### Keybindings
 - **Config file**: `~/.config/nex/config` — Ghostty-style `key = value` syntax. General settings: `focus-follows-mouse`, `focus-follows-mouse-delay`, `theme`, `tcp-port`. Keybindings: `keybind = super+d=split_right`. Workspace profiles: `profile = <name>:<KEY>=<value>` (one var per line; repeated lines merge by name, later wins). Parsed by `ConfigParser`, loaded by `KeybindingService`.
-- **Data model** (`KeyBinding.swift`): `KeyTrigger` (keyCode + modifiers), `NexAction` (48 bindable actions, including the web-pane verbs and the default-unbound `open_diff` / `toggle_sync_input`), `KeyBindingMap` (trigger → action dictionary with sorted lookups).
+- **Data model** (`KeyBinding.swift`): `KeyTrigger` (keyCode + modifiers), `NexAction` (51 bindable actions, including the web-pane verbs and the default-unbound `open_diff` / `toggle_sync_input` / `web_zoom_in` / `web_zoom_out` / `web_zoom_reset`), `KeyBindingMap` (trigger → action dictionary with sorted lookups).
 - **Two dispatch layers**: SwiftUI `Commands` (`NexCommands`) handles menu bar shortcuts; `PaneShortcutMonitor` (NSEvent local monitor) handles pane-context shortcuts. Both read from `AppReducer.State.keybindings`.
 - **Settings UI** (`KeybindingsSettingsView`): table grouped by category with key recorder sheet, per-action reset, and reset-all. Changes are persisted to the config file.
 - **Conditional shortcuts**: `toggle_markdown_edit` only fires for markdown panes, `close_search` only when search is active, `close_pane` deletes workspace when it's the last pane.

--- a/Resources/skills/nex-agentic/SKILL.md
+++ b/Resources/skills/nex-agentic/SKILL.md
@@ -289,7 +289,18 @@ not `claude --resume` a session that has already exited.
 # workspace_name,group?} object with --json — so a coordinator can capture
 # the id to target it later. --group creates the group if missing.
 # --profile assigns a workspace profile (env-var injection into every pane).
-nex workspace create [--name "..."] [--path /dir] [--color blue|green|red|yellow|purple|orange|pink|gray] [--group <name>] [--profile <name>] [--json]
+# --worktree creates a git worktree inline and opens the workspace's first
+# pane in it — ideal for isolating a fan-out worker on its own branch:
+#   --worktree <name>   worktree dir is <worktree-base-path>/<name>
+#   --branch <name>     branch to create/check out (defaults to <name>)
+#   --repo <path>       source repo (defaults to the CLI's cwd)
+#   --update-main       branch off a fresh origin/<default> (fetches first)
+#   --group <existing>  composes with --worktree, but the group must already
+#                       exist (an unknown/ambiguous name is rejected — it
+#                       won't create one, to avoid orphaning it on failure)
+# The reply adds `worktree_path` + `branch`; the create runs with a longer
+# read timeout so a slow `git fetch` isn't a spurious failure.
+nex workspace create [--name "..."] [--path /dir] [--color blue|green|red|yellow|purple|orange|pink|gray] [--group <name>] [--profile <name>] [--worktree <name> [--branch <name>] [--repo <path>] [--update-main]] [--json]
 
 # Assign or clear a workspace's profile (fire-and-forget). Applies to the
 # NEXT pane spawned in the workspace; existing panes keep their env.


### PR DESCRIPTION
Reviewed CLAUDE.md and the baked-in `nex-agentic` skill against everything shipped in **0.31.0** (`v0.30.0..v0.31.0`). Both are largely up to date; this fixes the two drifts found.

## Changes

- **CLAUDE.md — stale action count.** It claimed `NexAction (48 bindable actions...)`. PR #230 (`⌘+/⌘-/⌘0` web zoom) added `web_zoom_in` / `web_zoom_out` / `web_zoom_reset`, so the real count is **51** (verified against `Nex/Models/KeyBinding.swift`). Updated the count and listed the three default-unbound verbs alongside `open_diff` / `toggle_sync_input`.
- **nex-agentic skill — missing `--worktree`.** The inline git-worktree flag family (#222) shipped in 0.31.0 and is documented in CLAUDE.md, but the skill's `nex workspace create` reference omitted it — exactly the surface an orchestrator reads when spawning isolated fan-out workers. Added `--worktree` / `--branch` / `--repo` / `--update-main` with their semantics. Applied to the bundled repo copy (`Resources/skills/nex-agentic/SKILL.md`); the mirrored `~/.claude` copy was updated in lockstep.

## Verified already-documented in both docs
`nex workspace delete` + create request/response (#238), workspace profiles (#236), `group list` / `workspace list` (#232), full pane UUID in `pane list` (#240), reject-unknown-args (#237). The status-bar settings-tab move (#243) and the `⌘←/⌘→` web back/forward remap (#229) are internal UI/keybinding changes not surfaced at CLAUDE.md's documentation altitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)