### PR TITLE
fix(#254): accept palette pictographs in the custom emoji dialog

### DIFF
--- a/Nex/Features/Workspace/GroupCustomEmojiSheet.swift
+++ b/Nex/Features/Workspace/GroupCustomEmojiSheet.swift
@@ -25,7 +25,7 @@ struct GroupCustomEmojiSheet: View {
             Text("Custom Emoji for \"\(subjectName)\"")
                 .font(.headline)
 
-            Text("Type or paste a single emoji. Use \u{2303}\u{2318}Space, or the button below, to search every emoji. Non-emoji input is rejected.")
+            Text("Type or paste a single emoji or symbol. Use \u{2303}\u{2318}Space, or the button below, to search every emoji. Letters, digits, and punctuation are rejected.")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Nex/Models/GroupIcon.swift
+++ b/Nex/Models/GroupIcon.swift
@@ -51,16 +51,46 @@ private extension String {
 
 extension Character {
     /// Heuristic emoji check used by the Custom Emoji input so a
-    /// stray letter or digit can't be persisted as `.emoji`. Returns
-    /// `true` when any scalar of the grapheme defaults to emoji
-    /// presentation (single-codepoint pictographs, skin-toned,
-    /// flags, ZWJ sequences) or carries the explicit emoji-
-    /// presentation selector (`U+FE0F`). That covers common cases —
-    /// `"a"` / `"1"` / keyboard punctuation are rejected, while
-    /// `"❤️"`, `"👨‍👩‍👧‍👦"`, and `"1️⃣"` pass.
+    /// stray letter or digit can't be persisted as `.emoji`. The
+    /// macOS character palette (the sheet's "Browse All Emoji…"
+    /// button) offers glyphs well beyond RGI emoji — e.g. ⛙ U+26D9
+    /// carries no Unicode emoji properties at all (issue #254) — so
+    /// the check accepts, in order:
+    ///
+    /// 1. An emoji-presentation *base* scalar (`"🔥"`, skin tones,
+    ///    flags, ZWJ sequences), or an explicit `U+FE0F` selector on
+    ///    an emoji-capable base (`"❤️"`, `"1️⃣"` — digits carry
+    ///    `Emoji=Yes`, so keycaps pass). Anchoring on the first
+    ///    scalar rejects degenerate clusters — a lone invisible
+    ///    `U+FE0F`, a selector on a non-emoji base (`"a\u{FE0F}"`),
+    ///    or a letter with a skin-tone modifier glued on.
+    /// 2. Text-presentation emoji pasted bare, i.e. without the
+    ///    `U+FE0F` the palette usually appends (`"✂"`, `"ℹ"`, `"©"`):
+    ///    `Emoji=Yes` on a non-ASCII first scalar. The ASCII guard
+    ///    keeps `"1"` / `"#"` / `"*"` (also `Emoji=Yes`) rejected.
+    /// 3. Non-emoji pictographs and symbols (`"⛙"`, `"♞"`, `"→"`,
+    ///    `"⌘"`): non-ASCII first scalar in the So/Sm/Sc symbol
+    ///    categories. Sk (spacing accents like `"´"`) is deliberately
+    ///    excluded — it is a dead-key mistype away and never
+    ///    icon-worthy.
+    ///
+    /// Letters, digits, punctuation, whitespace, and lone combining
+    /// marks — ASCII or not (`"a"`, `"Ω"`, `"あ"`, `"！"`) — stay
+    /// rejected.
     var isGraphemeEmoji: Bool {
-        unicodeScalars.contains { scalar in
-            scalar.properties.isEmojiPresentation || scalar == "\u{FE0F}"
+        guard let first = unicodeScalars.first else { return false }
+        if first.properties.isEmojiPresentation { return true }
+        if unicodeScalars.count > 1, unicodeScalars.contains("\u{FE0F}"),
+           first.properties.isEmoji {
+            return true
+        }
+        guard !first.isASCII else { return false }
+        if first.properties.isEmoji { return true }
+        switch first.properties.generalCategory {
+        case .otherSymbol, .mathSymbol, .currencySymbol:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/NexTests/GroupIconTests.swift
+++ b/NexTests/GroupIconTests.swift
@@ -36,10 +36,74 @@ struct GroupIconTests {
         #expect(Character("👨‍👩‍👧‍👦").isGraphemeEmoji) // ZWJ family
     }
 
+    @Test func isGraphemeEmojiAcceptsBareTextPresentationEmoji() {
+        // Emoji=Yes scalars whose default presentation is text; the
+        // palette usually appends U+FE0F but bare pastes must pass too.
+        #expect(Character("✂").isGraphemeEmoji) // U+2702
+        #expect(Character("ℹ").isGraphemeEmoji) // U+2139
+        #expect(Character("©").isGraphemeEmoji) // U+00A9
+        #expect(Character("☂︎").isGraphemeEmoji) // U+2602 + text selector U+FE0E
+    }
+
+    @Test func isGraphemeEmojiAcceptsNonEmojiPictographs() {
+        // No Unicode emoji properties at all, but offered by the macOS
+        // character palette — the issue #254 regression class.
+        #expect(Character("⛙").isGraphemeEmoji) // U+26D9, the issue's char
+        #expect(Character("♞").isGraphemeEmoji) // U+265E chess knight
+        #expect(Character("→").isGraphemeEmoji) // U+2192, math symbol
+        #expect(Character("⌘").isGraphemeEmoji) // U+2318
+        #expect(Character("£").isGraphemeEmoji) // U+00A3, currency symbol
+        #expect(Character("°").isGraphemeEmoji) // U+00B0
+    }
+
     @Test func isGraphemeEmojiRejectsPlainText() {
         #expect(Character("a").isGraphemeEmoji == false)
         #expect(Character("1").isGraphemeEmoji == false)
         #expect(Character("!").isGraphemeEmoji == false)
         #expect(Character(" ").isGraphemeEmoji == false)
+        // ASCII with Emoji=Yes — the ASCII guard must beat tier 2.
+        #expect(Character("#").isGraphemeEmoji == false)
+        #expect(Character("*").isGraphemeEmoji == false)
+        // ASCII Symbol categories — the ASCII guard must beat tier 3.
+        #expect(Character("$").isGraphemeEmoji == false)
+        #expect(Character("=").isGraphemeEmoji == false)
+        #expect(Character("+").isGraphemeEmoji == false)
+    }
+
+    @Test func isGraphemeEmojiRejectsNonASCIILettersAndDigits() {
+        #expect(Character("Ω").isGraphemeEmoji == false)
+        #expect(Character("あ").isGraphemeEmoji == false)
+        #expect(Character("７").isGraphemeEmoji == false) // fullwidth digit
+        #expect(Character("¡").isGraphemeEmoji == false) // non-ASCII punctuation
+    }
+
+    @Test func isGraphemeEmojiRejectsInvisiblesAndBareMarks() {
+        // A lone variation selector is invisible; persisting it would
+        // render an empty avatar.
+        #expect(Character("\u{FE0F}").isGraphemeEmoji == false)
+        #expect(Character("\u{200D}").isGraphemeEmoji == false) // lone ZWJ
+        #expect(Character("\u{0301}").isGraphemeEmoji == false) // combining accent
+        // Keycap without the U+FE0F the palette inserts: first scalar
+        // is ASCII "1", so it stays rejected — a documented limitation
+        // (the palette always emits the U+FE0F form).
+        #expect(Character("1\u{20E3}").isGraphemeEmoji == false)
+    }
+
+    @Test func isGraphemeEmojiRejectsVS16OnNonEmojiBase() {
+        // U+FE0F only counts on an emoji-capable base — tacking a
+        // variation selector onto a letter must not smuggle it past
+        // the letter/digit rejection.
+        #expect(Character("a\u{FE0F}").isGraphemeEmoji == false)
+        #expect(Character("!\u{FE0F}").isGraphemeEmoji == false)
+        #expect(Character("Ω\u{FE0F}").isGraphemeEmoji == false)
+        #expect(Character("\u{FE0F}\u{20E3}").isGraphemeEmoji == false) // headless keycap
+        // Digits carry Emoji=Yes, so a digit + VS16 is a valid Unicode
+        // emoji presentation sequence and stays accepted.
+        #expect(Character("1\u{FE0F}").isGraphemeEmoji)
+        // A skin-tone modifier glued to a letter forms one grapheme;
+        // anchoring tier 1 on the base scalar keeps it out.
+        #expect(Character("a\u{1F3FB}").isGraphemeEmoji == false)
+        // Sk spacing accents are excluded from the symbol tier.
+        #expect(Character("´").isGraphemeEmoji == false)
     }
 }

--- a/NexTests/WorkspaceGroupCRUDTests.swift
+++ b/NexTests/WorkspaceGroupCRUDTests.swift
@@ -493,6 +493,19 @@ struct WorkspaceGroupCRUDTests {
         }
     }
 
+    @Test func confirmGroupCustomEmojiAcceptsNonEmojiPictograph() async {
+        let group = WorkspaceGroup(id: Self.groupA, name: "Work", childOrder: [])
+        let store = makeStore(groups: [group], topLevelOrder: [.group(Self.groupA)])
+
+        await store.send(.requestGroupCustomEmoji(Self.groupA))
+        // ⛙ (U+26D9) has no Unicode emoji properties but comes straight
+        // out of the macOS character palette (issue #254).
+        await store.send(.confirmGroupCustomEmoji("⛙")) { state in
+            #expect(state.groups[id: Self.groupA]?.icon == .emoji("⛙"))
+            #expect(state.groupCustomEmojiPrompt == nil)
+        }
+    }
+
     @Test func confirmGroupCustomEmojiRejectsNonEmoji() async {
         let group = WorkspaceGroup(id: Self.groupA, name: "Work", childOrder: [])
         let store = makeStore(groups: [group], topLevelOrder: [.group(Self.groupA)])
@@ -503,6 +516,31 @@ struct WorkspaceGroupCRUDTests {
         await store.send(.confirmGroupCustomEmoji("a")) { state in
             #expect(state.groups[id: Self.groupA]?.icon == nil)
             #expect(state.groupCustomEmojiPrompt == nil)
+        }
+    }
+
+    @Test func confirmWorkspaceCustomEmojiAcceptsNonEmojiPictograph() async {
+        // The workspace guard duplicates the group guard's logic in
+        // AppReducer rather than sharing it — mirror the ⛙ case so the
+        // copy can't silently drift (issue #254).
+        let ws = Self.makeWorkspace(id: Self.wsID1, name: "A")
+        let store = makeStore(workspaces: [ws], topLevelOrder: [.workspace(Self.wsID1)])
+
+        await store.send(.requestWorkspaceCustomEmoji(Self.wsID1))
+        await store.send(.confirmWorkspaceCustomEmoji("⛙")) { state in
+            #expect(state.workspaces[id: Self.wsID1]?.icon == .emoji("⛙"))
+            #expect(state.workspaceCustomEmojiPrompt == nil)
+        }
+    }
+
+    @Test func confirmWorkspaceCustomEmojiRejectsNonEmoji() async {
+        let ws = Self.makeWorkspace(id: Self.wsID1, name: "A")
+        let store = makeStore(workspaces: [ws], topLevelOrder: [.workspace(Self.wsID1)])
+
+        await store.send(.requestWorkspaceCustomEmoji(Self.wsID1))
+        await store.send(.confirmWorkspaceCustomEmoji("a")) { state in
+            #expect(state.workspaces[id: Self.wsID1]?.icon == nil)
+            #expect(state.workspaceCustomEmojiPrompt == nil)
         }
     }
 


### PR DESCRIPTION
## Summary
- Broadens `Character.isGraphemeEmoji` (shared by the Custom Emoji sheet's Set Icon enablement, its commit path, and both AppReducer guards) from "Emoji_Presentation or U+FE0F present" to a three-tier heuristic anchored on the base scalar: emoji presentation / VS16 on an emoji-capable base, bare `Emoji=Yes` non-ASCII scalars (✂ ℹ ©), and non-ASCII So/Sm/Sc symbols (⛙ ♞ → ⌘) — the class of characters the macOS palette offers that carry no Unicode emoji properties at all.
- Hardens two pre-existing holes on the way: a lone invisible U+FE0F (would persist an empty avatar) and degenerate clusters (VS16 or a skin-tone modifier glued to a letter) no longer pass.
- Updates the sheet help text ("Letters, digits, and punctuation are rejected.") and adds 28 new unit-test cases plus group- and workspace-side reducer tests.

Closes #254

## Reviewer notes
- Codex review: APPROVE with one SHOULD (VS16 on a non-emoji base slipped through) — applied.
- Fresh-Claude review: APPROVE with one SHOULD (anchor tier 1 on the base scalar so `a`+skin-tone is rejected) and two NITs (drop Sk spacing accents; mirror the workspace-side reducer test) — all applied.
- Deliberately accepted: digit+VS16 (`1️⃣`-style without keycap) is a valid Unicode emoji presentation sequence; keycap *without* VS16 (`1⃣`) stays rejected (the palette always emits the VS16 form) — pinned by tests as documented decisions.
- `make check` green except the two documented `RecursiveFSWatcherTests.liveWatcher*` timing flakes (fail on main too on a loaded host; unrelated to this diff).

## Validation
- Validated in a sandboxed macOS VM via cua/lume (`validate_issue_254.py`).
- TEST 1: the real `Nex/Models/GroupIcon.swift` from the branch worktree compiled with swiftc inside the VM against a 39-case accept/reject battery (Unicode property tables are OS-owned, so this exercises the VM's macOS tables) — all passed, including the issue's exact ⛙ U+26D9.
- TEST 2: the built Nex app code (`Nex.debug.dylib`) contains the updated sheet copy.
- TEST 3: launch health — app opens, `pane list --json` round-trips, initial pane survives.
- Screenshots: `/Users/ben/code/cua/out/branches/issue-254-custom-emoji-validation/issue-254/`

## Test plan
- [x] Right-click a workspace in the sidebar → Change Icon → Custom Emoji…, paste ⛙ (⌃⌘Space, search "merge"): Set Icon enables and the ⛙ avatar appears in the sidebar
- [x] Same dialog: type `a` — Set Icon stays disabled; type 🔥 or ❤️ — enables
- [x] Paste a bare text-style emoji (✂, ℹ): enables
- [x] Same flow on a group header (Change Icon → Custom Emoji…) sets the group icon
- [x] Existing palette emoji (Change Icon → Emoji submenu) still applies, Reset to Letter/Folder still works
- [x] Restart Nex: the custom icon persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AEWsLYZbwDyQQghyQau8i