### PR TITLE
fix(#127): ⌘W no longer closes the main application window

### DIFF
--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -208,9 +208,18 @@ final class PaneShortcutMonitor {
             return true
         }
 
-        guard let activeID = store.activeWorkspaceID else { return false }
-
         let trigger = KeyTrigger(event: event)
+
+        guard let activeID = store.activeWorkspaceID else {
+            // Even with no active workspace (e.g. the last one was just
+            // closed via ⌘W, landing on the "no workspace selected"
+            // placeholder), a pane-close shortcut must still be consumed
+            // here — otherwise it falls through to AppKit's default
+            // "Close Window", taking the app's only window with no way
+            // to bring it back (issue #127). Nothing to close, so it's a
+            // no-op beyond consuming the event.
+            return store.configHotkey.keybindings.action(for: trigger) == .closePane
+        }
 
         // Belt-and-braces: if the user configured a global hotkey that also
         // matches an in-app binding, skip the in-app dispatch. Carbon
@@ -535,7 +544,12 @@ final class PaneShortcutMonitor {
     private func handleClosePane(activeWorkspaceID id: UUID) -> Bool {
         guard let workspace = store.workspaces[id: id],
               let focusedID = workspace.focusedPaneID
-        else { return false }
+        else {
+            // Stale/inconsistent state (no such workspace, or no focused
+            // pane to close) — still consume so ⌘W never falls through to
+            // AppKit's default "Close Window" on the main window (#127).
+            return true
+        }
 
         // Last pane — close the workspace instead. Warn first if it has
         // active agents (same gate as the sidebar Delete item), so ⌘W

--- a/NexTests/PaneShortcutMonitorTests.swift
+++ b/NexTests/PaneShortcutMonitorTests.swift
@@ -361,6 +361,32 @@ struct PaneShortcutMonitorTests {
         #expect(store.workspaces[id: Self.wsID] == nil)
     }
 
+    /// Regression test for issue #127: pressing ⌘W a second time after it
+    /// deleted the only workspace (leaving no active workspace) must still
+    /// be consumed — otherwise it falls through to AppKit's default
+    /// "Close Window" and takes the app's only window with it.
+    @Test func cmdWAfterLastWorkspaceDeletedIsStillConsumed() {
+        let ws = Self.makeWorkspace()
+        let (store, monitor) = makeStoreAndMonitor(
+            workspaces: [ws],
+            activeWorkspaceID: Self.wsID
+        )
+
+        let event = keyEvent(keyCode: 13, modifierFlags: .command)
+        #expect(monitor.handleKeyEvent(event) == true)
+        #expect(store.activeWorkspaceID == nil)
+
+        // The follow-up press, with no active workspace, must also be
+        // consumed rather than falling through.
+        #expect(monitor.handleKeyEvent(event) == true)
+    }
+
+    @Test func cmdWWithNoWorkspacesAtAllIsConsumed() {
+        let (_, monitor) = makeStoreAndMonitor()
+        let event = keyEvent(keyCode: 13, modifierFlags: .command)
+        #expect(monitor.handleKeyEvent(event) == true)
+    }
+
     // MARK: - Workspace switching
 
     @Test func cmdOptDownSwitchesToNextWorkspace() {


### PR DESCRIPTION
## Summary

- `PaneShortcutMonitor.handleKeyEvent` returned `false` (event unconsumed) whenever there was no active workspace, and `handleClosePane` returned `false` when there was no focused pane to close in the active workspace. Either path let the ⌘W key event fall through past our pane-close handling to AppKit's default "Close Window" behavior on the app's only `NSWindow` — closing it with no way to bring it back short of relaunching Nex.
- Repro: single workspace with a single pane → ⌘W deletes the workspace (existing, intended behavior — lands on the "No workspace selected" placeholder) → ⌘W again → previously closed the whole window; now it's a no-op (nothing left to close, but the event is still consumed).
- Both fallthrough points now consume the event unconditionally instead of returning `false`, so ⌘W (or whatever key the user has bound to `close_pane`) can never leak to AppKit's default window-close handler.
- Deliberately scoped to the exact fallthrough bug in the issue title/repro. The broader "make a closed window recoverable" ask from the issue body already has its own dedicated ticket (#130, with its own plan to switch to a single-instance `Window` scene + `applicationShouldHandleReopen` + a `Window > Show Window` menu item) — out of scope here to avoid overlapping that work.

Closes #127

## Validation

Implemented, built, and UI-tested autonomously in a sandboxed VM.

- **CLI-driven setup**: confirmed a fresh launch has exactly one workspace ("Default") with one pane via `nex pane list --json`.
- **Exact repro from the issue** (screenshots `01`–`03` in the PR): pressed ⌘W once on the single pane → workspace deleted, "No workspace selected" placeholder shown (window still open, expected). Pressed ⌘W a second time on the placeholder → **before the fix this closed the entire app window**; after the fix the window stays open and the app remains fully usable.
- **Recovery still works**: clicked "Create Workspace" from the placeholder, created a new workspace named "Regression" — confirms nothing is broken by the fix (screenshots `04`–`05`).
- **Positive regression — multi-pane ⌘W**: split the pane (⌘D), pressed ⌘W → only the focused pane closed, workspace/window stayed open with 1 pane remaining (screenshots `06`–`07`).
- Full `xcodebuild test` suite (1390 tests) passes, including two new regression tests in `PaneShortcutMonitorTests`:
  - `cmdWAfterLastWorkspaceDeletedIsStillConsumed` — the exact issue repro at the unit level.
  - `cmdWWithNoWorkspacesAtAllIsConsumed` — no-workspace edge case.
- `swiftformat --lint` / `swiftlint lint` show zero new violations on the touched files (pre-existing `wrapIfStatementBodies` debt elsewhere in `NexCommands.swift` is unchanged by this diff).

## Test plan

- [x] Manually reproduce: single workspace/pane → ⌘W → ⌘W again → window should stay open (not vanish).
- [x] Confirm ⌘W with multiple panes still closes only the focused pane.
- [x] Confirm ⌘W with a single pane in a multi-workspace setup still deletes that workspace and switches to another, as before.