### PR TITLE
feat(#145): web pane full capture matrix + streaming console

### DIFF
--- a/Nex.xcodeproj/project.pbxproj
+++ b/Nex.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		DE4BB209669A230B465E2722 /* WorkspaceFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA19A5A6562DDB77C0AE44B6 /* WorkspaceFeatureTests.swift */; };
 		E02D1D3DE36CC8F66B5072AB /* GroupIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C5539104EFEFA5CCB936F1 /* GroupIcon.swift */; };
 		E0ABD2D68012C6BF24A92E7D /* KeybindingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D45D65A66C475B0CEEC53C /* KeybindingService.swift */; };
+		E14AC1E8FAC75B11E65DE35C /* WebConsoleStreamingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C38C6C3BF0FC9672488731 /* WebConsoleStreamingTests.swift */; };
 		E19F4E0C87CB85D959F0C8F2 /* GitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB94C2B6250E68349B287AF7 /* GitStatus.swift */; };
 		E31F1B84CF270603EF2B93E0 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523DE37561222E411737C3F8 /* SettingsView.swift */; };
 		E56B0EC49D7AC553B5CDC2CC /* MarkdownPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02A888F436610636F5A4D55 /* MarkdownPaneView.swift */; };
@@ -242,6 +243,7 @@
 		0F0461B8E2ED8F50BA8AF0DF /* ChromeIndicatorRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeIndicatorRefreshTests.swift; sourceTree = "<group>"; };
 		110ABCD54BF803110E5F5060 /* GraftInspectorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraftInspectorButton.swift; sourceTree = "<group>"; };
 		110D5179A9834B4AB19B705B /* StatusBarPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarPopoverView.swift; sourceTree = "<group>"; };
+		11C38C6C3BF0FC9672488731 /* WebConsoleStreamingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebConsoleStreamingTests.swift; sourceTree = "<group>"; };
 		11C5539104EFEFA5CCB936F1 /* GroupIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupIcon.swift; sourceTree = "<group>"; };
 		11CBC99B6D8094F73CDFBD80 /* WorktreeOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeOperationTests.swift; sourceTree = "<group>"; };
 		12DB8491263633C87CA73D00 /* WebPaneActuatorWaitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPaneActuatorWaitTests.swift; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 				1F2EE712AF1A36900D281E8B /* SurfaceViewKeyboardTests.swift */,
 				09D2D521EEDB4FE47843C382 /* SyncInputTests.swift */,
 				DEA151EED6939BCA9792BBF1 /* TitlebarDoubleClickActionTests.swift */,
+				11C38C6C3BF0FC9672488731 /* WebConsoleStreamingTests.swift */,
 				9AA64A9054515A57ED6B2ECA /* WebPaneActuatorActionTests.swift */,
 				9F338E618A147E5BAAFF5FE5 /* WebPaneActuatorSelectorTests.swift */,
 				12DB8491263633C87CA73D00 /* WebPaneActuatorWaitTests.swift */,
@@ -1048,6 +1051,7 @@
 				EF4258CFC52EB748609C7F18 /* SurfaceViewKeyboardTests.swift in Sources */,
 				ECC9AA8342DF3710795427C7 /* SyncInputTests.swift in Sources */,
 				C0741544E700ECB9D719CB64 /* TitlebarDoubleClickActionTests.swift in Sources */,
+				E14AC1E8FAC75B11E65DE35C /* WebConsoleStreamingTests.swift in Sources */,
 				04A463E95398A50F5AD5AA2B /* WebPaneActuatorActionTests.swift in Sources */,
 				E5D6BDD247E0BE03F097B4A2 /* WebPaneActuatorSelectorTests.swift in Sources */,
 				B0FA5E756635F6DFC402CD7C /* WebPaneActuatorWaitTests.swift in Sources */,

--- a/Nex/AppReducer+Socket.swift
+++ b/Nex/AppReducer+Socket.swift
@@ -604,6 +604,17 @@ extension AppReducer {
                 case .ping:
                     return handlePing(reply: reply)
 
+                case .socketSubscriberDisconnected(let replyID):
+                    // Fires for every dropped reply handle, not just
+                    // streaming ones — a miss here (the common case,
+                    // any ordinary request/response call) is just a
+                    // no-op dictionary removal.
+                    for paneID in state.webConsoleSubscribers.keys {
+                        state.webConsoleSubscribers[paneID]?.removeValue(forKey: replyID)
+                    }
+                    state.webConsoleSubscribers = state.webConsoleSubscribers.filter { !$0.value.isEmpty }
+                    return .none
+
                 case .webOpen(let paneID, let url, let isPrivate):
                     return handleWebOpen(
                         state: state,
@@ -692,13 +703,14 @@ extension AppReducer {
                         reply: reply
                     )
 
-                case .webConsole(let paneID, let target, let workspaceFilter, let since, let level, let clear):
+                case .webConsole(let paneID, let target, let workspaceFilter, let since, let level, let clear, let follow):
                     return handleWebConsole(
-                        state: state,
+                        &state,
                         scope: WebPaneScope(paneID: paneID, target: target, workspaceFilter: workspaceFilter),
                         since: since,
                         level: level,
                         clear: clear,
+                        follow: follow,
                         reply: reply
                     )
 

--- a/Nex/AppReducer+WebPane.swift
+++ b/Nex/AppReducer+WebPane.swift
@@ -661,7 +661,7 @@ extension AppReducer {
         }
 
         guard let captureMode = WebCaptureMode(rawValue: mode) else {
-            reply?.error("unknown capture mode '\(mode)' (allowed: meta, text, screenshot)")
+            reply?.error("unknown capture mode '\(mode)' (allowed: meta, text, screenshot, dom, all)")
             return .none
         }
 
@@ -677,9 +677,11 @@ extension AppReducer {
         let isPrivate = resolved.webState.isPrivate
 
         return .run { _ in
+            let coordinator = await MainActor.run {
+                store.coordinator(for: resolvedPaneID, isPrivate: isPrivate)
+            }
             let snapshot: (url: String, title: String) = await MainActor.run {
-                store.coordinator(for: resolvedPaneID, isPrivate: isPrivate).currentURLAndTitle(tabID: tabID)
-                    ?? (tabURL, tabTitle)
+                coordinator.currentURLAndTitle(tabID: tabID) ?? (tabURL, tabTitle)
             }
             var payload: [String: Any] = [
                 "ok": true,
@@ -689,39 +691,62 @@ extension AppReducer {
                 "title": snapshot.title,
                 "mode": captureMode.rawValue
             ]
+
+            /// Shared inline/spill-to-disk screenshot logic used by
+            /// both `.screenshot` (top-level `byte_count`) and `.all`
+            /// (namespaced `screenshot_byte_count`, alongside the
+            /// other modes' fields in the same composite payload).
+            func captureScreenshot(byteCountKey: String) async {
+                let pngData = await coordinator.captureScreenshot(tabID: tabID)
+                guard let pngData else {
+                    payload["screenshot_error"] = "screenshot capture failed"
+                    return
+                }
+                let inlineThreshold = 1_000_000 // 1 MB
+                if pngData.count <= inlineThreshold {
+                    payload["png_base64"] = pngData.base64EncodedString()
+                    payload[byteCountKey] = pngData.count
+                } else {
+                    // Per-app temporary directory — OS prunes it
+                    // automatically (vs. `/tmp` where files lingered
+                    // until reboot).
+                    let ts = Int(Date().timeIntervalSince1970)
+                    let url = FileManager.default.temporaryDirectory
+                        .appendingPathComponent("nex-web-capture-\(resolvedPaneID.uuidString)-\(ts).png")
+                    if (try? pngData.write(to: url)) != nil {
+                        payload["path"] = url.path
+                        payload[byteCountKey] = pngData.count
+                    } else {
+                        payload["screenshot_error"] = "failed to write screenshot to \(url.path)"
+                    }
+                }
+            }
+
             switch captureMode {
             case .meta:
                 break
             case .text:
-                let text = await store.coordinator(for: resolvedPaneID, isPrivate: isPrivate).captureText(tabID: tabID)
+                let text = await coordinator.captureText(tabID: tabID)
                 payload["text"] = text
                 payload["byte_count"] = text.utf8.count
+            case .dom:
+                let html = await coordinator.captureDOM(tabID: tabID)
+                payload["html"] = html
+                payload["byte_count"] = html.utf8.count
             case .screenshot:
-                let pngData = await store.coordinator(for: resolvedPaneID, isPrivate: isPrivate).captureScreenshot(tabID: tabID)
-                if let pngData {
-                    let inlineThreshold = 1_000_000 // 1 MB
-                    if pngData.count <= inlineThreshold {
-                        payload["png_base64"] = pngData.base64EncodedString()
-                        payload["byte_count"] = pngData.count
-                    } else {
-                        // Per-app temporary directory — OS prunes it
-                        // automatically (vs. `/tmp` where files lingered
-                        // until reboot).
-                        let ts = Int(Date().timeIntervalSince1970)
-                        let url = FileManager.default.temporaryDirectory
-                            .appendingPathComponent("nex-web-capture-\(resolvedPaneID.uuidString)-\(ts).png")
-                        if (try? pngData.write(to: url)) != nil {
-                            payload["path"] = url.path
-                            payload["byte_count"] = pngData.count
-                        } else {
-                            payload["ok"] = false
-                            payload["error"] = "failed to write screenshot to \(url.path)"
-                        }
-                    }
-                } else {
+                await captureScreenshot(byteCountKey: "byte_count")
+                if payload["screenshot_error"] != nil {
                     payload["ok"] = false
-                    payload["error"] = "screenshot capture failed"
+                    payload["error"] = payload.removeValue(forKey: "screenshot_error")
                 }
+            case .all:
+                let text = await coordinator.captureText(tabID: tabID)
+                payload["text"] = text
+                payload["text_byte_count"] = text.utf8.count
+                let html = await coordinator.captureDOM(tabID: tabID)
+                payload["html"] = html
+                payload["html_byte_count"] = html.utf8.count
+                await captureScreenshot(byteCountKey: "screenshot_byte_count")
             }
             reply?.sendAndClose(payload)
         }
@@ -1208,11 +1233,12 @@ extension AppReducer {
     }
 
     func handleWebConsole(
-        state: State,
+        _ state: inout State,
         scope: WebPaneScope,
         since: UInt64,
         level: String?,
         clear: Bool,
+        follow: Bool,
         reply: SocketServer.ReplyHandle?
     ) -> Effect<Action> {
         guard let resolved = resolveWebPane(state: state, scope: scope, reply: reply)
@@ -1225,13 +1251,17 @@ extension AppReducer {
         }
         let nextSeq = resolved.webState.consoleBuffer.nextSeq
         let dropped = resolved.webState.consoleBuffer.droppedSinceLastDrain
-        reply?.sendAndClose([
+        // `follow` keeps the handle open past this first line — the
+        // catch-up drain — so the CLI's stream loop sees it as line 1
+        // of the stream rather than the whole reply.
+        reply?.send([
             "ok": true,
             "pane_id": resolved.paneID.uuidString,
             "workspace_id": resolved.workspace.id.uuidString,
             "lines": filtered.map(consoleLineJSON),
             "next_since": nextSeq,
-            "dropped": dropped
+            "dropped": dropped,
+            "follow": follow
         ])
         // Acknowledge the reported drops so the next call only
         // surfaces drops that accumulated after this drain. Always
@@ -1249,7 +1279,46 @@ extension AppReducer {
                 action: .webConsoleClear(paneID: resolved.paneID)
             ))))
         }
+        if follow, let reply {
+            state.webConsoleSubscribers[resolved.paneID, default: [:]][reply.id] = reply
+        } else {
+            reply?.close()
+        }
         return .merge(effects)
+    }
+
+    /// Push a just-appended console line out to every live
+    /// `nex web console --follow` subscriber of `paneID`. Dispatched
+    /// from `AppReducer`'s core switch in response to
+    /// `WorkspaceFeature.Action.webConsoleLineAppended` — a follow-up
+    /// action sent *after* the append lands, so `consoleBuffer.entries.last`
+    /// here is guaranteed to be the line that was just appended (see
+    /// that action's doc for why this can't be read directly off
+    /// `webConsoleLineReceived`).
+    ///
+    /// Any ring-buffer drops picked up since the last acknowledgement
+    /// (Phase 3's `droppedSinceLastDrain`, shared with the polling
+    /// `nex web console` path) ride along on this line as a `dropped`
+    /// key rather than a separate synthetic message, so the ordering
+    /// between the drop notice and the live lines is unambiguous.
+    func fanOutWebConsoleLine(
+        state: inout State, workspaceID: UUID, paneID: UUID
+    ) -> Effect<Action> {
+        guard let subscribers = state.webConsoleSubscribers[paneID], !subscribers.isEmpty
+        else { return .none }
+        guard var webState = state.workspaces[id: workspaceID]?.webPanes[paneID],
+              let entry = webState.consoleBuffer.entries.last
+        else { return .none }
+        let dropped = webState.consoleBuffer.acknowledgeDrops()
+        if dropped > 0 {
+            state.workspaces[id: workspaceID]?.webPanes[paneID] = webState
+        }
+        var payload = consoleLineJSON(entry)
+        if dropped > 0 { payload["dropped"] = dropped }
+        for (_, handle) in subscribers {
+            handle.send(payload)
+        }
+        return .none
     }
 
     func handleWebInspect(

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -71,6 +71,17 @@ struct AppReducer {
         /// not state worth surfacing to the view layer or persisting.
         var webInspectArmedSubmit: [UUID: Bool] = [:]
 
+        /// Phase 7: `nex web console --follow` subscribers, keyed by
+        /// pane then by `SocketServer.ReplyHandle.id`. Each handle is
+        /// a long-lived reply channel (registered by `handleWebConsole`
+        /// when `follow` is set, never closed by the reducer) that a
+        /// new console line gets pushed to as it lands — see
+        /// `fanOutWebConsoleLine`. Entries are released on client
+        /// disconnect (`socketSubscriberDisconnected`) or when the
+        /// owning pane closes. Not persisted — a fresh launch has no
+        /// live CLI connections to resume anyway.
+        var webConsoleSubscribers: [UUID: [UInt64: SocketServer.ReplyHandle]] = [:]
+
         /// Web favourites + workspace label presets. See `PresetsFeature`.
         var presets = PresetsFeature.State()
 
@@ -2288,10 +2299,24 @@ struct AppReducer {
                     state.renamingPaneID = nil
                 }
                 state.webInspectArmedSubmit.removeValue(forKey: paneID)
+                // A closed `.web` pane can't be caught up on later —
+                // drop and close any live `nex web console --follow`
+                // subscribers rather than leaving their FDs open
+                // forever. Keyed off subscriber presence rather than
+                // `pane.type` so this doesn't depend on whether the
+                // pane is still resolvable at this point in the
+                // reduce (see the `webConsoleLineAppended` doc for why
+                // that ordering can't be assumed).
+                if let subscribers = state.webConsoleSubscribers.removeValue(forKey: paneID) {
+                    for (_, handle) in subscribers { handle.close() }
+                }
                 return .merge(
                     .send(.persistState),
                     scheduleAutoUnlink(workspaceID: wsID, in: state)
                 )
+
+            case .workspaces(.element(id: let wsID, action: .webConsoleLineAppended(let paneID))):
+                return fanOutWebConsoleLine(state: &state, workspaceID: wsID, paneID: paneID)
 
             case .workspaces(.element(_, action: .openMarkdownFile(_, .some(let reusePaneID)))):
                 // `--here` reuse parks (doesn't remove) the source

--- a/Nex/Features/WebPane/WebPaneCoordinator.swift
+++ b/Nex/Features/WebPane/WebPaneCoordinator.swift
@@ -590,6 +590,25 @@ final class WebPaneCoordinator: NSObject, WKNavigationDelegate {
         return truncated + "\n[truncated]"
     }
 
+    /// Full-document HTML for the active tab (`document.documentElement.outerHTML`),
+    /// clipped to `maxBytes` (default 5 MB — this is the whole DOM, not
+    /// just visible text, so pages with large inline assets or deeply
+    /// nested markup can get big). Returns the empty string when no
+    /// page has finished loading yet.
+    func captureDOM(tabID: UUID, maxBytes: Int = 5_000_000) async -> String {
+        guard let webView = webViews[tabID] else { return "" }
+        let result = try? await webView.evaluateJavaScript(
+            "document.documentElement ? document.documentElement.outerHTML : ''"
+        )
+        guard let html = result as? String else { return "" }
+        if html.utf8.count <= maxBytes { return html }
+        var truncated = html
+        while truncated.utf8.count > maxBytes {
+            truncated.removeLast()
+        }
+        return truncated + "\n<!-- truncated -->"
+    }
+
     /// Capture the visible viewport as a PNG. Returns the raw bytes;
     /// callers decide whether to inline as base64 or spill to a file.
     func captureScreenshot(tabID: UUID) async -> Data? {

--- a/Nex/Features/WebPane/WebPaneState.swift
+++ b/Nex/Features/WebPane/WebPaneState.swift
@@ -192,9 +192,13 @@ struct WebPaneState: Equatable {
 
 /// `nex web capture` modes. `meta` returns just URL + title; `text`
 /// adds visible page text; `screenshot` adds a PNG (inline base64
-/// or `/tmp` path depending on size).
+/// or `/tmp` path depending on size); `dom` adds the full
+/// `document.documentElement.outerHTML` (clipped to 5 MB); `all` is
+/// the composite of meta + text + dom + screenshot in one payload.
 enum WebCaptureMode: String {
     case meta
     case text
     case screenshot
+    case dom
+    case all
 }

--- a/Nex/Features/Workspace/WorkspaceFeature.swift
+++ b/Nex/Features/Workspace/WorkspaceFeature.swift
@@ -374,6 +374,19 @@ struct WorkspaceFeature {
         /// Dispatched from `ContentView` when the coordinator posts a
         /// `consoleLineNotification`.
         case webConsoleLineReceived(paneID: UUID, line: ConsoleLine)
+        /// Follow-up sent right after `webConsoleLineReceived` appends
+        /// the line. `AppReducer`'s core switch reacts to this (not to
+        /// `webConsoleLineReceived` directly) to fan the new line out
+        /// to `webConsoleSubscribers` — that dict lives on
+        /// `AppReducer.State`, so the fan-out has to happen after this
+        /// action re-enters the top of the reducer body, by which
+        /// point the append below has already landed in `state`.
+        /// Reacting to `webConsoleLineReceived` itself would run
+        /// *before* this case's append (core's giant `Reduce` block is
+        /// listed ahead of the `.forEach(\.workspaces, ...)` reducer
+        /// that owns this case), so it would only ever see the
+        /// buffer's previous entry.
+        case webConsoleLineAppended(paneID: UUID)
         /// Drop everything from the pane's console buffer (the
         /// `--clear` flag on `nex web console`). `seq` keeps counting.
         case webConsoleClear(paneID: UUID)
@@ -1051,6 +1064,12 @@ struct WorkspaceFeature {
                 guard var webState = state.webPanes[paneID] else { return .none }
                 webState.consoleBuffer.append(line)
                 state.webPanes[paneID] = webState
+                return .send(.webConsoleLineAppended(paneID: paneID))
+
+            case .webConsoleLineAppended:
+                // No-op here — consumed by AppReducer's core switch to
+                // fan the freshly-appended line out to
+                // `webConsoleSubscribers`. See the case doc.
                 return .none
 
             case .webConsoleClear(let paneID):

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -182,6 +182,15 @@ enum SocketMessage: Equatable {
     /// and the running app drift.
     case ping
 
+    /// Not a `nex` CLI verb — synthesised by `SocketServer` itself
+    /// (never parsed from the wire) when a client's dispatch source
+    /// cancels (EOF, SIGINT-triggered close, or an explicit
+    /// `reply.close()`). `replyID` is the `ReplyHandle.id` that just
+    /// went stale. The reducer uses this to release any held handle
+    /// in `webConsoleSubscribers` — see the cancel handler in
+    /// `acceptConnection`.
+    case socketSubscriberDisconnected(replyID: UInt64)
+
     // Web pane commands (Phase 1). `web` is a first-class top-level
     // CLI verb (not a `pane` subcommand), so the wire names follow
     // suit: `web-open` / `web-url` / etc.
@@ -225,9 +234,15 @@ enum SocketMessage: Equatable {
     /// `since` is the last seq the caller has already seen (0 = full
     /// buffer). `level` filters to a single severity. `clear` empties
     /// the buffer after the read so the next call starts fresh.
+    /// `follow` = true switches the reply from single-shot
+    /// request/response to a long-lived stream: the initial reply
+    /// (the catch-up drain) is sent without closing the `ReplyHandle`,
+    /// and every subsequent console line for this pane is pushed as
+    /// its own newline-delimited JSON object until the client
+    /// disconnects (`nex web console --follow`).
     case webConsole(
         paneID: UUID?, target: String?, workspace: String?,
-        since: UInt64, level: String?, clear: Bool
+        since: UInt64, level: String?, clear: Bool, follow: Bool
     )
     /// Arm the picker for the resolved pane's active tab. `sendTo`
     /// is an optional pane target (label or UUID) into which the
@@ -431,10 +446,25 @@ final class SocketServer: Sendable {
     /// receive `nil` and the server behaves identically to before.
     nonisolated(unsafe) var onMessage: (@Sendable (SocketMessage, ReplyHandle?) -> Void)?
 
-    /// Opaque handle the reducer uses to write a single JSON response
-    /// line and close the client connection. Safe to drop on the floor —
-    /// the existing EOF path still closes orphaned FDs when the CLI
-    /// disconnects.
+    /// Opaque handle the reducer uses to write a JSON response line
+    /// and (eventually) close the client connection. Safe to drop on
+    /// the floor — the existing EOF path still closes orphaned FDs
+    /// when the CLI disconnects.
+    ///
+    /// Two usage modes, both supported by the same handle:
+    /// - **Request/response** (the default, used by every command
+    ///   except `web-console --follow`): call `send`/`sendAndClose`
+    ///   once and stop — a single JSON line, then EOF.
+    /// - **Streaming**: call `send` any number of times without
+    ///   calling `close`. The reducer holds the handle open (e.g. in
+    ///   `AppReducer.State.webConsoleSubscribers`) and keeps writing
+    ///   newline-delimited JSON lines as events arrive. The CLI's
+    ///   `sendJSONAndStream` disables its read timeout and loops on
+    ///   the client side to match. The stream ends when the client
+    ///   disconnects (EOF / SIGINT closes its FD) — the server's
+    ///   `clientSource.setCancelHandler` detects this and dispatches
+    ///   `SocketMessage.socketSubscriberDisconnected(replyID:)` so the
+    ///   reducer can release the held handle.
     ///
     /// Closure-based so tests can supply capture stubs without a live
     /// `SocketServer`. Marked `@unchecked Sendable` because it only
@@ -669,10 +699,23 @@ final class SocketServer: Sendable {
             clientSources.removeValue(forKey: clientFD)
             // Drop any outstanding reply handles pointing at this FD.
             // The handle's `send()` / `close()` become no-ops.
+            var droppedReplyIDs: [UInt64] = []
             for (id, fd) in replyFDs where fd == clientFD {
                 replyFDs.removeValue(forKey: id)
+                droppedReplyIDs.append(id)
             }
+            let callback = onMessage
             lock.unlock()
+            // Fires for every dropped id, not just streaming
+            // subscribers — the reducer's cleanup is a cheap no-op
+            // for ids it never registered (e.g. every ordinary
+            // request/response call also ends in a cancelled source).
+            guard !droppedReplyIDs.isEmpty else { return }
+            DispatchQueue.main.async {
+                for id in droppedReplyIDs {
+                    callback?(.socketSubscriberDisconnected(replyID: id), nil)
+                }
+            }
         }
         lock.withLock { clientSources[clientFD] = clientSource }
         clientSource.resume()
@@ -838,6 +881,9 @@ final class SocketServer: Sendable {
         var level: String?
         /// `web-console --clear`, `web-inspect-result --clear`.
         var clear: Bool?
+        /// `web-console --follow` — keep the reply channel open and
+        /// stream new lines instead of a single-shot drain.
+        var follow: Bool?
         /// `web-inspect --send-to <pane-target>`.
         var sendTo: String?
         /// `web-inspect --submit`. Default false (paste only).
@@ -946,7 +992,7 @@ final class SocketServer: Sendable {
             case url, mode, hard
             case tab
             case makeActive = "make_active"
-            case since, level, clear
+            case since, level, clear, follow
             case sendTo = "send_to"
             case submit, disarm
             case isPrivate = "private"
@@ -1247,7 +1293,8 @@ final class SocketServer: Sendable {
                 workspace: scope.workspace,
                 since: wire.since ?? 0,
                 level: (wire.level?.isEmpty == true) ? nil : wire.level,
-                clear: wire.clear ?? false
+                clear: wire.clear ?? false,
+                follow: wire.follow ?? false
             ), wire)
         }
 

--- a/NexTests/SocketParsingTests.swift
+++ b/NexTests/SocketParsingTests.swift
@@ -968,7 +968,8 @@ struct SocketParsingTests {
             workspace: nil,
             since: 0,
             level: nil,
-            clear: false
+            clear: false,
+            follow: false
         ))
     }
 
@@ -984,7 +985,8 @@ struct SocketParsingTests {
             workspace: nil,
             since: 42,
             level: "error",
-            clear: true
+            clear: true,
+            follow: false
         ))
     }
 
@@ -999,7 +1001,8 @@ struct SocketParsingTests {
             workspace: nil,
             since: 0,
             level: nil,
-            clear: false
+            clear: false,
+            follow: false
         ))
     }
 
@@ -1022,7 +1025,24 @@ struct SocketParsingTests {
             workspace: "Dev",
             since: 0,
             level: nil,
-            clear: false
+            clear: false,
+            follow: false
+        ))
+    }
+
+    @Test func parseWebConsoleFollow() {
+        let data = jsonData("""
+        {"command":"web-console","pane_id":"\(Self.paneIDString)","follow":true}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webConsole(
+            paneID: Self.paneUUID,
+            target: nil,
+            workspace: nil,
+            since: 0,
+            level: nil,
+            clear: false,
+            follow: true
         ))
     }
 
@@ -1166,6 +1186,36 @@ struct SocketParsingTests {
         {"command":"web-navigate","pane_id":"\(Self.paneIDString)","url":""}
         """)
         #expect(SocketServer.parseWireMessage(data) == nil)
+    }
+
+    @Test func parseWebCaptureDefaultsToMeta() {
+        let data = jsonData("""
+        {"command":"web-capture","pane_id":"\(Self.paneIDString)"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webCapture(
+            paneID: Self.paneUUID, target: nil, workspace: nil, mode: "meta"
+        ))
+    }
+
+    @Test func parseWebCaptureModeDom() {
+        let data = jsonData("""
+        {"command":"web-capture","pane_id":"\(Self.paneIDString)","mode":"dom"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webCapture(
+            paneID: Self.paneUUID, target: nil, workspace: nil, mode: "dom"
+        ))
+    }
+
+    @Test func parseWebCaptureModeAll() {
+        let data = jsonData("""
+        {"command":"web-capture","target":"web","workspace":"Dev","mode":"all"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .webCapture(
+            paneID: nil, target: "web", workspace: "Dev", mode: "all"
+        ))
     }
 
     @Test func parseWebPrivateOn() {

--- a/NexTests/WebConsoleStreamingTests.swift
+++ b/NexTests/WebConsoleStreamingTests.swift
@@ -1,0 +1,263 @@
+import Clocks
+import ComposableArchitecture
+import Foundation
+@testable import Nex
+import Testing
+
+/// Phase 7 (issue #145): `nex web console --follow` subscriber
+/// lifecycle. Mirrors `PaneCaptureReplyTests` — captures JSON replies
+/// via a closure-backed `SocketServer.ReplyHandle` stub, no real
+/// socket involved.
+@MainActor
+struct WebConsoleStreamingTests {
+    private static let wsID = UUID(uuidString: "90000000-0000-0000-0000-000000000002")!
+    private static let paneID = UUID(uuidString: "00000000-0000-0000-0000-00000000D001")!
+    private static let tabID = UUID(uuidString: "00000000-0000-0000-0000-00000000D002")!
+
+    private final class ConsoleSink: @unchecked Sendable {
+        var payloads: [[String: Any]] = []
+        var closedCount = 0
+    }
+
+    private func makeConsoleHandle(_ sink: ConsoleSink, id: UInt64 = 1) -> SocketServer.ReplyHandle {
+        SocketServer.ReplyHandle(
+            id: id,
+            send: { json in sink.payloads.append(json) },
+            close: { sink.closedCount += 1 }
+        )
+    }
+
+    private func makeLine(_ message: String) -> ConsoleLine {
+        ConsoleLine(
+            tabID: Self.tabID, level: .log, message: message, url: "https://example.com",
+            lineNumber: nil, columnNumber: nil, capturedAt: Date(timeIntervalSince1970: 1000)
+        )
+    }
+
+    private func makeStore(webState: WebPaneState? = nil) -> TestStoreOf<AppReducer> {
+        let pane = Pane(id: Self.paneID, label: "web", type: .web)
+        let resolvedWebState = webState ?? WebPaneState(
+            tabs: [WebTab(id: Self.tabID, url: "https://example.com")],
+            activeTabID: Self.tabID, isPrivate: false
+        )
+        let workspace = WorkspaceFeature.State(
+            id: Self.wsID, name: "alpha", slug: "alpha", color: .blue,
+            panes: [pane],
+            layout: .leaf(Self.paneID),
+            focusedPaneID: Self.paneID,
+            createdAt: Date(timeIntervalSince1970: 1000),
+            lastAccessedAt: Date(timeIntervalSince1970: 1000),
+            webPanes: [Self.paneID: resolvedWebState]
+        )
+
+        var appState = AppReducer.State()
+        appState.workspaces = [workspace]
+        appState.activeWorkspaceID = Self.wsID
+        appState.topLevelOrder = [.workspace(Self.wsID)]
+
+        let store = TestStore(initialState: appState) {
+            AppReducer()
+        } withDependencies: {
+            $0.surfaceManager = SurfaceManager()
+            $0.uuid = .incrementing
+            $0.date = .constant(Date(timeIntervalSince1970: 1000))
+            $0.gitService.getCurrentBranch = { _ in nil }
+            $0.gitService.getStatus = { _ in .clean }
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+        return store
+    }
+
+    // MARK: - Registration
+
+    @Test func followRegistersSubscriberAndDoesNotClose() async {
+        let store = makeStore()
+        let sink = ConsoleSink()
+
+        await store.send(.socketMessage(
+            .webConsole(
+                paneID: Self.paneID, target: nil, workspace: nil,
+                since: 0, level: nil, clear: false, follow: true
+            ),
+            reply: makeConsoleHandle(sink)
+        ))
+        await store.finish()
+
+        #expect(sink.payloads.count == 1)
+        #expect(sink.payloads[0]["ok"] as? Bool == true)
+        #expect(sink.payloads[0]["follow"] as? Bool == true)
+        #expect(sink.closedCount == 0)
+        #expect(store.state.webConsoleSubscribers[Self.paneID]?[1] != nil)
+    }
+
+    @Test func nonFollowClosesAndNeverRegisters() async {
+        let store = makeStore()
+        let sink = ConsoleSink()
+
+        await store.send(.socketMessage(
+            .webConsole(
+                paneID: Self.paneID, target: nil, workspace: nil,
+                since: 0, level: nil, clear: false, follow: false
+            ),
+            reply: makeConsoleHandle(sink)
+        ))
+        await store.finish()
+
+        #expect(sink.closedCount == 1)
+        #expect(store.state.webConsoleSubscribers[Self.paneID] == nil)
+    }
+
+    // MARK: - Fan-out
+
+    @Test func newLineIsDeliveredToFollowSubscriber() async {
+        let store = makeStore()
+        let sink = ConsoleSink()
+
+        await store.send(.socketMessage(
+            .webConsole(
+                paneID: Self.paneID, target: nil, workspace: nil,
+                since: 0, level: nil, clear: false, follow: true
+            ),
+            reply: makeConsoleHandle(sink)
+        ))
+        await store.finish()
+        #expect(sink.payloads.count == 1)
+
+        await store.send(.workspaces(.element(
+            id: Self.wsID,
+            action: .webConsoleLineReceived(paneID: Self.paneID, line: makeLine("hello"))
+        )))
+        await store.finish()
+
+        #expect(sink.payloads.count == 2)
+        #expect(sink.payloads[1]["message"] as? String == "hello")
+        #expect(sink.payloads[1]["level"] as? String == "log")
+        #expect(sink.closedCount == 0)
+    }
+
+    @Test func multipleSubscribersAllReceiveTheLine() async {
+        let store = makeStore()
+        let sinkA = ConsoleSink()
+        let sinkB = ConsoleSink()
+
+        await store.send(.socketMessage(
+            .webConsole(
+                paneID: Self.paneID, target: nil, workspace: nil,
+                since: 0, level: nil, clear: false, follow: true
+            ),
+            reply: makeConsoleHandle(sinkA, id: 1)
+        ))
+        await store.send(.socketMessage(
+            .webConsole(
+                paneID: Self.paneID, target: nil, workspace: nil,
+                since: 0, level: nil, clear: false, follow: true
+            ),
+            reply: makeConsoleHandle(sinkB, id: 2)
+        ))
+        await store.finish()
+
+        await store.send(.workspaces(.element(
+            id: Self.wsID,
+            action: .webConsoleLineReceived(paneID: Self.paneID, line: makeLine("broadcast"))
+        )))
+        await store.finish()
+
+        #expect(sinkA.payloads.last?["message"] as? String == "broadcast")
+        #expect(sinkB.payloads.last?["message"] as? String == "broadcast")
+    }
+
+    // MARK: - Disconnect cleanup
+
+    @Test func subscriberDisconnectRemovesHandle() async {
+        let store = makeStore()
+        let sink = ConsoleSink()
+
+        await store.send(.socketMessage(
+            .webConsole(
+                paneID: Self.paneID, target: nil, workspace: nil,
+                since: 0, level: nil, clear: false, follow: true
+            ),
+            reply: makeConsoleHandle(sink)
+        ))
+        await store.finish()
+        #expect(store.state.webConsoleSubscribers[Self.paneID]?[1] != nil)
+
+        await store.send(.socketMessage(.socketSubscriberDisconnected(replyID: 1), reply: nil))
+        await store.finish()
+
+        #expect(store.state.webConsoleSubscribers[Self.paneID] == nil)
+    }
+
+    @Test func disconnectOfUnknownReplyIDIsANoOp() async {
+        let store = makeStore()
+        // No subscriber ever registered — a stray disconnect
+        // notification (e.g. from any ordinary request/response call)
+        // must not crash or mutate anything.
+        await store.send(.socketMessage(.socketSubscriberDisconnected(replyID: 999), reply: nil))
+        await store.finish()
+
+        #expect(store.state.webConsoleSubscribers.isEmpty)
+    }
+
+    // MARK: - Pane-close cleanup
+
+    @Test func closingThePaneClosesAndDropsSubscribers() async {
+        let store = makeStore()
+        let sink = ConsoleSink()
+
+        await store.send(.socketMessage(
+            .webConsole(
+                paneID: Self.paneID, target: nil, workspace: nil,
+                since: 0, level: nil, clear: false, follow: true
+            ),
+            reply: makeConsoleHandle(sink)
+        ))
+        await store.finish()
+        #expect(sink.closedCount == 0)
+
+        await store.send(.workspaces(.element(id: Self.wsID, action: .closePane(Self.paneID))))
+        await store.finish()
+
+        #expect(sink.closedCount == 1)
+        #expect(store.state.webConsoleSubscribers[Self.paneID] == nil)
+    }
+
+    // MARK: - Back-pressure
+
+    @Test func dropCounterAttachesToTheLineThatCausedTheEviction() async {
+        // Capacity 1 so a second append evicts the first entry inside
+        // the very same `.webConsoleLineReceived` that the fan-out
+        // reacts to — deterministic without needing to push 1000 lines
+        // through the buffer.
+        var webState = WebPaneState(
+            tabs: [WebTab(id: Self.tabID, url: "https://example.com")],
+            activeTabID: Self.tabID, isPrivate: false
+        )
+        webState.consoleBuffer = RingBuffer<ConsoleLine>(capacity: 1)
+        webState.consoleBuffer.append(makeLine("first"))
+        let store = makeStore(webState: webState)
+        let sink = ConsoleSink()
+
+        await store.send(.socketMessage(
+            .webConsole(
+                paneID: Self.paneID, target: nil, workspace: nil,
+                since: 0, level: nil, clear: false, follow: true
+            ),
+            reply: makeConsoleHandle(sink)
+        ))
+        await store.finish()
+        // No eviction yet — the buffer holds exactly one entry.
+        #expect(sink.payloads[0]["dropped"] as? Int == 0)
+
+        await store.send(.workspaces(.element(
+            id: Self.wsID,
+            action: .webConsoleLineReceived(paneID: Self.paneID, line: makeLine("second"))
+        )))
+        await store.finish()
+
+        #expect(sink.payloads.count == 2)
+        #expect(sink.payloads[1]["message"] as? String == "second")
+        #expect(sink.payloads[1]["dropped"] as? Int == 1)
+    }
+}

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -234,7 +234,7 @@ func printUsage() {
       nex web open [--private] <url>
       nex web navigate <url> [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web url|back|forward|reload [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--hard]
-      nex web capture [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot]
+      nex web capture [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot|dom|all]
       nex web private on|off [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web cookies list|clear|delete [...]
       nex web click <selector> [--target X] [--workspace Y] [--double] [--right] [--at x,y] [--json]
@@ -1105,6 +1105,182 @@ func sendViaTCP(
     return reply
 }
 
+// MARK: - Streaming transport (`nex web console --follow`)
+
+/// FD of the currently open streaming connection, if any. Read by
+/// `streamSIGINTHandler` so Ctrl-C can close the socket cleanly
+/// instead of just killing the process — closing the FD is what lets
+/// the server's `clientSource.setCancelHandler` fire and release the
+/// held `ReplyHandle` server-side (`socketSubscriberDisconnected`).
+/// `nonisolated(unsafe)` because it's only ever touched from the main
+/// thread (the streaming read loop) and the signal handler, which
+/// interrupts that same thread synchronously.
+nonisolated(unsafe) var activeStreamFD: Int32 = -1
+
+private func streamSIGINTHandler(_ sig: Int32) {
+    if activeStreamFD >= 0 {
+        close(activeStreamFD)
+        activeStreamFD = -1
+    }
+    // 128 + signal number is the standard shell convention for
+    // signal-terminated exits.
+    exit(128 + sig)
+}
+
+/// Install once before entering a streaming read loop. Safe to call
+/// more than once (just re-registers the same handler).
+func installStreamSIGINTHandler() {
+    signal(SIGINT, streamSIGINTHandler)
+}
+
+/// Read newline-delimited JSON lines from `fd` until EOF, calling
+/// `onLine` with each complete line's raw bytes (no trailing
+/// newline). No read timeout is applied by the caller — the stream
+/// can legitimately idle for a long time between events.
+private func readLinesUntilEOF(fd: Int32, onLine: (Data) -> Void) {
+    var buffer = Data()
+    var readBuf = [UInt8](repeating: 0, count: 4096)
+    while true {
+        let n = read(fd, &readBuf, readBuf.count)
+        if n > 0 {
+            buffer.append(readBuf, count: n)
+            while let newlineIndex = buffer.firstIndex(of: 0x0A) {
+                onLine(Data(buffer[..<newlineIndex]))
+                buffer.removeSubrange(...newlineIndex)
+            }
+            continue
+        }
+        if n == 0 { return } // EOF — server closed the connection.
+        if errno == EINTR { continue }
+        return
+    }
+}
+
+/// Streaming counterpart to `sendJSONAndReadReply`. Sends `payload`
+/// once, then disables the read timeout entirely (`SO_RCVTIMEO` is
+/// simply never applied — a plain blocking socket already waits
+/// indefinitely) and loops on `onLine` for every newline-delimited
+/// JSON line the server writes, until EOF or the process is
+/// interrupted (`installStreamSIGINTHandler` closes the FD, which
+/// unblocks the pending `read()` with `n == 0`/an error). Returns
+/// `false` if the connection couldn't be established at all — the
+/// caller should treat that like `sendJSONAndReadReply` returning nil.
+@discardableResult
+func sendJSONAndStream(
+    _ payload: [String: Any], onLine: (Data) -> Void
+) -> Bool {
+    switch transport {
+    case .unix(let path):
+        streamViaUnix(path: path, payload: payload, onLine: onLine)
+    case .tcp(let host, let port):
+        streamViaTCP(host: host, port: port, payload: payload, onLine: onLine)
+    }
+}
+
+private func streamViaUnix(
+    path: String, payload: [String: Any], onLine: (Data) -> Void
+) -> Bool {
+    lastTransportFailure = nil
+
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
+          var jsonString = String(data: jsonData, encoding: .utf8)
+    else { return false }
+    jsonString += "\n"
+
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else {
+        lastTransportFailure = .createSocketFailed(errno: errno)
+        return false
+    }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    path.withCString { cpath in
+        withUnsafeMutableBytes(of: &addr.sun_path) { sunPath in
+            let ptr = sunPath.baseAddress!.assumingMemoryBound(to: CChar.self)
+            strncpy(ptr, cpath, sunPath.count - 1)
+        }
+    }
+
+    let connectResult = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard connectResult == 0 else {
+        let err = errno
+        close(fd)
+        switch err {
+        case ENOENT:
+            lastTransportFailure = .unixSocketMissing(path: path)
+        case ECONNREFUSED:
+            lastTransportFailure = .unixConnectRefused(path: path)
+        default:
+            lastTransportFailure = .unixConnectFailed(path: path, errno: err)
+        }
+        return false
+    }
+
+    jsonString.withCString { ptr in
+        let len = strlen(ptr)
+        _ = send(fd, ptr, len, 0)
+    }
+
+    activeStreamFD = fd
+    readLinesUntilEOF(fd: fd, onLine: onLine)
+    activeStreamFD = -1
+    close(fd)
+    return true
+}
+
+private func streamViaTCP(
+    host: String, port: UInt16, payload: [String: Any], onLine: (Data) -> Void
+) -> Bool {
+    lastTransportFailure = nil
+
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
+          var jsonString = String(data: jsonData, encoding: .utf8)
+    else { return false }
+    jsonString += "\n"
+
+    var hints = addrinfo()
+    hints.ai_family = AF_INET
+    hints.ai_socktype = SOCK_STREAM
+    var result: UnsafeMutablePointer<addrinfo>?
+    guard getaddrinfo(host, String(port), &hints, &result) == 0,
+          let addrInfo = result
+    else {
+        lastTransportFailure = .tcpResolveFailed(host: host)
+        return false
+    }
+    defer { freeaddrinfo(result) }
+
+    let fd = socket(addrInfo.pointee.ai_family, addrInfo.pointee.ai_socktype, addrInfo.pointee.ai_protocol)
+    guard fd >= 0 else {
+        lastTransportFailure = .createSocketFailed(errno: errno)
+        return false
+    }
+
+    let connectResult = connect(fd, addrInfo.pointee.ai_addr, addrInfo.pointee.ai_addrlen)
+    guard connectResult == 0 else {
+        let err = errno
+        close(fd)
+        lastTransportFailure = .tcpConnectFailed(host: host, port: port, errno: err)
+        return false
+    }
+
+    jsonString.withCString { ptr in
+        let len = strlen(ptr)
+        _ = send(fd, ptr, len, 0)
+    }
+
+    activeStreamFD = fd
+    readLinesUntilEOF(fd: fd, onLine: onLine)
+    activeStreamFD = -1
+    close(fd)
+    return true
+}
+
 // MARK: - Subcommands
 
 func handleEvent(_ args: inout ArraySlice<String>) {
@@ -1963,12 +2139,12 @@ func printWebUsage(stream: UnsafeMutablePointer<FILE>) {
       nex web back     [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web forward  [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web reload   [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--hard]
-      nex web capture  [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot]
+      nex web capture  [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--mode meta|text|screenshot|dom|all]
       nex web tabs        [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--json] [--no-header]
       nex web tab-new     [<url>] [--target <name-or-uuid>] [--workspace <name-or-uuid>] [--no-focus]
       nex web tab-close   <ref> [--target <name-or-uuid>] [--workspace <name-or-uuid>]
       nex web tab-select  <ref> [--target <name-or-uuid>] [--workspace <name-or-uuid>]
-      nex web console     [--target ...] [--workspace ...] [--since N] [--level log|debug|info|warn|error] [--clear] [--json]
+      nex web console     [--target ...] [--workspace ...] [--since N] [--level log|debug|info|warn|error] [--clear] [--follow] [--json]
       nex web inspect     [--target ...] [--workspace ...] [--send-to <pane>] [--submit] [--disarm]
       nex web inspect-result [--target ...] [--workspace ...] [--clear] [--json]
       nex web private    on|off [--target ...] [--workspace ...]
@@ -2205,9 +2381,9 @@ func handleWeb(_ args: inout ArraySlice<String>) {
         let target = parseFlag("--target", from: &args)
         let workspace = parseFlag("--workspace", from: &args)
         let mode = parseFlag("--mode", from: &args) ?? "meta"
-        let allowed: Set = ["meta", "text", "screenshot"]
+        let allowed: Set = ["meta", "text", "screenshot", "dom", "all"]
         guard allowed.contains(mode) else {
-            fputs("nex web capture: unknown --mode '\(mode)' (allowed: meta, text, screenshot)\n", stderr)
+            fputs("nex web capture: unknown --mode '\(mode)' (allowed: meta, text, screenshot, dom, all)\n", stderr)
             exit(1)
         }
         var payload: [String: Any] = [
@@ -2274,6 +2450,7 @@ func handleWeb(_ args: inout ArraySlice<String>) {
         let level = parseFlag("--level", from: &args)
         let clear = popSwitch("--clear", from: &args)
         let asJSON = popSwitch("--json", from: &args)
+        let follow = popSwitch("--follow", from: &args)
         var payload: [String: Any] = ["command": "web-console"]
         if let sinceArg, let parsed = UInt64(sinceArg) {
             payload["since"] = parsed
@@ -2290,8 +2467,13 @@ func handleWeb(_ args: inout ArraySlice<String>) {
             payload["level"] = level
         }
         if clear { payload["clear"] = true }
+        if follow { payload["follow"] = true }
         attachWebTargetScope(&payload, target: target, workspace: workspace, command: "console")
-        sendWebReplyAndPrintConsole(payload, asJSON: asJSON)
+        if follow {
+            sendWebConsoleFollow(payload, asJSON: asJSON)
+        } else {
+            sendWebReplyAndPrintConsole(payload, asJSON: asJSON)
+        }
 
     case "inspect":
         let target = parseFlag("--target", from: &args)
@@ -2882,12 +3064,23 @@ private func sendWebReplyAndPrintCapture(_ payload: [String: Any]) {
     switch mode {
     case "text":
         if let text = json["text"] as? String { print(text) }
+    case "dom":
+        if let html = json["html"] as? String { print(html) }
     case "screenshot":
         if let path = json["path"] as? String {
             print(path)
         } else if let b64 = json["png_base64"] as? String {
             // Inline: print to stdout — the caller can pipe to `base64 -D > out.png`.
             print(b64)
+        }
+    case "all":
+        // Composite of meta + text + dom + screenshot — too many
+        // shapes for a single plain-text rendering, so dump the raw
+        // reply. Screenshot bytes still land inline (`png_base64`) or
+        // as a `path`, same as the standalone `screenshot` mode.
+        if let out = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]),
+           let s = String(data: out, encoding: .utf8) {
+            print(s)
         }
     default:
         // meta — print URL + title + byte_count
@@ -2903,27 +3096,88 @@ private func sendWebReplyAndPrintCapture(_ payload: [String: Any]) {
     }
 }
 
+/// `[seq] level: message` — shared between the single-shot drain
+/// (`sendWebReplyAndPrintConsole`) and each streamed line
+/// (`sendWebConsoleFollow`) so both print identically.
+private func formatConsoleLinePlain(_ line: [String: Any]) -> String {
+    let seq = (line["seq"] as? UInt64) ?? 0
+    let level = (line["level"] as? String) ?? "log"
+    let message = (line["message"] as? String) ?? ""
+    return "[\(seq)] \(level): \(message)"
+}
+
+private func printJSONLine(_ json: [String: Any]) {
+    if let out = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]),
+       let s = String(data: out, encoding: .utf8) {
+        print(s)
+    }
+}
+
 private func sendWebReplyAndPrintConsole(_ payload: [String: Any], asJSON: Bool) {
     let json = decodeReply(payload, command: "nex web console")
     let lines = (json["lines"] as? [[String: Any]]) ?? []
     if asJSON {
-        if let out = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]),
-           let s = String(data: out, encoding: .utf8) {
-            print(s)
-        }
+        printJSONLine(json)
         return
     }
     if let dropped = json["dropped"] as? Int, dropped > 0 {
         fputs("(dropped \(dropped) lines before this batch — buffer was full)\n", stderr)
     }
     for line in lines {
-        let seq = (line["seq"] as? UInt64) ?? 0
-        let level = (line["level"] as? String) ?? "log"
-        let message = (line["message"] as? String) ?? ""
-        print("[\(seq)] \(level): \(message)")
+        print(formatConsoleLinePlain(line))
     }
     if let next = json["next_since"] as? UInt64 {
         fputs("(next_since=\(next))\n", stderr)
+    }
+}
+
+/// `nex web console --follow`. The first line back is the catch-up
+/// drain (same shape as the non-follow reply); every line after that
+/// is a single streamed console entry, pushed as its own
+/// newline-delimited JSON object until the server closes the
+/// connection or the user hits Ctrl-C (`installStreamSIGINTHandler`
+/// closes the socket FD so the server's cancel handler releases the
+/// subscriber slot).
+private func sendWebConsoleFollow(_ payload: [String: Any], asJSON: Bool) {
+    installStreamSIGINTHandler()
+    var isFirstLine = true
+    let connected = sendJSONAndStream(payload) { lineData in
+        guard let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+            return
+        }
+        if isFirstLine {
+            isFirstLine = false
+            if let ok = json["ok"] as? Bool, ok == false {
+                let msg = (json["error"] as? String) ?? "unknown error"
+                fputs("nex web console: \(msg)\n", stderr)
+                exit(1)
+            }
+            if asJSON {
+                printJSONLine(json)
+            } else {
+                if let dropped = json["dropped"] as? Int, dropped > 0 {
+                    fputs("(dropped \(dropped) lines before this batch — buffer was full)\n", stderr)
+                }
+                let lines = (json["lines"] as? [[String: Any]]) ?? []
+                for line in lines {
+                    print(formatConsoleLinePlain(line))
+                }
+                fputs("(following — press Ctrl-C to stop)\n", stderr)
+            }
+            return
+        }
+        if asJSON {
+            printJSONLine(json)
+        } else {
+            if let dropped = json["dropped"] as? Int, dropped > 0 {
+                fputs("(dropped \(dropped) lines)\n", stderr)
+            }
+            print(formatConsoleLinePlain(json))
+        }
+    }
+    if !connected {
+        printTransportFailure(command: "nex web console --follow")
+        exit(1)
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 7 of the web pane feature (issue #145) — the deliberate "do it
all together" piece since the streaming transport touches the socket
layer end-to-end. Once this lands the web pane is feature-complete
against the original spec.

- **CLI surface**: `nex web capture --mode dom` (full-document
  `outerHTML`, clipped to 5 MB) and `nex web capture --mode all`
  (composite of meta + text + dom + screenshot in one payload).
- **Streaming console**: `nex web console --follow` streams
  newline-delimited JSON console lines until SIGINT instead of a
  single-shot drain.
- **Wire protocol**: policy + bookkeeping only, per the issue —
  `SocketServer.ReplyHandle` already supported multiple `send` calls
  before `close`. Documented the two usage modes (request/response vs.
  streaming) on the handle itself.
- **Server-side subscriber registry**: `AppReducer.State.webConsoleSubscribers:
  [UUID: [UInt64: SocketServer.ReplyHandle]]`, keyed pane → replyID.
  `handleWebConsole` registers the handle without closing it when
  `follow` is set; a new `webConsoleLineAppended` follow-up action
  (dispatched right after `webConsoleLineReceived` appends to the ring
  buffer) triggers `fanOutWebConsoleLine`, which pushes the new line to
  every subscriber for that pane.
- **Back-pressure**: any ring-buffer drop picked up as part of the same
  append rides along on that line as a `dropped` key, so the marker is
  correctly ordered relative to the live lines it's a sibling of.
- **Cleanup**: client disconnect (SIGINT closing the FD → the server's
  existing cancel handler → new `SocketMessage.socketSubscriberDisconnected(replyID:)`)
  and pane-close (`.closePane` effect) both release held handles.
- **CLI transport**: new `sendJSONAndStream` disables the read timeout
  and loops on newline-delimited JSON until EOF; `installStreamSIGINTHandler`
  closes the socket FD on Ctrl-C so the server's cancel handler fires
  cleanly.

## Test plan

- [x] `xcodebuild test` — full suite green (1388/1388), including new
      `WebConsoleStreamingTests` (subscriber registration, fan-out,
      multi-subscriber broadcast, disconnect cleanup, pane-close
      cleanup, back-pressure marker) and new `SocketParsingTests` wire
      round-trips for `web-console --follow` and `web-capture --mode
      dom|all`.
- [x] `swiftformat --lint .` / `swiftlint lint` — no new violations
      beyond the codebase's existing baseline (52/195 files already
      fail format-lint on `main`; one new `function_parameter_count`
      warning on `handleWebConsole`, consistent with ~10 other
      7–8-parameter handlers already in the same file).

## Validation (autonomous, sandboxed VM)

All exercised against a real running `Nex.app` via the bundled `nex`
CLI over the Unix socket — screenshots in this PR's VM output show the
live app state.

- `nex web capture --target <web-pane> --mode dom` → returned the
  live page's full `outerHTML`.
- `nex web capture --target <web-pane> --mode all` → single payload
  with `text`/`text_byte_count`, `html`/`html_byte_count`,
  `png_base64`/`screenshot_byte_count`, `url`, `title`.
- `nex web capture --mode bogus` → rejected with the updated
  `allowed: meta, text, screenshot, dom, all` error.
- `nex web console --follow` (single subscriber): registered without
  closing the reply; three `console.log`/`warn`/`error` calls via
  `nex web exec` streamed live, one JSON line each, in order.
- Two concurrent `--follow` subscribers on the same pane both received
  an identical broadcast of a new console line — no duplication, no
  cross-talk.
- `--follow` + Ctrl-C (`kill -INT`): CLI exits cleanly; app stays
  healthy afterward (`nex doctor` still all-PASS).
- Closing the web pane while a `--follow` subscriber was attached
  cleanly terminated the CLI process (server closed the FD) and left
  the app healthy — no hang, no orphaned handle.
- `--follow --json`: catch-up envelope and streamed lines both emit as
  single-line JSON objects.

Closes #145

🤖 Generated autonomously in a sandboxed macOS VM — implemented, built,
tested, and UI-validated end to end.