### PR TITLE
feat: add Window > Show Nex Window menu command

### DIFF
--- a/Nex/Commands/NexCommands.swift
+++ b/Nex/Commands/NexCommands.swift
@@ -5,6 +5,26 @@ import SwiftUI
 struct NexCommands: Commands {
     let store: StoreOf<AppReducer>
 
+    @Environment(\.openWindow) private var openWindow
+
+    /// Bring the main window back, whatever state it's in: minimized →
+    /// deminiaturize, behind / on another Space → order front, closed via
+    /// the red traffic light → recreate the WindowGroup scene by id (the
+    /// closed window is released, so there is nothing left to order
+    /// front; `MainWindowRegistry` relinquished primary on close, so the
+    /// recreated window re-claims it like a Dock-icon reopen).
+    private func showMainWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+        if let window = MainWindowRegistry.primary {
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
+            window.makeKeyAndOrderFront(nil)
+        } else {
+            openWindow(id: NexApp.mainSceneID)
+        }
+    }
+
     var body: some Commands {
         // Replace the default "New Window" (⌘N) with "New Workspace"
         CommandGroup(replacing: .newItem) {
@@ -65,6 +85,15 @@ struct NexCommands: Commands {
 
             menuButton("Toggle Inspector", action: .toggleInspector) {
                 store.send(.toggleInspector)
+            }
+        }
+
+        // Window — recovery path for a window closed via the red traffic
+        // light: with no main window left, only the menu bar (and Dock)
+        // can bring Nex back.
+        CommandGroup(after: .windowArrangement) {
+            Button("Show Nex Window") {
+                showMainWindow()
             }
         }
 

--- a/Nex/NexApp.swift
+++ b/Nex/NexApp.swift
@@ -37,8 +37,14 @@ struct NexApp: App {
             || NSClassFromString("XCTestCase") != nil
     }
 
+    /// Scene id of the main WindowGroup — lets the Window ▸ Show Nex Window
+    /// menu command recreate the window via `openWindow` after the user
+    /// closes it with the red traffic light (there is no window left to
+    /// order front, and only scenes with an id can be reopened by id).
+    static let mainSceneID = "main"
+
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: Self.mainSceneID) {
             RootChromeView(store: store)
                 .environment(\.surfaceManager, SurfaceManager.liveValue)
                 .environment(\.socketServer, SocketServer.liveValue)


### PR DESCRIPTION
## Summary

Closing the main window with the red traffic light leaves Nex running with no window and no in-app way to get it back (only the Dock icon reopen). This adds **Window ▸ Show Nex Window**, which recovers the window from any stranded state:

- **Minimized** → deminiaturize + key
- **Behind other windows / another Space** → activate + order front
- **Closed via the red traffic light** → recreate the WindowGroup scene via `openWindow(id:)` — the main `WindowGroup` now has a stable `"main"` scene id. `MainWindowRegistry` already relinquishes primary on close, so the recreated window re-claims primary exactly like the existing Dock-icon reopen path (frame restore included via `WindowFrameRestorer`).

## Test plan

- [x] Build + full test suite (only pre-existing `RecursiveFSWatcherTests` FSEvents-timing flake fails — reproduced identically on plain `main`)
- [x] Manual: close window with red traffic light → Window ▸ Show Nex Window brings it back with panes intact (surfaces persist in `SurfaceManager`, so PTYs survive)
- [x] Manual: ⌘M minimize → menu item deminiaturizes
- [x] Manual: window behind another app → menu item brings to front

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8onyu3wAEXYxsqcrUZ4Rv