### PR TITLE
fix(#189): cmd-click links while a fullscreen TUI has captured the mouse

### DIFF
--- a/Nex/Ghostty/GhosttyApp.swift
+++ b/Nex/Ghostty/GhosttyApp.swift
@@ -267,15 +267,7 @@ final class GhosttyApp {
         case GHOSTTY_ACTION_OPEN_URL:
             let openUrl = action.action.open_url
             guard let urlPtr = openUrl.url else { return false }
-            // Ghostty's URL regex includes trailing spaces that run to end-of-line
-            // (see ghostty/src/config/url.zig `trailing_spaces_at_eol`), so a path
-            // matched at the end of a terminal line arrives padded with spaces.
-            // Trim before the .md suffix check or we'd silently fall through to
-            // ghostty's default opener and `open(1)` would fail.
-            var urlString = String(cString: urlPtr).trimmingCharacters(in: .whitespacesAndNewlines)
-            while urlString.hasSuffix(".") {
-                urlString.removeLast()
-            }
+            let urlString = Self.trimmedLinkString(String(cString: urlPtr))
             let path = NSString(string: urlString).standardizingPath
             guard path.hasSuffix(".md") else { return false }
             let surface = target.tag == GHOSTTY_TARGET_SURFACE ? target.target.surface : nil
@@ -401,6 +393,45 @@ final class GhosttyApp {
         default:
             return false
         }
+    }
+
+    /// Trims the padding libghostty's URL regex bakes into matched text:
+    /// trailing spaces that run to end-of-line (see
+    /// `ghostty/src/config/url.zig` `trailing_spaces_at_eol`) and a trailing
+    /// sentence-ending period. Shared by `GHOSTTY_ACTION_OPEN_URL` and the
+    /// cmd-click-while-mouse-captured path in `openExternalLink`.
+    private nonisolated static func trimmedLinkString(_ raw: String) -> String {
+        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        while trimmed.hasSuffix(".") {
+            trimmed.removeLast()
+        }
+        return trimmed
+    }
+
+    /// Opens a link `SurfaceView.mouseDown` detected itself (via
+    /// `GhosttySurface.readText(row:columns:)`) for the cmd-click-while-
+    /// mouse-captured case, where the click is intercepted instead of
+    /// forwarded to libghostty (issue #189 — forwarding it would just hand
+    /// the click to a fullscreen TUI that has captured the mouse, instead of
+    /// opening the link). Mirrors `GHOSTTY_ACTION_OPEN_URL`'s routing: `.md`
+    /// paths open in a Nex markdown pane, everything else opens in the
+    /// default app/browser. Must be called on the main thread.
+    static func openExternalLink(_ raw: String, surface: ghostty_surface_t?) {
+        let urlString = trimmedLinkString(raw)
+        let path = NSString(string: urlString).standardizingPath
+        if path.hasSuffix(".md") {
+            NotificationCenter.default.post(
+                name: Self.openFileNotification,
+                object: nil,
+                userInfo: [
+                    "path": path,
+                    "surface": surface as Any
+                ]
+            )
+            return
+        }
+        guard let url = URL(string: urlString) else { return }
+        NSWorkspace.shared.open(url)
     }
 
     deinit {

--- a/Nex/Ghostty/GhosttySurface.swift
+++ b/Nex/Ghostty/GhosttySurface.swift
@@ -256,4 +256,27 @@ final class GhosttySurface {
         guard let ptr = text.text else { return "" }
         return String(cString: ptr)
     }
+
+    /// Read the text of a single viewport row (0-indexed from the top of the
+    /// visible screen). Used for local link detection on cmd-click when the
+    /// mouse is captured by the foreground program — libghostty's own
+    /// hover/click link detection doesn't run against a captured surface
+    /// (`GHOSTTY_ACTION_MOUSE_OVER_LINK` never fires with a URL there), so
+    /// `SurfaceView.mouseDown` reads the row itself and matches a link
+    /// against it (issue #189).
+    func readText(row: UInt32, columns: UInt32) -> String? {
+        guard columns > 0 else { return nil }
+        let selection = ghostty_selection_s(
+            top_left: ghostty_point_s(tag: GHOSTTY_POINT_VIEWPORT, coord: GHOSTTY_POINT_COORD_EXACT, x: 0, y: row),
+            bottom_right: ghostty_point_s(
+                tag: GHOSTTY_POINT_VIEWPORT, coord: GHOSTTY_POINT_COORD_EXACT, x: columns - 1, y: row
+            ),
+            rectangle: false
+        )
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_text(surface, selection, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard let ptr = text.text else { return "" }
+        return String(cString: ptr)
+    }
 }

--- a/Nex/Ghostty/SurfaceView.swift
+++ b/Nex/Ghostty/SurfaceView.swift
@@ -465,9 +465,67 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
         return NSPoint(x: point.x, y: frame.height - point.y)
     }
 
+    /// Finds a link at a ghostty-space point by reading that row's text and
+    /// matching it with `NSDataDetector`. Used only for the mouse-captured
+    /// cmd-click path (see `mouseDown`) — libghostty's own link detection is
+    /// unavailable there, so this re-derives "what's under the cursor" from
+    /// scratch. Column math assumes one grid column per character, which
+    /// holds for the ASCII URLs/paths this targets; it isn't attempted for
+    /// wide (e.g. CJK) text preceding the link on the same row.
+    private func detectLink(at point: NSPoint) -> String? {
+        guard let ghosttySurface else { return nil }
+        let size = ghosttySurface.size
+        guard size.cell_width_px > 0, size.cell_height_px > 0, size.columns > 0, size.rows > 0 else { return nil }
+        let scale = window?.backingScaleFactor ?? 2.0
+        let cellWidth = CGFloat(size.cell_width_px) / scale
+        let cellHeight = CGFloat(size.cell_height_px) / scale
+        guard cellWidth > 0, cellHeight > 0 else { return nil }
+        let row = Int(point.y / cellHeight)
+        let col = Int(point.x / cellWidth)
+        guard row >= 0, row < Int(size.rows), col >= 0 else { return nil }
+
+        guard let rowText = ghosttySurface.readText(row: UInt32(row), columns: UInt32(size.columns)),
+              let detector = Self.linkDetector else { return nil }
+        let nsText = rowText as NSString
+        for match in detector.matches(in: rowText, range: NSRange(location: 0, length: nsText.length))
+            where match.range.location <= col && col < match.range.location + match.range.length {
+            return nsText.substring(with: match.range)
+        }
+        return nil
+    }
+
+    private static let linkDetector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+
+    /// Link found under the cursor by `mouseDown`'s cmd-click interception,
+    /// carried through to `mouseUp` so the actual open happens on release
+    /// (matching the drag-away-cancels convention of a normal click) — nil
+    /// means this click isn't a link-open, so `mouseUp` forwards normally.
+    private var interceptedLinkClick: String?
+
     override func mouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
         let point = mousePoint(from: event)
+
+        // A cmd-click on a link normally opens it via libghostty's own
+        // GHOSTTY_ACTION_OPEN_URL (fired from ghostty_surface_mouse_button).
+        // But when the foreground program has captured the mouse (e.g. a
+        // fullscreen TUI like Claude Code, running in the alternate screen
+        // buffer with mouse reporting enabled), forwarding the click instead
+        // hands it to the program as a raw mouse-report escape sequence — the
+        // program doesn't understand it as "open this link" and the browser
+        // never opens (issue #189). libghostty's own link detection doesn't
+        // help here either: it skips hover/click link matching entirely on a
+        // captured surface. So detect the link ourselves from the clicked
+        // row's text and, if found, intercept the click instead of
+        // forwarding anything to the captured program.
+        interceptedLinkClick = nil
+        if event.modifierFlags.contains(.command), ghosttySurface?.mouseCaptured == true {
+            interceptedLinkClick = detectLink(at: point)
+            if interceptedLinkClick != nil {
+                return
+            }
+        }
+
         ghosttySurface?.sendMousePos(x: point.x, y: point.y, mods: Self.mods(from: event))
         _ = ghosttySurface?.sendMouseButton(
             state: GHOSTTY_MOUSE_PRESS,
@@ -477,6 +535,15 @@ final class SurfaceView: NSView, @preconcurrency NSTextInputClient {
     }
 
     override func mouseUp(with event: NSEvent) {
+        if let link = interceptedLinkClick {
+            interceptedLinkClick = nil
+            let surface = ghosttySurface?.surface
+            MainActor.assumeIsolated {
+                GhosttyApp.openExternalLink(link, surface: surface)
+            }
+            return
+        }
+
         let point = mousePoint(from: event)
         ghosttySurface?.sendMousePos(x: point.x, y: point.y, mods: Self.mods(from: event))
         _ = ghosttySurface?.sendMouseButton(


### PR DESCRIPTION
## Summary

- Cmd-clicking a URL stopped opening the browser whenever the pane's foreground program had captured the mouse (`ghostty_surface_mouse_captured`) — e.g. Claude Code's fullscreen TUI running in the alternate screen buffer with SGR mouse reporting enabled. The click was forwarded to libghostty as a normal mouse event, which — because the program owns mouse input in that mode — encodes it as a raw mouse-report escape sequence for the PTY instead of triggering `GHOSTTY_ACTION_OPEN_URL`. libghostty's own hover/click link detection is also unavailable on a captured surface (confirmed empirically — `GHOSTTY_ACTION_MOUSE_OVER_LINK` never returns a URL there, even with cmd held), so there was no way to recover the link from libghostty's side.
- `SurfaceView.mouseDown` now checks `ghosttySurface.mouseCaptured` when cmd is held: if the mouse is captured, it reads the clicked row's text via a new `GhosttySurface.readText(row:columns:)` and matches a link at the clicked column with `NSDataDetector`. If a link is found, the click is intercepted locally (nothing is forwarded to the captured program) and opened on `mouseUp` via a new `GhosttyApp.openExternalLink` helper, which mirrors the existing `GHOSTTY_ACTION_OPEN_URL` routing (`.md` → Nex markdown pane, everything else → default app/browser).
- Every other click path is unchanged: cmd-click on a non-captured surface still goes through libghostty's existing `GHOSTTY_ACTION_OPEN_URL` action untouched, and cmd-click on a captured surface with no link under the cursor falls through to the original forwarding behavior.

Closes #189

## Validation

All done autonomously in a sandboxed VM by building the app, launching it, and driving it via the bundled `nex` CLI + a UI automation helper (screenshots below). Since the VM doesn't have Claude Code installed, a fullscreen TUI was faithfully simulated with raw ANSI escapes: `\033[?1049h` (alternate screen) + `\033[?1002h\033[?1006h` (SGR mouse reporting) — the same mode a Claude Code / vim / htop style TUI enables — with a background reader consuming stdin so the pane behaves like a real captured program.

- **Exact issue repro (fixed)**: pane in alt-screen + mouse-reporting mode showing a URL → cmd-click → Safari opens to the URL, and `nex pane capture` on the pane afterward shows **no leaked raw mouse-report bytes** (previously `^[[<0;15;1M^[[<0;15;1m`-style garbage leaked into the program's input). See `issue189-before-cmdclick-altscreen-mousereport.png` / `issue189-after-cmdclick-opens-browser.png`.
- **Regression — normal (non-captured) pane**: cmd-click on a URL in a plain shell still opens the browser via the pre-existing `GHOSTTY_ACTION_OPEN_URL` path, unaffected by this change. See `issue189-regression-normal-mode-setup.png` / `issue189-regression-normal-mode-cmdclick-opens-browser.png`.
- **Edge case — captured pane, no link under the cursor**: cmd-click on a line with no URL falls through to normal forwarding exactly as before (no crash, no behavior change). See `issue189-edgecase-no-link-under-cursor-setup.png` / `issue189-edgecase-no-link-under-cursor-no-crash.png`.
- Full `xcodebuild test` suite: **1390/1390 passed**, 0 failures.
- `swiftlint lint` on the changed files: 0 violations. `swiftformat --lint` on the changed files: no new violations introduced (pre-existing `wrapIfStatementBodies` findings elsewhere in these files, unrelated to this diff, were left untouched to keep the change minimal).

### Known limitation (out of scope for this fix)

Bare filesystem paths (e.g. a `.md` path with no `http(s)://` scheme) are not matched by `NSDataDetector`, so cmd-click on a bare path while the mouse is captured is not reliably fixed by this change — it falls back to the pre-existing (already inconsistent) forwarding behavior, unchanged from before this PR. The issue's repro and description are specifically about URLs, which this fixes.

## Test plan

- [ ] Cmd-click a URL printed inside a real Claude Code session's fullscreen TUI and confirm it opens in the default browser.
- [ ] Cmd-click a `.md` path printed inside a fullscreen TUI (vim, htop, etc. with mouse mode on) and confirm current (unchanged) behavior.
- [ ] Cmd-click a URL in a normal, non-TUI shell pane and confirm no regression.