### PR TITLE
fix: derive graft root lock from sessions so workspace deletion can't orphan it

### DIFF
--- a/Nex/AppReducer+RepoGit.swift
+++ b/Nex/AppReducer+RepoGit.swift
@@ -88,11 +88,12 @@ extension AppReducer {
                 let stopEffects = removedAssociationIDs.map {
                     Effect.send(Action.stopHeadWatcher(associationID: $0))
                 }
-                // Stop any live graft sessions on removed associations.
-                // Without this, removing the repo leaves grafts mirroring
-                // a worktree whose association is gone.
+                // Stop any graft sessions on removed associations —
+                // unconditionally, since filtering by the reducer's
+                // session mirror used to skip live service sessions
+                // the mirror lost track of (#231). Stop is a cheap
+                // no-op for associations without one.
                 let graftStopEffects = removedAssociationIDs
-                    .filter { state.graft.sessions[id: $0] != nil }
                     .map { Effect.send(Action.graft(.forceStop($0))) }
                 return .merge(stopEffects + graftStopEffects + [.send(.persistState)])
 
@@ -178,25 +179,20 @@ extension AppReducer {
                       let assoc = workspace.repoAssociations[id: associationID],
                       let repo = state.repoRegistry[id: assoc.repoID] else { return .none }
 
-                // Stop any active graft session FIRST. Otherwise the
-                // session keeps trying to mirror a worktree that no
-                // longer has an association (and, in the
-                // `deleteWorktree: true` case, is about to disappear
-                // entirely), leaving the parent root mid-mirror and
-                // the breadcrumb stranded.
-                let needsGraftStop = state.graft.sessions[id: associationID] != nil
-
                 state.workspaces[id: workspaceID]?.repoAssociations.remove(id: associationID)
                 state.gitStatuses.removeValue(forKey: associationID)
 
-                // `forceStop` (not `toggleGraft`) because the
-                // association is being deleted entirely. `toggleGraft`
-                // would retry-start a graft when the existing session
-                // is in `.error` state, which is wrong here — the
-                // worktree is going away.
-                let graftStop: Effect<Action> = needsGraftStop
-                    ? .send(.graft(.forceStop(associationID)))
-                    : .none
+                // Stop any graft session FIRST. Otherwise the session
+                // keeps trying to mirror a worktree that no longer has
+                // an association (and, in the `deleteWorktree: true`
+                // case, is about to disappear entirely), leaving the
+                // parent root mid-mirror and the breadcrumb stranded.
+                // Unconditional — filtering by the reducer's session
+                // mirror used to skip live service sessions the mirror
+                // lost track of (#231). `forceStop` (not `toggleGraft`)
+                // because the association is being deleted entirely and
+                // a retry-start would be wrong here.
+                let graftStop: Effect<Action> = .send(.graft(.forceStop(associationID)))
 
                 if deleteWorktree {
                     // graftStop and removeWorktree run in parallel —
@@ -376,12 +372,14 @@ extension AppReducer {
 
                 if removedRepoIDs.isEmpty { return .none }
                 let stopEffects = stoppedAssocIDs.map { Effect.send(Action.stopHeadWatcher(associationID: $0)) }
-                // Stop any live graft sessions for auto-unlinked
-                // associations. Otherwise a graft set up against an
-                // auto-linked worktree keeps mirroring after the pane
-                // moves out of that worktree.
+                // Stop any graft sessions for auto-unlinked
+                // associations — unconditionally, since filtering by
+                // the reducer's session mirror used to skip live
+                // service sessions the mirror lost track of (#231).
+                // Otherwise a graft set up against an auto-linked
+                // worktree keeps mirroring after the pane moves out
+                // of that worktree.
                 let graftStopEffects = stoppedAssocIDs
-                    .filter { state.graft.sessions[id: $0] != nil }
                     .map { Effect.send(Action.graft(.forceStop($0))) }
                 return .merge(stopEffects + graftStopEffects + [.send(.persistState)])
 

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -834,7 +834,7 @@ struct AppReducer {
         return .resolved(results)
     }
 
-    private func sessionJSON(_ session: GraftSession) -> [String: Any] {
+    private static func sessionJSON(_ session: GraftSession) -> [String: Any] {
         let statusString = switch session.status {
         case .starting: "starting"
         case .watching: "watching"
@@ -920,7 +920,7 @@ struct AppReducer {
         paneID: UUID?,
         reply: SocketServer.ReplyHandle?
     ) -> Effect<Action> {
-        let assocs: [RepoAssociation]
+        var assocs: [RepoAssociation] = []
         switch resolveGraftAssociations(
             state: state,
             workspaceFilter: workspaceFilter,
@@ -930,30 +930,62 @@ struct AppReducer {
         case .resolved(let resolved):
             assocs = resolved
         case .failure(let error):
-            reply?.send(["ok": false, "error": error])
-            reply?.close()
-            return .none
+            // A bare repo filter that matches no association is NOT
+            // fatal: the session's owning association may have been
+            // deleted with its workspace (issue #231), in which case
+            // only the service still knows it — the fallback below
+            // matches it by path. Everything else (no scope at all,
+            // unknown workspace) stays an error.
+            guard repoFilter != nil, workspaceFilter == nil else {
+                reply?.send(["ok": false, "error": error])
+                reply?.close()
+                return .none
+            }
         }
 
-        // Only stop associations that actually have a live session.
-        let activeIDs = Set(state.graft.sessions.ids)
-        let targets = assocs.filter { activeIDs.contains($0.id) }
-        if targets.isEmpty {
-            reply?.send(["ok": true, "stopped": []])
-            reply?.close()
-            return .none
-        }
-
+        let assocIDs = Set(assocs.map(\.id))
         return .run { [graftService] _ in
+            // Filter against the SERVICE's live sessions, not the
+            // reducer mirror — the two can diverge, and a session the
+            // mirror lost track of must still be stoppable from the
+            // CLI (issue #231). The empty-targets reply lives inside
+            // the effect for the same reason: an empty mirror must
+            // not short-circuit ahead of the service check.
+            let active = await graftService.activeSessions()
+            var targetIDs = active.map(\.id).filter { assocIDs.contains($0) }
+            if let repoFilter {
+                // Orphan fallback: a session whose association is gone
+                // can never resolve via workspaces, but `--repo` can
+                // still address it by worktree path, parent repo root,
+                // or their last path components (mirroring the
+                // association matching in `resolveGraftAssociations`).
+                for session in active where !targetIDs.contains(session.id) {
+                    let candidates = [
+                        session.worktreePath,
+                        (session.worktreePath as NSString).lastPathComponent,
+                        session.parentRepoRoot,
+                        (session.parentRepoRoot as NSString).lastPathComponent
+                    ]
+                    if candidates.contains(repoFilter)
+                        || candidates.contains(Self.standardizedPath(repoFilter)) {
+                        targetIDs.append(session.id)
+                    }
+                }
+            }
+            if targetIDs.isEmpty {
+                reply?.send(["ok": true, "stopped": []])
+                reply?.close()
+                return
+            }
             var stopped: [String] = []
             var failures: [[String: Any]] = []
-            for assoc in targets {
+            for targetID in targetIDs {
                 do {
-                    try await graftService.stop(assoc.id)
-                    stopped.append(assoc.id.uuidString)
+                    try await graftService.stop(targetID)
+                    stopped.append(targetID.uuidString)
                 } catch {
                     failures.append([
-                        "association_id": assoc.id.uuidString,
+                        "association_id": targetID.uuidString,
                         "error": String(describing: error)
                     ])
                 }
@@ -967,17 +999,34 @@ struct AppReducer {
         }
     }
 
+    /// Expand + canonicalize a user-supplied path argument so it can
+    /// be compared against the service's canonicalized session paths.
+    /// Mirrors `GraftServiceImpl.canonicalize` (standardize, then
+    /// resolve symlinks — e.g. /tmp → /private/tmp) plus tilde
+    /// expansion for CLI ergonomics.
+    private static func standardizedPath(_ raw: String) -> String {
+        (((raw as NSString).expandingTildeInPath as NSString)
+            .standardizingPath as NSString)
+            .resolvingSymlinksInPath
+    }
+
     func handleGraftStatus(
-        state: State,
+        state _: State,
         reply: SocketServer.ReplyHandle?
     ) -> Effect<Action> {
-        let payload: [String: Any] = [
-            "ok": true,
-            "sessions": state.graft.sessions.map(sessionJSON)
-        ]
-        reply?.send(payload)
-        reply?.close()
-        return .none
+        // Report the SERVICE's sessions, not the reducer mirror — the
+        // service is the source of truth, and a session the mirror
+        // lost track of must still show up here so `alreadyActive`
+        // rejections are always explainable via `status` (issue #231).
+        .run { [graftService] _ in
+            let sessions = await graftService.activeSessions()
+            let payload: [String: Any] = [
+                "ok": true,
+                "sessions": sessions.map(Self.sessionJSON)
+            ]
+            reply?.send(payload)
+            reply?.close()
+        }
     }
 
     /// `nex ping` — cheap IPC round-trip used by `nex doctor` and as
@@ -1244,11 +1293,6 @@ struct AppReducer {
                 let paneIDs = workspace.layout.allPaneIDs
                     + workspace.parkedPanes.map(\.id)
                 let assocIDs = workspace.repoAssociations.map(\.id)
-                // Capture associations with live graft sessions BEFORE
-                // removal so we can issue `forceStop` for each — head
-                // watcher cancellation alone leaves the graft mirroring
-                // a worktree whose association is gone.
-                let liveGraftAssocIDs = assocIDs.filter { state.graft.sessions[id: $0] != nil }
                 state.workspaces.remove(id: id)
                 state.topLevelOrder.removeAll { $0 == .workspace(id) }
                 for groupID in state.groups.ids {
@@ -1275,7 +1319,12 @@ struct AppReducer {
                 }
 
                 let stopEffects = assocIDs.map { Effect.send(Action.stopHeadWatcher(associationID: $0)) }
-                let graftStopEffects = liveGraftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
+                // `forceStop` every removed association unconditionally
+                // — filtering by the reducer's session mirror used to
+                // skip cleanup whenever the mirror had lost track of a
+                // live service session (issue #231). Stop is a cheap
+                // no-op for associations without one.
+                let graftStopEffects = assocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
                 let mgr = surfaceManager
                 return .merge(
                     [
@@ -1548,18 +1597,16 @@ struct AppReducer {
                 guard ids.count < state.workspaces.count else { return .none }
 
                 var panesToDestroy: [UUID] = []
-                // Capture associations with live graft sessions BEFORE
-                // removal — otherwise the graft keeps mirroring a
-                // worktree whose association is gone with no UI/CLI
-                // path to stop it.
-                var liveGraftAssocIDs: [UUID] = []
+                // Capture association ids BEFORE removal so we can
+                // `forceStop` each — unconditionally, since filtering
+                // by the reducer's session mirror used to skip live
+                // service sessions the mirror lost track of (#231).
+                var graftAssocIDs: [UUID] = []
                 for id in ids {
                     guard let workspace = state.workspaces[id: id] else { continue }
                     panesToDestroy.append(contentsOf: workspace.layout.allPaneIDs)
                     panesToDestroy.append(contentsOf: workspace.parkedPanes.map(\.id))
-                    liveGraftAssocIDs.append(contentsOf: workspace.repoAssociations
-                        .map(\.id)
-                        .filter { state.graft.sessions[id: $0] != nil })
+                    graftAssocIDs.append(contentsOf: workspace.repoAssociations.map(\.id))
                     state.workspaces.remove(id: id)
                 }
                 let removedSet = Set(ids)
@@ -1588,7 +1635,7 @@ struct AppReducer {
 
                 let paneIDs = panesToDestroy
                 let deletedWorkspaceIDs = ids
-                let graftStopEffects = liveGraftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
+                let graftStopEffects = graftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
                 let mgr = surfaceManager
                 return .merge(
                     [
@@ -1804,18 +1851,17 @@ struct AppReducer {
                     // Drop each child workspace. Mirrors `deleteWorkspace` so
                     // surfaces are destroyed and downstream state stays clean.
                     var paneIDs: [UUID] = []
-                    // Capture associations with live graft sessions
-                    // BEFORE removal so we can issue `forceStop` for
-                    // each — otherwise grafts on child workspaces
-                    // keep running with no way to stop them.
-                    var liveGraftAssocIDs: [UUID] = []
+                    // Capture association ids BEFORE removal so we can
+                    // `forceStop` each — unconditionally, since
+                    // filtering by the reducer's session mirror used
+                    // to skip live service sessions the mirror lost
+                    // track of (#231).
+                    var graftAssocIDs: [UUID] = []
                     for wsID in childIDs {
                         guard let workspace = state.workspaces[id: wsID] else { continue }
                         paneIDs.append(contentsOf: workspace.layout.allPaneIDs)
                         paneIDs.append(contentsOf: workspace.parkedPanes.map(\.id))
-                        liveGraftAssocIDs.append(contentsOf: workspace.repoAssociations
-                            .map(\.id)
-                            .filter { state.graft.sessions[id: $0] != nil })
+                        graftAssocIDs.append(contentsOf: workspace.repoAssociations.map(\.id))
                         state.workspaces.remove(id: wsID)
                     }
                     let removedSet = Set(childIDs)
@@ -1839,7 +1885,7 @@ struct AppReducer {
 
                     let captured = paneIDs
                     let cascadedWorkspaceIDs = childIDs
-                    let graftStopEffects = liveGraftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
+                    let graftStopEffects = graftAssocIDs.map { Effect.send(Action.graft(.forceStop($0))) }
                     let mgr = surfaceManager
                     return .merge(
                         [

--- a/Nex/Features/Graft/GraftFeature.swift
+++ b/Nex/Features/Graft/GraftFeature.swift
@@ -37,6 +37,12 @@ struct GraftFeature {
         /// swap prompt) from a generic error (which surfaces in the
         /// per-association tooltip / red dot).
         case startFailed(association: RepoAssociation, failure: GraftStartFailure)
+        /// The service reported an active session for a contested
+        /// parent root that reducer state had lost track of (an
+        /// orphan — e.g. the owning workspace was deleted). Re-adopts
+        /// the session into state and presents the swap prompt so the
+        /// user has a working stop-and-swap path.
+        case alreadyActiveOwnerFound(association: RepoAssociation, existing: GraftSession)
         case stopSucceeded(UUID)
         case stopFailed(UUID, error: String)
         case sessionEvent(GraftSessionEvent)
@@ -80,13 +86,32 @@ struct GraftFeature {
 
             case .toggleGraft(let association):
                 if let existing = state.sessions[id: association.id] {
-                    // A session in `.error` state never owns live
-                    // resources — it's just the error tooltip from
-                    // the last failed attempt. Toggle becomes "retry":
-                    // drop the error session and re-run start.
+                    // An `.error` session is either a start-failure
+                    // placeholder (owns nothing) or a LIVE session
+                    // that failed a sync — the latter still owns the
+                    // watcher, the parent-root claim, and the
+                    // breadcrumb (issue #231). Toggle becomes "retry":
+                    // unwind whatever the service still holds first
+                    // (a no-op for placeholders), then re-run start.
+                    // If the unwind fails, do NOT retry-start — a
+                    // fresh start would overwrite the recovery
+                    // breadcrumb and orphan the user's stash.
                     if case .error = existing.status {
                         state.sessions.remove(id: association.id)
-                        return .send(.toggleGraft(association))
+                        return .run { send in
+                            do {
+                                try await graftService.stop(association.id)
+                            } catch {
+                                await send(.startFailed(
+                                    association: association,
+                                    failure: .other(message:
+                                        "Couldn't unwind the previous graft: \(error). " +
+                                            "Resolve the repo state, then toggle to retry.")
+                                ))
+                                return
+                            }
+                            await send(.toggleGraft(association))
+                        }
                     }
                     return .run { send in
                         do {
@@ -128,15 +153,17 @@ struct GraftFeature {
                 }
 
             case .forceStop(let assocID):
-                guard let existing = state.sessions[id: assocID] else { return .none }
-                // A session in `.error` state never owns live
-                // resources — just drop the placeholder. Unlike
-                // `toggleGraft`, we never retry-start (the caller is
-                // a removal path; the association no longer exists).
-                if case .error = existing.status {
-                    state.sessions.remove(id: assocID)
-                    return .none
-                }
+                // Always tear down via the service — even when reducer
+                // state has no session (or only an `.error` one) for
+                // this id. A session that started fine and later hit a
+                // sync error still owns live resources (watcher,
+                // parent-root claim, breadcrumb); skipping the service
+                // stop for it leaked all of that when the owning
+                // workspace was deleted (issue #231). For ids the
+                // service doesn't know, stop() is a cheap no-op.
+                // Unlike `toggleGraft`, we never retry-start (the
+                // caller is a removal path; the association no longer
+                // exists).
                 return .run { send in
                     do {
                         try await graftService.stop(assocID)
@@ -171,8 +198,34 @@ struct GraftFeature {
                             existingWorktreePath: existing.worktreePath,
                             parentRepoRoot: parentRepoRoot
                         )
+                        return .none
                     }
-                    return .none
+                    // No reducer-visible owner. The service is the
+                    // source of truth — it may still hold a session
+                    // reducer state lost track of. Query it so the
+                    // user gets the swap prompt (a real recovery
+                    // lever) instead of a silently dead button
+                    // (issue #231).
+                    return .run { send in
+                        let sessions = await graftService.activeSessions()
+                        if let owner = sessions.first(where: { $0.parentRepoRoot == parentRepoRoot }) {
+                            await send(.alreadyActiveOwnerFound(
+                                association: association,
+                                existing: owner
+                            ))
+                        } else {
+                            // Nobody visibly owns the claim (e.g. a
+                            // start on the same root is mid-flight).
+                            // Surface a visible error instead of
+                            // nothing.
+                            await send(.startFailed(
+                                association: association,
+                                failure: .other(message:
+                                    "Another graft is already active for \(parentRepoRoot). " +
+                                        "Stop it first, then retry.")
+                            ))
+                        }
+                    }
                 case .other(let message):
                     // Re-insert the session in `.error` state so the
                     // tooltip / red dot persists until the user
@@ -189,6 +242,29 @@ struct GraftFeature {
                     return .none
                 }
 
+            case .alreadyActiveOwnerFound(let association, let existing):
+                // The service session IS this association — reducer
+                // state simply lost track of it. Re-adopt it and show
+                // it as active; a swap prompt would offer to swap the
+                // worktree with itself.
+                if existing.id == association.id {
+                    state.sessions[id: existing.id] = existing
+                    return .none
+                }
+                // Re-adopt the service-side session so the prompt's
+                // "existing" side is visible in the inspector and
+                // `status`, and remains stoppable if the user cancels.
+                state.sessions[id: existing.id] = existing
+                state.swapPrompt = GraftSwapPrompt(
+                    id: association.id,
+                    newAssociation: association,
+                    existingSessionID: existing.id,
+                    existingBranch: existing.branch,
+                    existingWorktreePath: existing.worktreePath,
+                    parentRepoRoot: existing.parentRepoRoot
+                )
+                return .none
+
             case .confirmSwap(let prompt):
                 state.swapPrompt = nil
                 // Optimistically show the new session as .starting so
@@ -203,7 +279,7 @@ struct GraftFeature {
                     lastSync: nil
                 ))
                 return .run { send in
-                    // Stop must complete (busyRoots released) before
+                    // Stop must complete (root claim released) before
                     // start can succeed — sequentially.
                     do {
                         try await graftService.stop(prompt.existingSessionID)

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -174,19 +174,18 @@ struct NexApp: App {
                     }
 
                     QuitGate.shared.flushGraftSessions = {
-                        // Snapshot active session IDs from the store and
-                        // call graftService.stop on each. Block (with a
+                        // Stop every session the SERVICE holds (not the
+                        // store's mirror — the mirror can lose track of
+                        // live sessions, issue #231). Block (with a
                         // 2-second cap) so the breadcrumb files are
                         // gone before the process exits. Sessions that
                         // can't stop in time fall back to the orphan
                         // recovery path on next launch.
-                        let sessionIDs = store.withState { $0.graft.sessions.ids }
-                        guard !sessionIDs.isEmpty else { return }
                         let service = GraftService.liveValue
                         let semaphore = DispatchSemaphore(value: 0)
                         Task.detached {
-                            for id in sessionIDs {
-                                try? await service.stop(id)
+                            for session in await service.activeSessions() {
+                                try? await service.stop(session.id)
                             }
                             semaphore.signal()
                         }

--- a/Nex/Services/GraftService.swift
+++ b/Nex/Services/GraftService.swift
@@ -104,10 +104,23 @@ final class GraftServiceImpl: Sendable {
     /// `read-tree --reset -u` AFTER `restoreParent` (which would
     /// re-corrupt the parent and break the stash pop).
     private nonisolated(unsafe) var activeSyncTasks: [UUID: Task<Void, Never>] = [:]
-    /// Canonicalised `parentRepoRoot` paths that currently hold a graft
-    /// session. A second association targeting the same root is rejected
-    /// with `GraftError.alreadyActive`.
-    private nonisolated(unsafe) var busyRoots: Set<String> = []
+    /// Canonicalised `parentRepoRoot` paths with a `start()` currently
+    /// mid-flight (claimed before the session exists). The busy check
+    /// derives "root is claimed" from this set PLUS the live `sessions`
+    /// values — there is no separately-maintained lock that could
+    /// outlive its session. Issue #231 was exactly that: a removal
+    /// path dropped the session without releasing the old standalone
+    /// `busyRoots` set, leaving an `alreadyActive` rejection that
+    /// neither `status` nor `stop` could see until app restart.
+    private nonisolated(unsafe) var startingRoots: Set<String> = []
+    /// In-flight `stop()` work keyed by association id. Concurrent
+    /// stops for the same id coalesce onto one task and all await its
+    /// real outcome — a second caller must neither double-run the
+    /// parent restore + stash pop (spurious conflict) nor return
+    /// "stopped" before teardown actually finished (the CLI reply and
+    /// `confirmSwap`'s stop-then-start both rely on stop-returned ⇒
+    /// teardown-done).
+    private nonisolated(unsafe) var stopTasks: [UUID: Task<Void, Error>] = [:]
     private nonisolated(unsafe) var subscribers: [UUID: AsyncStream<GraftSessionEvent>.Continuation] = [:]
 
     init(
@@ -140,23 +153,29 @@ final class GraftServiceImpl: Sendable {
             throw GraftError.notAWorktree(path: worktreePath)
         }
 
-        // Reject if the parent root is already being grafted into.
+        // Reject if the parent root is already being grafted into —
+        // by a live session (whatever its status, including `.error`)
+        // or another start() that's mid-flight. Deriving the check
+        // from `sessions` means whatever holds the claim is always
+        // visible via `activeSessions()` and releasable via `stop()`.
         try lock.withLock {
-            if busyRoots.contains(parentRepoRoot) {
+            let claimed = startingRoots.contains(parentRepoRoot)
+                || sessions.values.contains { $0.parentRepoRoot == parentRepoRoot }
+            if claimed {
                 throw GraftError.alreadyActive(parentRepoRoot: parentRepoRoot)
             }
-            busyRoots.insert(parentRepoRoot)
+            startingRoots.insert(parentRepoRoot)
         }
 
         let state: RepoState
         do {
             state = try await gitService.repoState(parentRepoRoot)
         } catch {
-            releaseBusy(parentRepoRoot)
+            releaseStarting(parentRepoRoot)
             throw error
         }
         guard state == .clean else {
-            releaseBusy(parentRepoRoot)
+            releaseStarting(parentRepoRoot)
             throw GraftError.repoBusy(state: describe(state))
         }
 
@@ -172,7 +191,7 @@ final class GraftServiceImpl: Sendable {
             preGraftBranch = try await gitService.getCurrentBranch(parentRepoRoot)
             preGraftSha = try await gitService.getHeadSha(parentRepoRoot)
         } catch {
-            releaseBusy(parentRepoRoot)
+            releaseStarting(parentRepoRoot)
             throw error
         }
 
@@ -190,11 +209,11 @@ final class GraftServiceImpl: Sendable {
                 )
             }
         } catch {
-            releaseBusy(parentRepoRoot)
+            releaseStarting(parentRepoRoot)
             throw error
         }
 
-        /// Helper that undoes the stash + busyRoots side-effects when
+        /// Helper that undoes the stash + startingRoots side-effects when
         /// a later step in `start` throws. Without it, a failed
         /// initial sync would leave the user's stash on disk with no
         /// recovery breadcrumb and no in-memory session — and a
@@ -226,7 +245,7 @@ final class GraftServiceImpl: Sendable {
                     )
                 }
             }
-            releaseBusy(parentRepoRoot)
+            releaseStarting(parentRepoRoot)
             return originalError
         }
 
@@ -304,7 +323,14 @@ final class GraftServiceImpl: Sendable {
             worktreePreGraftSha: worktreePreGraftSha
         )
 
-        lock.withLock { sessions[association.id] = initialSession }
+        // Atomically publish the session and drop the mid-start claim —
+        // the root's busy claim transfers from `startingRoots` to the
+        // session itself with no gap a concurrent start could slip
+        // through.
+        lock.withLock {
+            sessions[association.id] = initialSession
+            _ = startingRoots.remove(parentRepoRoot)
+        }
         publish(.started(initialSession))
 
         // Spawn the watcher loop. Cancelling the task tears the
@@ -314,50 +340,62 @@ final class GraftServiceImpl: Sendable {
             rootPath: worktreePath,
             debounce: debounce
         )
-        let task = Task { [weak self] in
-            for await batch in watchStream {
-                guard let self else { return }
-                // Spawn each batch handler as its own Task and record
-                // it so `stop()` can await the current sync before
-                // tearing down. Without this, a sync pass already
-                // inside its `read-tree` call survives stop's watcher
-                // cancellation and re-applies the worktree's tree
-                // AFTER the parent has been restored, leaving the
-                // parent dirty and breaking the stash pop.
-                //
-                // The spawn + register MUST happen atomically under
-                // the lock, AND we must verify the watcher entry is
-                // still live AFTER the lock. Otherwise `stop()` can
-                // slip in between batch arrival and registration:
-                //   1. batch arrives, watcher about to spawn syncTask
-                //   2. stop() removes our watcherTask, reads empty
-                //      activeSyncTasks, proceeds to restoreParent
-                //   3. watcher finally spawns syncTask → read-tree
-                //      lands AFTER restore and corrupts the parent.
-                // Guarding on `watcherTasks[assocID] != nil` inside
-                // the same lock closes the race: stop's first lock
-                // (`watcherTasks.removeValue`) and our spawn-or-abort
-                // check are now totally ordered.
-                let assocID = association.id
-                let syncTask: Task<Void, Never>? = lock.withLock {
-                    guard watcherTasks[assocID] != nil else { return nil }
-                    let task = Task { [weak self] in
-                        guard let self else { return }
-                        await handleBatch(associationID: assocID, batch: batch)
+        // Create AND register the watcher task under one lock hold.
+        // The loop body's liveness guard reads `watcherTasks[assocID]`
+        // under the same lock, so a batch that arrives while we're
+        // still registering blocks until the entry exists — otherwise
+        // a fast first event could observe "not registered", bail,
+        // and permanently kill sync for a session `status` still
+        // reports as watching.
+        lock.withLock {
+            let task = Task { [weak self] in
+                for await batch in watchStream {
+                    guard let self else { return }
+                    // Spawn each batch handler as its own Task and
+                    // record it so `stop()` can await the current sync
+                    // before tearing down. Without this, a sync pass
+                    // already inside its `read-tree` call survives
+                    // stop's watcher cancellation and re-applies the
+                    // worktree's tree AFTER the parent has been
+                    // restored, leaving the parent dirty and breaking
+                    // the stash pop.
+                    //
+                    // The spawn + register MUST happen atomically
+                    // under the lock, AND we must verify the watcher
+                    // entry is still live AFTER the lock. Otherwise
+                    // `stop()` can slip in between batch arrival and
+                    // registration:
+                    //   1. batch arrives, watcher about to spawn
+                    //      syncTask
+                    //   2. stop() removes our watcherTask, reads empty
+                    //      activeSyncTasks, proceeds to restoreParent
+                    //   3. watcher finally spawns syncTask → read-tree
+                    //      lands AFTER restore and corrupts the parent.
+                    // Guarding on `watcherTasks[assocID] != nil` inside
+                    // the same lock closes the race: stop's first lock
+                    // (`watcherTasks.removeValue`) and our
+                    // spawn-or-abort check are now totally ordered.
+                    let assocID = association.id
+                    let syncTask: Task<Void, Never>? = lock.withLock {
+                        guard watcherTasks[assocID] != nil else { return nil }
+                        let task = Task { [weak self] in
+                            guard let self else { return }
+                            await handleBatch(associationID: assocID, batch: batch)
+                        }
+                        activeSyncTasks[assocID] = task
+                        return task
                     }
-                    activeSyncTasks[assocID] = task
-                    return task
+                    guard let syncTask else { return }
+                    await syncTask.value
+                    // The watcher loop is serial — only one batch can
+                    // be in flight per session at a time. If `stop()`
+                    // already pulled the entry out (it awaits and
+                    // removes via `removeValue`), this is a no-op.
+                    lock.withLock { _ = activeSyncTasks.removeValue(forKey: assocID) }
                 }
-                guard let syncTask else { return }
-                await syncTask.value
-                // The watcher loop is serial — only one batch can be
-                // in flight per session at a time. If `stop()` already
-                // pulled the entry out (it awaits and removes via
-                // `removeValue`), this is a no-op.
-                lock.withLock { _ = activeSyncTasks.removeValue(forKey: assocID) }
             }
+            watcherTasks[association.id] = task
         }
-        lock.withLock { watcherTasks[association.id] = task }
 
         return initialSession
     }
@@ -365,14 +403,46 @@ final class GraftServiceImpl: Sendable {
     // MARK: - Stop
 
     func stop(_ associationID: UUID) async throws {
-        let session: GraftSession? = lock.withLock {
-            sessions[associationID]
+        // Coalesce concurrent stops of the same association. Removal
+        // paths send `forceStop` unconditionally and the CLI stop
+        // reads service state, so two initiators can race — the
+        // second joins the first's task and reports its real outcome.
+        let (task, isOwner): (Task<Void, Error>, Bool) = lock.withLock {
+            if let existing = stopTasks[associationID] {
+                return (existing, false)
+            }
+            let task = Task<Void, Error> { [weak self] in
+                guard let self else { return }
+                try await performStop(associationID)
+            }
+            stopTasks[associationID] = task
+            return (task, true)
         }
-        guard let session else { return }
+        defer {
+            if isOwner {
+                lock.withLock { _ = stopTasks.removeValue(forKey: associationID) }
+            }
+        }
+        try await task.value
+    }
 
+    /// The actual teardown. Only ever runs on the coalesced task —
+    /// callers go through `stop(_:)`.
+    ///
+    /// Known window: stopping an association whose `start()` is still
+    /// mid-flight (no session published yet) is a no-op here, and the
+    /// start then completes into a live session with no owning
+    /// association. That session stays visible in `activeSessions()`
+    /// and recoverable — the next start on its root offers the swap
+    /// prompt, `graft stop --repo` matches it by path, and the quit
+    /// path flushes it.
+    private func performStop(_ associationID: UUID) async throws {
         // Cancel the watcher first so a NEW sync pass can't fire
         // mid-stop. Cancellation propagates to the `for await batch
         // in watchStream` loop; the next iteration won't start.
+        // This runs BEFORE the session guard below so `stop()` is a
+        // thorough no-op cleanup even for ids the sessions dict has
+        // lost track of.
         if let task = lock.withLock({ watcherTasks.removeValue(forKey: associationID) }) {
             task.cancel()
         }
@@ -386,6 +456,11 @@ final class GraftServiceImpl: Sendable {
         if let inFlight = lock.withLock({ activeSyncTasks.removeValue(forKey: associationID) }) {
             await inFlight.value
         }
+
+        let session: GraftSession? = lock.withLock {
+            sessions[associationID]
+        }
+        guard let session else { return }
 
         // Rewind the WORKTREE's branch first so the checkpoint
         // commits disappear before the parent restore renames any
@@ -412,10 +487,9 @@ final class GraftServiceImpl: Sendable {
             // LEAVE the breadcrumb in place so the orphan-recovery
             // banner can pick this up on next launch — the user's
             // stash is still on disk and they need a UI path to it.
-            // We still release `busyRoots` and drop the in-memory
-            // session so the user can retry start() on a different
-            // worktree without colliding.
-            releaseBusy(session.parentRepoRoot)
+            // Dropping the in-memory session releases the root claim
+            // so the user can retry start() on a different worktree
+            // without colliding.
             lock.withLock { _ = sessions.removeValue(forKey: associationID) }
             publish(.stopped(associationID))
             throw error
@@ -430,7 +504,6 @@ final class GraftServiceImpl: Sendable {
                 // try again later (or inspect `git stash list`). Drop
                 // the in-memory session so the toggle reflects the
                 // detached state and the user can re-attempt later.
-                releaseBusy(session.parentRepoRoot)
                 lock.withLock { _ = sessions.removeValue(forKey: associationID) }
                 publish(.stopped(associationID))
                 throw GraftError.stashPopConflict(
@@ -441,7 +514,6 @@ final class GraftServiceImpl: Sendable {
         }
 
         removeBreadcrumb(at: session.parentRepoRoot)
-        releaseBusy(session.parentRepoRoot)
         lock.withLock { _ = sessions.removeValue(forKey: associationID) }
         publish(.stopped(associationID))
     }
@@ -659,8 +731,11 @@ final class GraftServiceImpl: Sendable {
 
     // MARK: - State helpers
 
-    private func releaseBusy(_ parentRepoRoot: String) {
-        lock.withLock { _ = busyRoots.remove(parentRepoRoot) }
+    /// Release the mid-start claim on a root after a failed `start()`.
+    /// Once a session exists, the claim lives on the session itself and
+    /// is released by removing it from `sessions` (in `stop()`).
+    private func releaseStarting(_ parentRepoRoot: String) {
+        lock.withLock { _ = startingRoots.remove(parentRepoRoot) }
     }
 
     private func mutateAndPublish(
@@ -794,7 +869,13 @@ extension GraftService: DependencyKey {
                     lastSync: nil
                 )
             ),
-            stop: unimplemented("GraftService.stop"),
+            // `stop` is deliberately a no-op (not unimplemented):
+            // removal paths dispatch `forceStop` unconditionally for
+            // every removed association (issue #231), so any test
+            // that deletes a workspace/repo would otherwise trip the
+            // unimplemented sentinel. Tests that assert stop calls
+            // override with a recording closure.
+            stop: { _ in },
             activeSessions: { [] },
             updates: { AsyncStream { _ in } },
             detectOrphans: { _ in [] },

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -537,6 +537,51 @@ struct AppReducerTests {
         }
     }
 
+    /// Issue #231 wiring lock-in: deleting a workspace dispatches a
+    /// graft `forceStop` (→ `graftService.stop`) for EVERY removed
+    /// association, even when the reducer's graft mirror has no
+    /// session for it — filtering by the mirror is how a live service
+    /// session got orphaned in the first place.
+    @Test func deleteWorkspaceStopsGraftForAssociationsWithEmptyMirror() async {
+        var ws1 = Self.makeWorkspace(id: Self.wsID1, name: "WS1", paneID: Self.paneID1)
+        let assocID = UUID(uuidString: "10000000-0000-0000-0000-0000000000AA")!
+        ws1.repoAssociations = [
+            RepoAssociation(
+                id: assocID,
+                repoID: UUID(),
+                worktreePath: "/tmp/wt",
+                branchName: "feature/x"
+            )
+        ]
+        let ws2 = Self.makeWorkspace(id: Self.wsID2, name: "WS2", paneID: Self.paneID2)
+
+        let store = makeStore(
+            workspaces: [ws1, ws2],
+            activeWorkspaceID: Self.wsID2
+        )
+        let stopRecorder = StopRecorder()
+        store.dependencies.graftService = GraftService(
+            start: { _ in
+                GraftSession(
+                    id: UUID(), worktreePath: "", parentRepoRoot: "",
+                    branch: "", status: .starting, stashRef: nil, lastSync: nil
+                )
+            },
+            stop: { id in stopRecorder.append(id) },
+            activeSessions: { [] },
+            updates: { AsyncStream { _ in } },
+            detectOrphans: { _ in [] },
+            recoverOrphan: { _ in },
+            dismissOrphan: { _ in }
+        )
+
+        await store.send(.deleteWorkspace(Self.wsID1)) { state in
+            #expect(state.workspaces[id: Self.wsID1] == nil)
+        }
+        await store.finish()
+        #expect(stopRecorder.values == [assocID])
+    }
+
     // MARK: - setActiveWorkspace
 
     @Test func setActiveWorkspaceUpdatesID() async {
@@ -2193,4 +2238,14 @@ struct AppReducerTests {
         let parked = store.state.workspaces[id: Self.wsID1]?.parkedPanes[id: parkedID]
         #expect(parked?.status == .waitingForInput)
     }
+}
+
+private final class StopRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _values: [UUID] = []
+    func append(_ id: UUID) {
+        lock.withLock { _values.append(id) }
+    }
+
+    var values: [UUID] { lock.withLock { _values } }
 }

--- a/NexTests/GraftCLIReplyTests.swift
+++ b/NexTests/GraftCLIReplyTests.swift
@@ -30,6 +30,7 @@ struct GraftCLIReplyTests {
 
     private func makeStore(
         sessions: IdentifiedArrayOf<GraftSession> = [],
+        activeSessions: @escaping @Sendable () async -> [GraftSession] = { [] },
         graftStartResult: @escaping @Sendable (RepoAssociation) async throws -> GraftSession,
         graftStopResult: @escaping @Sendable (UUID) async throws -> Void = { _ in }
     ) -> TestStoreOf<AppReducer> {
@@ -62,7 +63,7 @@ struct GraftCLIReplyTests {
             $0.graftService = GraftService(
                 start: graftStartResult,
                 stop: graftStopResult,
-                activeSessions: { [] },
+                activeSessions: activeSessions,
                 updates: { AsyncStream { _ in } },
                 detectOrphans: { _ in [] },
                 recoverOrphan: { _ in },
@@ -160,6 +161,7 @@ struct GraftCLIReplyTests {
         let session = Self.makeSession()
         let store = makeStore(
             sessions: [session],
+            activeSessions: { [session] },
             graftStartResult: { _ in session },
             graftStopResult: { _ in }
         )
@@ -183,9 +185,69 @@ struct GraftCLIReplyTests {
             .graftStop(workspace: nil, repo: nil, paneID: Self.paneID),
             reply: makeCaptureHandle(sink)
         ))
+        await store.finish()
 
         #expect(sink.payloads[0]["ok"] as? Bool == true)
         #expect((sink.payloads[0]["stopped"] as? [String])?.isEmpty == true)
+    }
+
+    /// Issue #231: a session the reducer mirror lost track of must
+    /// still be stoppable — the stop handler filters against the
+    /// SERVICE's sessions, not reducer state.
+    @Test func graftStopReachesSessionMissingFromReducerMirror() async {
+        let session = Self.makeSession()
+        let stopCalls = LockedString()
+        let store = makeStore(
+            sessions: [],
+            activeSessions: { [session] },
+            graftStartResult: { _ in session },
+            graftStopResult: { id in stopCalls.set(id.uuidString) }
+        )
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .graftStop(workspace: nil, repo: nil, paneID: Self.paneID),
+            reply: makeCaptureHandle(sink)
+        ))
+        await store.finish()
+
+        #expect(sink.payloads[0]["ok"] as? Bool == true)
+        let stopped = sink.payloads[0]["stopped"] as? [String] ?? []
+        #expect(stopped == [Self.assocID.uuidString])
+        #expect(stopCalls.value == Self.assocID.uuidString)
+    }
+
+    /// Issue #231: a session whose owning association was deleted
+    /// (workspace gone) resolves via NO workspace scope, but
+    /// `graft stop --repo <path>` must still reach it by matching the
+    /// service session's worktree path directly.
+    @Test func graftStopRepoFilterReachesOrphanWithDeletedAssociation() async {
+        let orphanID = UUID(uuidString: "70000000-0000-0000-0000-0000000000EE")!
+        let orphanSession = GraftSession(
+            id: orphanID,
+            worktreePath: "/tmp/wt-orphan",
+            parentRepoRoot: "/tmp/parent-orphan",
+            branch: "gone-branch",
+            status: .watching,
+            stashRef: nil,
+            lastSync: nil
+        )
+        let stopCalls = LockedString()
+        let store = makeStore(
+            activeSessions: { [orphanSession] },
+            graftStartResult: { _ in orphanSession },
+            graftStopResult: { id in stopCalls.set(id.uuidString) }
+        )
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .graftStop(workspace: nil, repo: "/tmp/wt-orphan", paneID: nil),
+            reply: makeCaptureHandle(sink)
+        ))
+        await store.finish()
+
+        #expect(sink.payloads[0]["ok"] as? Bool == true)
+        let stopped = sink.payloads[0]["stopped"] as? [String] ?? []
+        #expect(stopped == [orphanID.uuidString])
+        #expect(stopCalls.value == orphanID.uuidString)
     }
 
     // MARK: - graft-status
@@ -194,6 +256,7 @@ struct GraftCLIReplyTests {
         let session = Self.makeSession()
         let store = makeStore(
             sessions: [session],
+            activeSessions: { [session] },
             graftStartResult: { _ in session }
         )
         let sink = CaptureSink()
@@ -201,12 +264,36 @@ struct GraftCLIReplyTests {
             .graftStatus,
             reply: makeCaptureHandle(sink)
         ))
+        await store.finish()
 
         #expect(sink.payloads[0]["ok"] as? Bool == true)
         let sessions = sink.payloads[0]["sessions"] as? [[String: Any]] ?? []
         #expect(sessions.count == 1)
         #expect(sessions.first?["branch"] as? String == "feature/x")
         #expect(sessions.first?["status"] as? String == "watching")
+    }
+
+    /// Issue #231: `status` must report what the SERVICE holds even
+    /// when the reducer mirror is empty, so an `alreadyActive`
+    /// rejection is always explainable from the CLI.
+    @Test func graftStatusShowsSessionMissingFromReducerMirror() async {
+        let session = Self.makeSession()
+        let store = makeStore(
+            sessions: [],
+            activeSessions: { [session] },
+            graftStartResult: { _ in session }
+        )
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .graftStatus,
+            reply: makeCaptureHandle(sink)
+        ))
+        await store.finish()
+
+        #expect(sink.payloads[0]["ok"] as? Bool == true)
+        let sessions = sink.payloads[0]["sessions"] as? [[String: Any]] ?? []
+        #expect(sessions.count == 1)
+        #expect(sessions.first?["association_id"] as? String == Self.assocID.uuidString)
     }
 }
 

--- a/NexTests/GraftFeatureTests.swift
+++ b/NexTests/GraftFeatureTests.swift
@@ -313,6 +313,284 @@ struct GraftFeatureTests {
             state.orphans = [orphan]
         }
     }
+
+    // MARK: - Issue #231 regressions
+
+    @Test func forceStopOnErroredSessionCallsServiceStop() async {
+        // THE regression for issue #231: a session in `.error` status
+        // can be a LIVE session whose sync failed — it still owns the
+        // watcher, the parent-root claim, and the breadcrumb.
+        // `forceStop` (used by every removal path) must call
+        // graftService.stop for it, not just drop the reducer state.
+        var erroredSession = makeSession()
+        erroredSession.status = .error("sync failed: worktree missing")
+        var initial = GraftFeature.State()
+        initial.sessions.append(erroredSession)
+
+        let stopCalls = ConcurrentCounter()
+        let store = TestStore(initialState: initial) {
+            GraftFeature()
+        } withDependencies: {
+            $0.graftService = GraftService(
+                start: { _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
+                stop: { _ in stopCalls.increment() },
+                activeSessions: { [] },
+                updates: { AsyncStream { _ in } },
+                detectOrphans: { _ in [] },
+                recoverOrphan: { _ in },
+                dismissOrphan: { _ in }
+            )
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.forceStop(Self.assocID))
+        await store.receive(.stopSucceeded(Self.assocID)) { state in
+            state.sessions.remove(id: Self.assocID)
+        }
+        await store.finish()
+        #expect(stopCalls.value == 1)
+    }
+
+    @Test func forceStopWithoutReducerSessionStillCallsServiceStop() async {
+        // The reducer mirror can lose track of a live service session;
+        // forceStop must reach the service regardless (stop is a
+        // cheap no-op when the service doesn't know the id either).
+        let stopCalls = ConcurrentCounter()
+        let store = TestStore(initialState: GraftFeature.State()) {
+            GraftFeature()
+        } withDependencies: {
+            $0.graftService = GraftService(
+                start: { _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
+                stop: { _ in stopCalls.increment() },
+                activeSessions: { [] },
+                updates: { AsyncStream { _ in } },
+                detectOrphans: { _ in [] },
+                recoverOrphan: { _ in },
+                dismissOrphan: { _ in }
+            )
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.forceStop(Self.assocID))
+        await store.receive(.stopSucceeded(Self.assocID))
+        await store.finish()
+        #expect(stopCalls.value == 1)
+    }
+
+    @Test func toggleOnErroredSessionStopsBeforeRestarting() async {
+        // Retry on an errored session must unwind the service first
+        // (release the root claim) or the restart self-collides with
+        // its own `alreadyActive`.
+        var erroredSession = makeSession()
+        erroredSession.status = .error("sync failed")
+        var initial = GraftFeature.State()
+        initial.sessions.append(erroredSession)
+
+        let ordering = LockedArray()
+        let restarted = makeSession()
+        let store = TestStore(initialState: initial) {
+            GraftFeature()
+        } withDependencies: {
+            $0.graftService = GraftService(
+                start: { assoc in
+                    ordering.append("start:\(assoc.id.uuidString)")
+                    return restarted
+                },
+                stop: { id in
+                    ordering.append("stop:\(id.uuidString)")
+                },
+                activeSessions: { [] },
+                updates: { AsyncStream { _ in } },
+                detectOrphans: { _ in [] },
+                recoverOrphan: { _ in },
+                dismissOrphan: { _ in }
+            )
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        await store.send(.toggleGraft(makeAssociation())) { state in
+            state.sessions.remove(id: Self.assocID)
+        }
+        await store.receive(.startSucceeded(restarted)) { state in
+            state.sessions[id: Self.assocID] = restarted
+        }
+        await store.finish()
+
+        #expect(ordering.snapshot.first?.hasPrefix("stop:") == true)
+        #expect(ordering.snapshot.last?.hasPrefix("start:") == true)
+    }
+
+    @Test func toggleOnErroredSessionAbortsRetryWhenStopFails() async {
+        // If the unwind fails, the recovery breadcrumb (and any
+        // stash) is still on disk — retry-starting would overwrite
+        // it. The retry must abort with a visible error instead.
+        var erroredSession = makeSession()
+        erroredSession.status = .error("sync failed")
+        var initial = GraftFeature.State()
+        initial.sessions.append(erroredSession)
+
+        let startCalls = ConcurrentCounter()
+        let store = TestStore(initialState: initial) {
+            GraftFeature()
+        } withDependencies: {
+            $0.graftService = GraftService(
+                start: { _ in
+                    startCalls.increment()
+                    return .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil)
+                },
+                stop: { _ in throw GraftError.unknown("restore failed") },
+                activeSessions: { [] },
+                updates: { AsyncStream { _ in } },
+                detectOrphans: { _ in [] },
+                recoverOrphan: { _ in },
+                dismissOrphan: { _ in }
+            )
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        let assoc = makeAssociation()
+        await store.send(.toggleGraft(assoc)) { state in
+            state.sessions.remove(id: Self.assocID)
+        }
+        await store.receive(\.startFailed)
+        await store.finish()
+
+        // A visible `.error` session is re-inserted; start never ran.
+        #expect(startCalls.value == 0)
+        let reinserted = store.state.sessions[id: Self.assocID]
+        if case .error(let message)? = reinserted?.status {
+            #expect(message.contains("Couldn't unwind"))
+        } else {
+            Issue.record("expected a visible .error session, got \(String(describing: reinserted))")
+        }
+    }
+
+    @Test func alreadyActiveWithOrphanedServiceSessionPresentsSwapPrompt() async {
+        // The silent-button fix: reducer state has NO session for the
+        // contested root, but the service still holds one (the #231
+        // orphan). The reducer must query the service, re-adopt the
+        // session, and present the swap prompt instead of doing
+        // nothing.
+        let orphanID = UUID(uuidString: "00000000-0000-0000-0000-00000000D001")!
+        let orphanSession = GraftSession(
+            id: orphanID,
+            worktreePath: "/tmp/wt-orphan",
+            parentRepoRoot: "/tmp/repo",
+            branch: "orphan-branch",
+            status: .watching,
+            stashRef: nil,
+            lastSync: nil
+        )
+        let store = TestStore(initialState: GraftFeature.State()) {
+            GraftFeature()
+        } withDependencies: {
+            $0.graftService = GraftService(
+                start: { _ in
+                    throw GraftError.alreadyActive(parentRepoRoot: "/tmp/repo")
+                },
+                stop: { _ in },
+                activeSessions: { [orphanSession] },
+                updates: { AsyncStream { _ in } },
+                detectOrphans: { _ in [] },
+                recoverOrphan: { _ in },
+                dismissOrphan: { _ in }
+            )
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        let newAssoc = makeAssociation()
+        await store.send(.toggleGraft(newAssoc))
+        await store.receive(.alreadyActiveOwnerFound(
+            association: newAssoc,
+            existing: orphanSession
+        )) { state in
+            state.sessions[id: orphanID] = orphanSession
+            state.swapPrompt = GraftSwapPrompt(
+                id: newAssoc.id,
+                newAssociation: newAssoc,
+                existingSessionID: orphanID,
+                existingBranch: "orphan-branch",
+                existingWorktreePath: "/tmp/wt-orphan",
+                parentRepoRoot: "/tmp/repo"
+            )
+        }
+    }
+
+    @Test func alreadyActiveWithSameAssociationReadoptsWithoutPrompt() async {
+        // The service session belongs to the SAME association the
+        // user toggled — reducer state just lost track of it. That
+        // must repair state (session re-adopted, shown active), not
+        // offer to swap a worktree with itself.
+        let orphanSession = makeSession()
+        let store = TestStore(initialState: GraftFeature.State()) {
+            GraftFeature()
+        } withDependencies: {
+            $0.graftService = GraftService(
+                start: { _ in
+                    throw GraftError.alreadyActive(parentRepoRoot: "/tmp/repo")
+                },
+                stop: { _ in },
+                activeSessions: { [orphanSession] },
+                updates: { AsyncStream { _ in } },
+                detectOrphans: { _ in [] },
+                recoverOrphan: { _ in },
+                dismissOrphan: { _ in }
+            )
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        let assoc = makeAssociation()
+        await store.send(.toggleGraft(assoc))
+        await store.receive(.alreadyActiveOwnerFound(
+            association: assoc,
+            existing: orphanSession
+        )) { state in
+            state.sessions[id: Self.assocID] = orphanSession
+        }
+        await store.finish()
+        #expect(store.state.swapPrompt == nil)
+    }
+
+    @Test func alreadyActiveWithNoVisibleOwnerSurfacesError() async {
+        // Nobody visibly owns the claim (e.g. a mid-flight start on
+        // the same root). The button must not fail silently — a
+        // visible `.error` session is inserted. Its parentRepoRoot
+        // stays empty so it can never satisfy a future swap-prompt
+        // lookup (no phantom-prompt loop).
+        let store = TestStore(initialState: GraftFeature.State()) {
+            GraftFeature()
+        } withDependencies: {
+            $0.graftService = GraftService(
+                start: { _ in
+                    throw GraftError.alreadyActive(parentRepoRoot: "/tmp/repo")
+                },
+                stop: { _ in },
+                activeSessions: { [] },
+                updates: { AsyncStream { _ in } },
+                detectOrphans: { _ in [] },
+                recoverOrphan: { _ in },
+                dismissOrphan: { _ in }
+            )
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        let newAssoc = makeAssociation()
+        await store.send(.toggleGraft(newAssoc))
+        // First the alreadyActive failure, then the follow-up .other
+        // failure emitted after the service query finds no owner.
+        await store.receive(\.startFailed)
+        await store.receive(\.startFailed)
+        await store.finish()
+
+        let inserted = store.state.sessions[id: newAssoc.id]
+        #expect(inserted?.parentRepoRoot == "")
+        if case .error(let message)? = inserted?.status {
+            #expect(message.contains("already active"))
+        } else {
+            Issue.record("expected a visible .error session, got \(String(describing: inserted))")
+        }
+        #expect(store.state.swapPrompt == nil)
+    }
 }
 
 private final class ConcurrentCounter: @unchecked Sendable {

--- a/NexTests/GraftServiceTests.swift
+++ b/NexTests/GraftServiceTests.swift
@@ -237,6 +237,157 @@ struct GraftServiceTests {
         try await impl.stop(env.association.id)
     }
 
+    /// Heart of issue #231 at the service level: a live session whose
+    /// sync failed (worktree deleted) still holds the parent-root
+    /// claim — a second start must be rejected — but the claim is
+    /// derived from the session itself, so `stop` releases it and a
+    /// retry succeeds. Under the old standalone `busyRoots` set, a
+    /// removal path that skipped `stop` left the claim held forever.
+    @Test func erroredSessionBlocksSecondStartUntilStopped() async throws {
+        let env = try makeRepoEnv()
+        defer { env.cleanup() }
+        let secondWorktree = try addSiblingWorktree(parent: env.parent, name: "feature-2")
+        let secondAssoc = RepoAssociation(
+            id: UUID(),
+            repoID: UUID(),
+            worktreePath: secondWorktree,
+            branchName: "feature-2"
+        )
+        let watcher = RecursiveFSWatcher(backend: .test)
+        let impl = GraftServiceImpl(gitService: .live, watcher: watcher)
+
+        _ = try await impl.start(env.association)
+
+        // Delete the worktree out from under the session, then poke
+        // the watcher — the sync pass fails with `missingWorktree`
+        // and the session flips to `.error` while staying live.
+        try FileManager.default.removeItem(atPath: env.worktree)
+        watcher.inject(
+            [(env.worktree as NSString).appendingPathComponent("gone.txt")],
+            into: env.worktree
+        )
+        try await pollUntilAsync(timeout: .seconds(5)) {
+            let sessions = await impl.activeSessions()
+            if case .error = sessions.first(where: { $0.id == env.association.id })?.status {
+                return true
+            }
+            return false
+        }
+
+        // The errored session still owns the parent root.
+        do {
+            _ = try await impl.start(secondAssoc)
+            Issue.record("expected GraftError.alreadyActive")
+        } catch let error as GraftError {
+            if case .alreadyActive = error {
+                // ok
+            } else {
+                Issue.record("unexpected error: \(error)")
+            }
+        }
+
+        // Stopping the errored session releases the claim...
+        try await impl.stop(env.association.id)
+        let after = await impl.activeSessions()
+        #expect(after.isEmpty)
+
+        // ...so the retry on the same parent root now succeeds.
+        let session = try await impl.start(secondAssoc)
+        #expect(session.parentRepoRoot.hasSuffix((env.parent as NSString).lastPathComponent))
+        try await impl.stop(secondAssoc.id)
+    }
+
+    /// A start that fails (parent mid-merge) must release the
+    /// mid-start root claim so a later attempt isn't rejected with a
+    /// phantom `alreadyActive`.
+    @Test func failedStartReleasesRootClaimForRetry() async throws {
+        let env = try makeRepoEnv()
+        defer { env.cleanup() }
+        let impl = GraftServiceImpl(
+            gitService: .live,
+            watcher: RecursiveFSWatcher(backend: .test)
+        )
+
+        // Fake an in-progress merge in the parent.
+        let headSha = try shell("git", ["rev-parse", "HEAD"], at: env.parent)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let mergeHead = (env.parent as NSString)
+            .appendingPathComponent(".git/MERGE_HEAD")
+        try headSha.write(toFile: mergeHead, atomically: true, encoding: .utf8)
+
+        do {
+            _ = try await impl.start(env.association)
+            Issue.record("expected GraftError.repoBusy")
+        } catch let error as GraftError {
+            if case .repoBusy = error {
+                // ok
+            } else {
+                Issue.record("unexpected error: \(error)")
+            }
+        }
+
+        // Clear the merge state; the retry must not hit alreadyActive.
+        try FileManager.default.removeItem(atPath: mergeHead)
+        _ = try await impl.start(env.association)
+        try await impl.stop(env.association.id)
+    }
+
+    /// Concurrent stops of the same session coalesce onto one
+    /// teardown: both callers succeed, the stash pops exactly once,
+    /// and neither returns before the teardown finished.
+    @Test func concurrentStopsCoalesceAndPopStashOnce() async throws {
+        let env = try makeRepoEnv()
+        defer { env.cleanup() }
+        // Dirty the parent so a stash exists — a double-run of the
+        // stop sequence would pop twice and the second would throw a
+        // spurious stashPopConflict.
+        let dirty = (env.parent as NSString).appendingPathComponent("dirty.txt")
+        try "dirty contents".write(toFile: dirty, atomically: true, encoding: .utf8)
+        let impl = GraftServiceImpl(
+            gitService: .live,
+            watcher: RecursiveFSWatcher(backend: .test)
+        )
+        _ = try await impl.start(env.association)
+
+        let assocID = env.association.id
+        async let first: Void = impl.stop(assocID)
+        async let second: Void = impl.stop(assocID)
+        try await first
+        try await second
+
+        let stashList = try shell("git", ["stash", "list"], at: env.parent)
+        #expect(!stashList.contains("nex-graft"))
+        let restored = try String(contentsOfFile: dirty)
+        #expect(restored == "dirty contents")
+        let breadcrumbPath = (env.parent as NSString)
+            .appendingPathComponent(".git/\(GraftServiceImpl.breadcrumbName)")
+        #expect(!FileManager.default.fileExists(atPath: breadcrumbPath))
+        let after = await impl.activeSessions()
+        #expect(after.isEmpty)
+    }
+
+    /// `stop` for an id the service doesn't know is a silent no-op:
+    /// no throw, no published `.stopped` event (so reducer mirrors
+    /// are never perturbed by stops of start-failure placeholders).
+    @Test func stopUnknownAssociationIsSilentNoOp() async throws {
+        let impl = GraftServiceImpl(
+            gitService: .live,
+            watcher: RecursiveFSWatcher(backend: .test)
+        )
+        let events = LockedEventCount()
+        let stream = impl.updates()
+        let listener = Task {
+            for await _ in stream {
+                events.increment()
+            }
+        }
+
+        try await impl.stop(UUID())
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(events.value == 0)
+        listener.cancel()
+    }
+
     @Test func detectOrphansReturnsPreseededBreadcrumb() async throws {
         let env = try makeRepoEnv()
         defer { env.cleanup() }
@@ -397,6 +548,21 @@ struct GraftServiceTests {
         return try JSONDecoder().decode(DecodedBreadcrumb.self, from: data)
     }
 
+    private func pollUntilAsync(
+        timeout: Duration,
+        _ predicate: @escaping () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock().now.advanced(by: timeout)
+        while ContinuousClock().now < deadline {
+            if await predicate() { return }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        throw NSError(
+            domain: "GraftTestShell", code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "poll timed out"]
+        )
+    }
+
     private func pollUntil(
         timeout: Duration,
         _ predicate: @escaping () -> Bool
@@ -411,4 +577,14 @@ struct GraftServiceTests {
             userInfo: [NSLocalizedDescriptionKey: "poll timed out"]
         )
     }
+}
+
+private final class LockedEventCount: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+    func increment() {
+        lock.withLock { _value += 1 }
+    }
+
+    var value: Int { lock.withLock { _value } }
 }


### PR DESCRIPTION
## Summary
- Deleting a workspace that owned a graft whose session had hit a sync error leaked the service's in-memory `busyRoots` lock forever: `forceStop`/`toggleGraft` treated every `.error` session as resourceless and skipped `graftService.stop`, while `status`/`stop` read the (now empty) reducer mirror. Every later `graft start` failed with `alreadyActive` until app restart, and the graft button failed silently.
- The root-busy check is now derived from live sessions plus in-flight starts, so a lock structurally cannot outlive its session; `forceStop` always calls the service (all six removal paths unconditionally); concurrent stops coalesce onto one task whose real outcome every caller awaits; the CLI `graft status`/`graft stop` and the quit path read `graftService.activeSessions()` instead of the reducer mirror, and `stop --repo` matches orphaned sessions by path.
- The silent button is fixed: an `alreadyActive` rejection with no reducer-visible owner queries the service and either re-adopts the same association's session, presents the swap prompt built from the service session, or surfaces a visible error session.

Closes #231

## Reviewer notes
Two review passes ran (fresh Claude session + Codex). Applied from review: the watcher-task registration race (create+register now atomic under the lock), coalesced concurrent stops (was: second stop returned success early), same-association re-adoption instead of a self-swap prompt, and the `stop --repo` orphan fallback. Acknowledged but deferred:
- `graft status` no longer shows reducer-only `.starting`/`.error` placeholder entries (service is the source of truth; failed-start errors remain visible in the GUI tooltip).
- Pre-existing narrow window: a `stop()` landing between session publish and watcher registration leaves an inert watcher-task entry; and deleting a workspace while its graft `start()` is mid-flight still yields a session with no owning association - now visible in `status`, stoppable via `stop --repo` and the swap prompt, no longer a permanent lock. Worth a follow-up issue.
- `GraftService.testValue.stop` is now a no-op rather than `unimplemented` because removal paths legitimately dispatch stop unconditionally.

## Validation
- Validated in a sandboxed macOS VM via cua/lume (VM `lunar-uakari`, build from this branch).
- Per-issue assertions (all passed):
  - TEST1: `graft start` on a worktree workspace succeeds and `status` shows a watching session.
  - TEST2: session driven into `.error` (fake merge in parent + sync trigger), visible in `status`.
  - TEST3 (the #231 repro): deleting the owning workspace tears the errored session down (`status` drains to `[]`) and `graft start` on a second worktree of the same parent succeeds - pre-fix this was a permanent `alreadyActive` lockout.
  - TEST4: `graft stop` releases everything; `status` returns `[]`.
- Screenshots: `/Users/ben/code/cua/out/branches/issue-231-graft-orphaned-lock/issue-231/`
- `make check` green (1373 tests). New unit coverage: service-level (errored session blocks second start until stopped, failed start releases the root claim, unknown-id stop publishes nothing, concurrent stops coalesce and pop the stash once), feature-level (forceStop on errored/missing sessions calls the service, errored-toggle stops-then-restarts and aborts visibly on stop failure, alreadyActive fallbacks incl. same-id re-adoption), CLI-level (status/stop read service truth, `--repo` reaches a deleted-association orphan), and an AppReducer test pinning the unconditional forceStop dispatch on workspace delete.

## Test plan
- [x] Graft a worktree workspace via the inspector button; confirm the icon flips and a second toggle stops it cleanly.
- [x] Force a sync error (create `.git/MERGE_HEAD` in the parent, touch a worktree file), delete the owning workspace (or cascade-delete its group), then graft another worktree of the same repo - must succeed with no restart.
- [x] With one graft active, toggle graft on a second worktree of the same repo - swap prompt appears; confirm swaps, cancel keeps the original running.
- [x] `nex graft status --json` / `nex graft stop --workspace <ws>` / `nex graft stop --repo <path>` round-trip against the GUI state.
- [x] Quit Nex with a graft active - breadcrumb (`.git/nex-graft-active`) is cleaned up and the parent repo is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk1DHCt57q1GZ8bctg7WmE