### PR TITLE
feat(#245): Cmd+F / in-page find for web (HTML viewer) panes

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		E56B0EC49D7AC553B5CDC2CC /* MarkdownPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02A888F436610636F5A4D55 /* MarkdownPaneView.swift */; };
 		E5D6BDD247E0BE03F097B4A2 /* WebPaneActuatorSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F338E618A147E5BAAFF5FE5 /* WebPaneActuatorSelectorTests.swift */; };
 		E62618BAC6927017CC4ECC44 /* WorkspaceFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA6AA9E98405375983902BD /* WorkspaceFeature.swift */; };
+		E8782D8EA01D478118188915 /* WebPaneFindScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E2306FC006196957D7AF72 /* WebPaneFindScript.swift */; };
 		E89E89193A52010164900B00 /* WorkspaceInspectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C59BDCBA03302FC7FDE16B /* WorkspaceInspectorView.swift */; };
 		EA22F9720B68648A78D237E3 /* MarkdownHTMLRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200EB2588E40ABB7C51E24E6 /* MarkdownHTMLRendererTests.swift */; };
 		EAF43DC55C5612F3AE83BF02 /* SettingsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD43112159981D690331BA5 /* SettingsFeatureTests.swift */; };
@@ -353,6 +354,7 @@
 		9F338E618A147E5BAAFF5FE5 /* WebPaneActuatorSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneActuatorSelectorTests.swift; sourceTree = "<group>"; };
 		A0A94E80914F7411EED712E5 /* WebPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneStore.swift; sourceTree = "<group>"; };
 		A11F5427AE75515696FB8295 /* PaneLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLayoutTests.swift; sourceTree = "<group>"; };
+		A1E2306FC006196957D7AF72 /* WebPaneFindScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneFindScript.swift; sourceTree = "<group>"; };
 		A2554566AF4F790EB30637E3 /* AgentLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleTests.swift; sourceTree = "<group>"; };
 		A47FF7FB9A9C29221EAD089E /* GhosttyConfigClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigClient.swift; sourceTree = "<group>"; };
 		AC03B83D15C0B9F7298F2E6A /* PresetsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsFeature.swift; sourceTree = "<group>"; };
@@ -758,6 +760,7 @@
 				D919B65B3E950098BF3405EA /* WebPaneConsoleScript.swift */,
 				FDC5A9C48821CE81CCB7FFB5 /* WebPaneCoordinator.swift */,
 				E3F9EB3CC6EA8ED5CEE1F156 /* WebPaneExecWrapper.swift */,
+				A1E2306FC006196957D7AF72 /* WebPaneFindScript.swift */,
 				B2BAD220346CCE551765FCD9 /* WebPaneInspectorScript.swift */,
 				37B04ED477C0C51A44953A8C /* WebPaneState.swift */,
 				A0A94E80914F7411EED712E5 /* WebPaneStore.swift */,
@@ -1178,6 +1181,7 @@
 				2B0CCA8BFF359E4AF96AB5AA /* WebPaneConsoleScript.swift in Sources */,
 				A60D7684F5DA8DD340A04A01 /* WebPaneCoordinator.swift in Sources */,
 				53440A04E421A768EB338560 /* WebPaneExecWrapper.swift in Sources */,
+				E8782D8EA01D478118188915 /* WebPaneFindScript.swift in Sources */,
 				C1FC2BD79FF0D9DC86910028 /* WebPaneInspectorScript.swift in Sources */,
 				630837DB73DACFE99190C60D /* WebPaneState.swift in Sources */,
 				A8626EC08DC12588F912E1EF /* WebPaneStore.swift in Sources */,

--- a/Nex/ContentView.swift
+++ b/Nex/ContentView.swift
@@ -553,6 +553,26 @@ struct ContentView: View {
                         store.send(.searchSelectedUpdated(paneID: paneID, selected: current))
                     }
                 }
+                .onReceive(NotificationCenter.default.publisher(for: WebPaneCoordinator.findResultNotification)) { notification in
+                    guard let paneID = notification.userInfo?["paneID"] as? UUID,
+                          let tabID = notification.userInfo?["tabID"] as? UUID,
+                          let total = notification.userInfo?["total"] as? Int,
+                          let current = notification.userInfo?["current"] as? Int else { return }
+                    // Web find is per-tab; drop results from a tab that
+                    // isn't the pane's active one (e.g. the outgoing tab's
+                    // clear() during a tab switch, which would otherwise
+                    // clobber the incoming tab's count).
+                    if let ws = store.workspaces.first(where: { $0.panes[id: paneID] != nil }),
+                       let activeTabID = ws.webPanes[paneID]?.activeTab?.id,
+                       activeTabID != tabID {
+                        return
+                    }
+                    store.send(.searchTotalUpdated(paneID: paneID, total: total))
+                    // current is -1 when there are no matches; only forward a real index.
+                    if current >= 0 {
+                        store.send(.searchSelectedUpdated(paneID: paneID, selected: current))
+                    }
+                }
                 .onAppear {
                     // The xcodebuild test host instantiates ContentView; skip the
                     // socket listener so `xcodebuild test` never touches

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -65,6 +65,12 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
     /// popover. User info: `paneID`, `tabID`, `itemID`.
     static let batchItemRemovedFromPopoverNotification = Notification.Name("WebPaneCoordinator.batchItemRemovedFromPopover")
 
+    /// Notification posted after an in-page find pass completes.
+    /// User info: `paneID`, `tabID`, `total: Int`, `current: Int`
+    /// (`current` is `-1` when there is no active match). `ContentView`
+    /// translates this into `searchTotalUpdated` / `searchSelectedUpdated`.
+    static let findResultNotification = Notification.Name("WebPaneCoordinator.findResult")
+
     /// KVO tokens per webview, so deinit (or destroy) can detach.
     private var kvoTokens: [UUID: [NSKeyValueObservation]] = [:]
 
@@ -94,6 +100,13 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
     /// URL; we re-emit this value through `stateDidChangeNotification`
     /// so the URL bar keeps showing what the user tried.
     private var lastAttemptedURL: [UUID: String] = [:]
+
+    /// Active find needle per tab, if the find bar is open against it.
+    /// Kept so a navigation / reload (which wipes the injected marks and
+    /// rebuilds `window.__nexWebFind` fresh) can re-apply the search in
+    /// `didFinish` instead of leaving a stale match count in the overlay.
+    /// Cleared by `runFindClose`.
+    private var lastFindNeedle: [UUID: String] = [:]
 
     init(
         paneID: UUID,
@@ -159,6 +172,7 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         webViews.removeValue(forKey: tabID)
         lastAttemptedURL.removeValue(forKey: tabID)
         lastPostedProgress.removeValue(forKey: tabID)
+        lastFindNeedle.removeValue(forKey: tabID)
         showingErrorPage.remove(tabID)
         // Drop the inspector arm if it pointed at the destroyed tab
         // — a late click against the gone WebView could otherwise
@@ -194,6 +208,7 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         config.userContentController.add(handler, name: "nexConsole")
         config.userContentController.add(handler, name: "nexInspect")
         config.userContentController.add(handler, name: "nexBatchMarker")
+        config.userContentController.add(handler, name: "nexWebFind")
         // Console wraps `console.*` so we want it to run before page
         // code; `forMainFrameOnly: false` so cross-origin iframes
         // also report (still scoped to this pane's WebView).
@@ -222,6 +237,15 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         config.userContentController.addUserScript(WKUserScript(
             source: WebPaneActuatorScript.source,
             injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        ))
+        // Find-in-page namespace (window.__nexWebFind). Injected at
+        // documentEnd (needs a body to walk) main-frame only, mirroring
+        // the markdown preview's find. Dormant until the reducer drives
+        // it via `runFind`.
+        config.userContentController.addUserScript(WKUserScript(
+            source: WebPaneFindScript.source,
+            injectionTime: .atDocumentEnd,
             forMainFrameOnly: true
         ))
 
@@ -619,6 +643,42 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         webViews[tabID] != nil
     }
 
+    // MARK: - Find-in-page
+
+    /// Run (or re-run) the in-page find for `needle` against the named
+    /// tab. Remembers the needle so a later navigation can re-apply it.
+    /// An empty needle clears the highlight without forgetting the bar
+    /// is open — `runFindClose` is the explicit teardown.
+    func runFind(tabID: UUID, needle: String) {
+        lastFindNeedle[tabID] = needle
+        guard let webView = webViews[tabID] else { return }
+        let escaped = WebPaneFindScript.encodeNeedle(needle)
+        webView.evaluateJavaScript("window.__nexWebFind && window.__nexWebFind.search(\(escaped));")
+    }
+
+    /// Cycle to the next / previous match in the named tab.
+    func runFindNavigate(tabID: UUID, forward: Bool) {
+        guard let webView = webViews[tabID] else { return }
+        let fn = forward ? "next" : "prev"
+        webView.evaluateJavaScript("window.__nexWebFind && window.__nexWebFind.\(fn)();")
+    }
+
+    /// Tear down the find for the named tab — clears the highlight and
+    /// forgets the remembered needle so navigations no longer re-apply.
+    func runFindClose(tabID: UUID) {
+        lastFindNeedle.removeValue(forKey: tabID)
+        guard let webView = webViews[tabID] else { return }
+        webView.evaluateJavaScript("window.__nexWebFind && window.__nexWebFind.clear();")
+    }
+
+    /// Re-apply the remembered needle after a load finished (navigation /
+    /// reload rebuilds the DOM and a fresh `window.__nexWebFind`). No-op
+    /// when the find bar isn't open against this tab.
+    private func reapplyFind(tabID: UUID) {
+        guard let needle = lastFindNeedle[tabID], !needle.isEmpty else { return }
+        runFind(tabID: tabID, needle: needle)
+    }
+
     // MARK: - WKNavigationDelegate
 
     @preconcurrency
@@ -680,6 +740,9 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
             guard let self, let webView, let tabID = tabID(for: webView) else { return }
             if showingErrorPage.contains(tabID) { return }
             lastAttemptedURL.removeValue(forKey: tabID)
+            // The load wiped any active find marks + rebuilt a fresh
+            // `window.__nexWebFind`. Re-apply if the find bar is open.
+            reapplyFind(tabID: tabID)
         }
     }
 
@@ -1061,6 +1124,25 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
             ]
         )
     }
+
+    /// Handle a `nexWebFind` message — the `{ total, current }` result
+    /// of a find pass. Re-broadcast as `findResultNotification` for
+    /// `ContentView` to fold into the search overlay.
+    fileprivate func handleFindMessage(tabID: UUID, body: Any) {
+        guard let dict = body as? [String: Any],
+              let total = dict["total"] as? Int,
+              let current = dict["current"] as? Int else { return }
+        NotificationCenter.default.post(
+            name: Self.findResultNotification,
+            object: nil,
+            userInfo: [
+                "paneID": paneID,
+                "tabID": tabID,
+                "total": total,
+                "current": current
+            ]
+        )
+    }
 }
 
 /// Bridge between WKScriptMessageHandler (which Cocoa retains
@@ -1102,6 +1184,8 @@ private final class WebPaneScriptHandler: NSObject, WKScriptMessageHandler {
                 coord.handleInspectMessage(tabID: tabID, body: body, isMainFrame: isMainFrame)
             case "nexBatchMarker":
                 coord.handleBatchMarkerMessage(tabID: tabID, body: body, isMainFrame: isMainFrame)
+            case "nexWebFind":
+                coord.handleFindMessage(tabID: tabID, body: body)
             default:
                 break
             }

--- a/Nex/Features/WebPane/WebPaneFindScript.swift
+++ b/Nex/Features/WebPane/WebPaneFindScript.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+/// JavaScript injected into every web-pane WKWebView (main frame). Defines
+/// `window.__nexWebFind` with `search(needle)`, `next()`, `prev()`, and
+/// `clear()`. Each call posts a result back via the `nexWebFind` script
+/// message: `{ total: Int, current: Int }` (`current` is `-1` when there
+/// is no active match).
+///
+/// This is the web-pane sibling of `MarkdownFindScript`: same tree-walker /
+/// case-folding-regex / `<mark>`-highlight machinery, but namespaced to
+/// `__nexWebFind` / `nexWebFind` so it never collides with the markdown
+/// preview's find (a web pane loads arbitrary pages, not our renderer).
+/// It highlights by wrapping matches in `<mark>` and restores the original
+/// DOM via `normalize()` on `clear()`, so the mutation only lives for the
+/// duration of an active find.
+enum WebPaneFindScript {
+    static let source: String = """
+    (function() {
+      if (window.__nexWebFind) { return; }
+      var ns = {};
+      window.__nexWebFind = ns;
+      ns.matches = [];
+      ns.currentIndex = -1;
+
+      var styleEl = document.createElement('style');
+      // Colors mirror ghostty's `search-background` /
+      // `search-selected-background` so terminal find, markdown find and
+      // web find all share one palette.
+      styleEl.textContent = (
+        "mark.nex-webfind-match { background: #F2D027; color: #000; border-radius: 2px; padding: 0; }" +
+        "mark.nex-webfind-match.nex-webfind-current { background: #FF7A00; color: #000; }"
+      );
+      function injectStyle() {
+        if (document.head) {
+          document.head.appendChild(styleEl);
+        } else {
+          requestAnimationFrame(injectStyle);
+        }
+      }
+      injectStyle();
+
+      function postResult() {
+        if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.nexWebFind) {
+          window.webkit.messageHandlers.nexWebFind.postMessage({
+            total: ns.matches.length,
+            current: ns.matches.length === 0 ? -1 : ns.currentIndex
+          });
+        }
+      }
+
+      function clearMarks() {
+        var marks = document.querySelectorAll('mark.nex-webfind-match');
+        for (var i = 0; i < marks.length; i++) {
+          var m = marks[i];
+          var parent = m.parentNode;
+          if (!parent) continue;
+          while (m.firstChild) parent.insertBefore(m.firstChild, m);
+          parent.removeChild(m);
+          parent.normalize();
+        }
+        ns.matches = [];
+        ns.currentIndex = -1;
+      }
+
+      function setCurrent(scroll) {
+        var prev = document.querySelectorAll('mark.nex-webfind-match.nex-webfind-current');
+        for (var i = 0; i < prev.length; i++) prev[i].classList.remove('nex-webfind-current');
+        if (ns.currentIndex >= 0 && ns.currentIndex < ns.matches.length) {
+          var m = ns.matches[ns.currentIndex];
+          m.classList.add('nex-webfind-current');
+          if (scroll) m.scrollIntoView({ block: 'center', inline: 'nearest' });
+        }
+      }
+
+      function shouldSkipNode(node) {
+        var p = node.parentNode;
+        while (p) {
+          if (p.nodeType !== 1) { p = p.parentNode; continue; }
+          var tag = p.tagName;
+          if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT') return true;
+          if (p.classList && p.classList.contains('nex-webfind-match')) return true;
+          p = p.parentNode;
+        }
+        return false;
+      }
+
+      function escapeRegex(s) {
+        return s.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&');
+      }
+
+      function search(needle) {
+        clearMarks();
+        if (!needle) { postResult(); return; }
+        if (!document.body) { postResult(); return; }
+        // Regex with the `i` flag so case folding is done by the engine
+        // itself — avoids the offset drift that bites
+        // `toLowerCase().indexOf()` when case folding changes string
+        // length (Turkish dotted I, German eszett, etc).
+        var rx;
+        try {
+          rx = new RegExp(escapeRegex(needle), 'gi');
+        } catch (e) {
+          postResult();
+          return;
+        }
+
+        var walker = document.createTreeWalker(
+          document.body,
+          NodeFilter.SHOW_TEXT,
+          {
+            acceptNode: function(node) {
+              if (!node.nodeValue) return NodeFilter.FILTER_REJECT;
+              if (shouldSkipNode(node)) return NodeFilter.FILTER_REJECT;
+              return NodeFilter.FILTER_ACCEPT;
+            }
+          }
+        );
+        var textNodes = [];
+        var n;
+        while ((n = walker.nextNode())) textNodes.push(n);
+
+        var matches = [];
+        for (var t = 0; t < textNodes.length; t++) {
+          var node = textNodes[t];
+          var text = node.nodeValue;
+          rx.lastIndex = 0;
+          var first = rx.exec(text);
+          if (!first) continue;
+          var parent = node.parentNode;
+          if (!parent) continue;
+          var cursor = 0;
+          var fragments = [];
+          var m = first;
+          while (m) {
+            var idx = m.index;
+            var len = m[0].length;
+            if (len === 0) { rx.lastIndex = idx + 1; m = rx.exec(text); continue; }
+            if (idx > cursor) {
+              fragments.push(document.createTextNode(text.slice(cursor, idx)));
+            }
+            var mark = document.createElement('mark');
+            mark.className = 'nex-webfind-match';
+            mark.appendChild(document.createTextNode(text.slice(idx, idx + len)));
+            fragments.push(mark);
+            matches.push(mark);
+            cursor = idx + len;
+            m = rx.exec(text);
+          }
+          if (cursor < text.length) {
+            fragments.push(document.createTextNode(text.slice(cursor)));
+          }
+          for (var f = 0; f < fragments.length; f++) {
+            parent.insertBefore(fragments[f], node);
+          }
+          parent.removeChild(node);
+        }
+
+        ns.matches = matches;
+        ns.currentIndex = matches.length > 0 ? 0 : -1;
+        setCurrent(true);
+        postResult();
+      }
+
+      function navigate(delta) {
+        if (ns.matches.length === 0) { postResult(); return; }
+        ns.currentIndex = (ns.currentIndex + delta + ns.matches.length) % ns.matches.length;
+        setCurrent(true);
+        postResult();
+      }
+
+      ns.search = search;
+      ns.next = function() { navigate(1); };
+      ns.prev = function() { navigate(-1); };
+      ns.clear = function() { clearMarks(); postResult(); };
+    })();
+    """
+
+    /// JSON-encode the needle so it can be inlined inside
+    /// `__nexWebFind.search(...)`. Falls back to `""` on encoding failure.
+    static func encodeNeedle(_ needle: String) -> String {
+        guard let data = try? JSONEncoder().encode(needle),
+              let s = String(data: data, encoding: .utf8)
+        else { return "\"\"" }
+        return s
+    }
+}

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -479,6 +479,34 @@ struct WorkspaceFeature {
         }
     }
 
+    /// Move an open find from one tab of a web pane to another. Web-pane
+    /// find is per-tab (marks + needle live in each WKWebView) but the
+    /// search bar is per-pane, so switching / closing tabs while find is
+    /// open must clear the outgoing tab and re-run the needle on the
+    /// incoming one. Keeping only the active tab needled also means
+    /// `searchClose` (which targets the active tab) fully tears find
+    /// down, and a background tab never resurrects marks via
+    /// `reapplyFind`. No-op when the find bar isn't open on this pane.
+    private func retargetWebFind(
+        paneID: UUID,
+        from oldTabID: UUID?,
+        to newTabID: UUID?,
+        needle: String
+    ) -> Effect<Action> {
+        let store = webPaneStore
+        return .run { _ in
+            await MainActor.run {
+                guard let coord = store.coordinatorIfExists(for: paneID) else { return }
+                if let oldTabID, oldTabID != newTabID {
+                    coord.runFindClose(tabID: oldTabID)
+                }
+                if let newTabID {
+                    coord.runFind(tabID: newTabID, needle: needle)
+                }
+            }
+        }
+    }
+
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
@@ -954,18 +982,32 @@ struct WorkspaceFeature {
                     state.syncWebPaneHeader(paneID: paneID)
                 }
                 let store = webPaneStore
-                return .run { _ in
+                let destroyEffect: Effect<Action> = .run { _ in
                     await store.destroyTab(paneID: paneID, tabID: tabID)
                 }
+                // Closing the active tab with find open: `destroyTab`
+                // clears the closed tab's find; re-run the needle on the
+                // tab that takes over so the bar keeps working.
+                if wasActive, state.searchingPaneID == paneID,
+                   let newActiveID = webState.activeTabID {
+                    return .merge(
+                        destroyEffect,
+                        retargetWebFind(paneID: paneID, from: nil, to: newActiveID, needle: state.searchNeedle)
+                    )
+                }
+                return destroyEffect
 
             case .webPaneTabSelect(let paneID, let tabID):
                 guard var webState = state.webPanes[paneID] else { return .none }
                 guard webState.contains(tabID: tabID) else { return .none }
                 guard webState.activeTabID != tabID else { return .none }
+                let oldTabID = webState.activeTab?.id
                 webState.activeTabID = tabID
                 state.webPanes[paneID] = webState
                 state.syncWebPaneHeader(paneID: paneID)
-                return .none
+                // Move an open find to the newly-active tab.
+                guard state.searchingPaneID == paneID else { return .none }
+                return retargetWebFind(paneID: paneID, from: oldTabID, to: tabID, needle: state.searchNeedle)
 
             case .webPaneTabCycle(let paneID, let offset):
                 guard var webState = state.webPanes[paneID], webState.tabs.count > 1 else { return .none }
@@ -973,10 +1015,12 @@ struct WorkspaceFeature {
                 guard let activeID, let currentIdx = webState.index(of: activeID) else { return .none }
                 let count = webState.tabs.count
                 let nextIdx = ((currentIdx + offset) % count + count) % count
-                webState.activeTabID = webState.tabs[nextIdx].id
+                let newTabID = webState.tabs[nextIdx].id
+                webState.activeTabID = newTabID
                 state.webPanes[paneID] = webState
                 state.syncWebPaneHeader(paneID: paneID)
-                return .none
+                guard state.searchingPaneID == paneID else { return .none }
+                return retargetWebFind(paneID: paneID, from: activeID, to: newTabID, needle: state.searchNeedle)
 
             case .webPaneTabReorder(let paneID, let orderedTabIDs):
                 guard var webState = state.webPanes[paneID] else { return .none }
@@ -1599,7 +1643,7 @@ struct WorkspaceFeature {
             case .toggleSearch:
                 guard let focusedID = state.focusedPaneID,
                       let pane = state.panes[id: focusedID],
-                      pane.type == .shell || (pane.type == .markdown && !pane.isEditing)
+                      pane.type == .shell || pane.type == .web || (pane.type == .markdown && !pane.isEditing)
                 else { return .none }
                 if state.searchingPaneID != nil {
                     return .send(.searchClose)
@@ -1630,7 +1674,20 @@ struct WorkspaceFeature {
                 state.searchNeedle = needle
                 state.searchSelected = nil
                 guard let paneID = state.searchingPaneID else { return .none }
-                let isMarkdown = state.panes[id: paneID]?.type == .markdown
+                let paneType = state.panes[id: paneID]?.type
+                if paneType == .web {
+                    // WKWebView find runs locally in JS; drive it directly
+                    // against the active tab so typing feels responsive.
+                    guard let tabID = state.webPanes[paneID]?.activeTab?.id else { return .none }
+                    let store = webPaneStore
+                    return .run { _ in
+                        await MainActor.run {
+                            store.coordinatorIfExists(for: paneID)?.runFind(tabID: tabID, needle: needle)
+                        }
+                    }
+                    .cancellable(id: SearchDebounceID.debounce, cancelInFlight: true)
+                }
+                let isMarkdown = paneType == .markdown
                 if isMarkdown {
                     // WKWebView find runs locally in JS; no backend round-trip
                     // to debounce. Drive it directly so typing feels responsive.
@@ -1662,7 +1719,17 @@ struct WorkspaceFeature {
 
             case .searchNavigateNext:
                 guard let paneID = state.searchingPaneID else { return .none }
-                if state.panes[id: paneID]?.type == .markdown {
+                let nextType = state.panes[id: paneID]?.type
+                if nextType == .web {
+                    guard let tabID = state.webPanes[paneID]?.activeTab?.id else { return .none }
+                    let store = webPaneStore
+                    return .run { _ in
+                        await MainActor.run {
+                            store.coordinatorIfExists(for: paneID)?.runFindNavigate(tabID: tabID, forward: true)
+                        }
+                    }
+                }
+                if nextType == .markdown {
                     return .run { _ in
                         await MainActor.run {
                             MarkdownFindController.shared.navigateNext(paneID: paneID)
@@ -1676,7 +1743,17 @@ struct WorkspaceFeature {
 
             case .searchNavigatePrevious:
                 guard let paneID = state.searchingPaneID else { return .none }
-                if state.panes[id: paneID]?.type == .markdown {
+                let prevType = state.panes[id: paneID]?.type
+                if prevType == .web {
+                    guard let tabID = state.webPanes[paneID]?.activeTab?.id else { return .none }
+                    let store = webPaneStore
+                    return .run { _ in
+                        await MainActor.run {
+                            store.coordinatorIfExists(for: paneID)?.runFindNavigate(tabID: tabID, forward: false)
+                        }
+                    }
+                }
+                if prevType == .markdown {
                     return .run { _ in
                         await MainActor.run {
                             MarkdownFindController.shared.navigatePrevious(paneID: paneID)
@@ -1690,12 +1767,22 @@ struct WorkspaceFeature {
 
             case .searchClose:
                 guard let paneID = state.searchingPaneID else { return .none }
-                let isMarkdown = state.panes[id: paneID]?.type == .markdown
+                let closeType = state.panes[id: paneID]?.type
+                let webTabID = state.webPanes[paneID]?.activeTab?.id
                 state.searchingPaneID = nil
                 state.searchNeedle = ""
                 state.searchTotal = nil
                 state.searchSelected = nil
-                if isMarkdown {
+                if closeType == .web {
+                    guard let tabID = webTabID else { return .none }
+                    let store = webPaneStore
+                    return .run { _ in
+                        await MainActor.run {
+                            store.coordinatorIfExists(for: paneID)?.runFindClose(tabID: tabID)
+                        }
+                    }
+                }
+                if closeType == .markdown {
                     return .run { _ in
                         await MainActor.run {
                             MarkdownFindController.shared.close(paneID: paneID)

--- a/NexTests/WorkspaceFeatureTests.swift
+++ b/NexTests/WorkspaceFeatureTests.swift
@@ -1451,6 +1451,96 @@ struct WorkspaceFeatureTests {
         // No state change asserted: state.searchingPaneID stays nil.
     }
 
+    @Test func toggleSearchOpensForWebPane() async {
+        let paneID = UUID()
+        var workspace = WorkspaceFeature.State(name: "Test")
+        workspace.panes = [Pane(id: paneID, type: .web, workingDirectory: "/tmp")]
+        workspace.layout = .leaf(paneID)
+        workspace.focusedPaneID = paneID
+        workspace.webPanes = [
+            paneID: WebPaneState(
+                tabs: [WebTab(id: UUID(), url: "https://example.com")],
+                activeTabID: nil,
+                isPrivate: false
+            )
+        ]
+
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.toggleSearch) { state in
+            state.searchingPaneID = paneID
+            state.searchNeedle = ""
+            state.searchTotal = nil
+            state.searchSelected = nil
+        }
+    }
+
+    @Test func searchCloseClearsStateForWebPane() async {
+        let paneID = UUID()
+        var workspace = WorkspaceFeature.State(name: "Test")
+        workspace.panes = [Pane(id: paneID, type: .web, workingDirectory: "/tmp")]
+        workspace.layout = .leaf(paneID)
+        workspace.focusedPaneID = paneID
+        workspace.webPanes = [
+            paneID: WebPaneState(
+                tabs: [WebTab(id: UUID(), url: "https://example.com")],
+                activeTabID: nil,
+                isPrivate: false
+            )
+        ]
+        workspace.searchingPaneID = paneID
+        workspace.searchNeedle = "foo"
+        workspace.searchTotal = 3
+        workspace.searchSelected = 1
+
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.searchClose) { state in
+            state.searchingPaneID = nil
+            state.searchNeedle = ""
+            state.searchTotal = nil
+            state.searchSelected = nil
+        }
+    }
+
+    @Test func webPaneTabSwitchWhileSearchingPreservesSearchState() async {
+        let paneID = UUID()
+        let tabA = UUID()
+        let tabB = UUID()
+        var workspace = WorkspaceFeature.State(name: "Test")
+        workspace.panes = [Pane(id: paneID, type: .web, workingDirectory: "/tmp")]
+        workspace.layout = .leaf(paneID)
+        workspace.focusedPaneID = paneID
+        workspace.webPanes = [
+            paneID: WebPaneState(
+                tabs: [WebTab(id: tabA, url: "https://a.example"), WebTab(id: tabB, url: "https://b.example")],
+                activeTabID: tabA,
+                isPrivate: false
+            )
+        ]
+        workspace.searchingPaneID = paneID
+        workspace.searchNeedle = "foo"
+
+        let store = TestStore(initialState: workspace) { WorkspaceFeature() } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        // Switching the active tab retargets find (no coordinator in
+        // tests, so the effect is a no-op) without dropping the bar.
+        await store.send(.webPaneTabSelect(paneID: paneID, tabID: tabB)) { state in
+            state.webPanes[paneID]?.activeTabID = tabB
+        }
+        #expect(store.state.searchingPaneID == paneID)
+        #expect(store.state.searchNeedle == "foo")
+    }
+
     @Test func toggleMarkdownEditDismissesActiveSearch() async {
         let paneID = UUID()
         var workspace = WorkspaceFeature.State(name: "Test")


### PR DESCRIPTION
## Summary
- Add Cmd+F in-page find to web / HTML-viewer panes, wiring them into the existing find pipeline (overlay + reducer + match count) that already backs terminal and markdown panes.
- New `WebPaneFindScript` injects `window.__nexWebFind` (tree-walker + case-folding regex + `<mark>` highlights + `{total,current}` reporting), mirroring `MarkdownFindScript`; the DOM is restored on close.
- `WebPaneCoordinator` injects the script, routes `nexWebFind` results to a `findResultNotification`, and exposes `runFind` / `runFindNavigate` / `runFindClose` with per-tab needle memory so a reload re-applies the active find.
- `WorkspaceFeature.toggleSearch` and the four search actions now handle `.web` panes, driving the active tab's coordinator.
- **Find follows the active tab:** switching / closing tabs while find is open clears the outgoing tab and re-runs the needle on the incoming one, so only the active tab ever holds a needle (no zombie highlights). The result handler drops stale non-active-tab results.

Closes #245

## Reviewer notes
- Two parallel reviewers converged on one real issue: web find is per-tab but the search bar is per-pane, so tab switch/close while find is open could leave zombie highlights + stale counts (and `reapplyFind` could resurrect highlights after close). Fixed via the "find follows the active tab" retargeting + the active-tab guard in the result handler.
- Chose the JS `<mark>` highlight approach (parity with markdown find: live "3 of 12" count + cycling) over the native `WKWebView.find()` API, which returns only a match/no-match boolean and can't drive the existing count overlay. DOM is mutated only while a find is active and restored on close.

## Validation
- Validated in a sandboxed macOS VM via cua/lume. Assertions: `nex open page.html` creates a web pane; Cmd+F → type → Enter ×2 → Esc never destroyed the web or shell pane; Cmd+F toggle preserves the pane.
- Screenshots (`/Users/ben/code/cua/out/branches/fix-245-web-pane-find/issue-245/`) visually confirm: Cmd+F opens the find bar; typing "FINDME" highlights all 12 matches (current in orange) with a **1/12** count; Enter cycles to **3/12** moving the current-match highlight; Esc closes the bar and clears highlights.
- New reducer tests: `toggleSearchOpensForWebPane`, `searchCloseClearsStateForWebPane`, `webPaneTabSwitchWhileSearchingPreservesSearchState`. Full suite green (pre-existing FS-watcher timing flakes excepted).

## Test plan
- [x] Cmd+F on a web pane opens the find bar; typing highlights matches, scrolls to the first, and shows the count.
- [x] Enter / Shift+Enter cycle through matches; the count and current-match highlight update.
- [x] Esc closes the bar and removes highlights.
- [x] With find open, switch/close tabs — the count re-runs against the new active tab and no stale highlights remain on the old one.
- [x] With find open, reload the page (⌘R) — highlights re-apply with a fresh count.
- [x] Find works on a remote page (long docs page), a private/incognito web pane, and a page that fails to load (error stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xDAAF1Na7wsQ1ZxQgYaCh