### PR TITLE
feat(graft): graft into another worktree via --into

### DIFF
--- a/Nex/AppReducer+Socket.swift
+++ b/Nex/AppReducer+Socket.swift
@@ -580,12 +580,13 @@ extension AppReducer {
                         reply: reply
                     )
 
-                case .graftStart(let workspaceFilter, let repoFilter, let paneID):
+                case .graftStart(let workspaceFilter, let repoFilter, let paneID, let into):
                     return handleGraftStart(
                         state: state,
                         workspaceFilter: workspaceFilter,
                         repoFilter: repoFilter,
                         paneID: paneID,
+                        into: into,
                         reply: reply
                     )
 

--- a/Nex/AppReducer.swift
+++ b/Nex/AppReducer.swift
@@ -876,6 +876,7 @@ struct AppReducer {
         workspaceFilter: String?,
         repoFilter: String?,
         paneID: UUID?,
+        into: String?,
         reply: SocketServer.ReplyHandle?
     ) -> Effect<Action> {
         let assocs: [RepoAssociation]
@@ -893,13 +894,26 @@ struct AppReducer {
             return .none
         }
 
+        // An explicit destination is a single-target operation — with
+        // several associations in scope they'd all race to claim the
+        // same destination root and every one but the first would
+        // fail with `alreadyActive`. Make the ambiguity a hard error.
+        if into != nil, assocs.count > 1 {
+            reply?.send([
+                "ok": false,
+                "error": "--into requires a single association in scope; narrow with --repo"
+            ])
+            reply?.close()
+            return .none
+        }
+
         return .run { [graftService] _ in
             var started: [[String: Any]] = []
             var failedAny = false
             var lastError: String?
             for assoc in assocs {
                 do {
-                    let session = try await graftService.start(assoc)
+                    let session = try await graftService.start(assoc, into)
                     started.append([
                         "association_id": session.id.uuidString,
                         "worktree_path": session.worktreePath,
@@ -2179,7 +2193,17 @@ struct AppReducer {
                     }
                 }
 
-                let parentRepoRoots = Array(Set(state.repoRegistry.map(\.path)))
+                // Scan registered repo roots AND every association's
+                // worktree path for orphaned breadcrumbs — a graft
+                // with an explicit `--into <worktree>` destination
+                // leaves its breadcrumb in that worktree's git dir,
+                // not the main checkout's.
+                let parentRepoRoots = Array(Set(
+                    state.repoRegistry.map(\.path)
+                        + state.workspaces.flatMap { ws in
+                            ws.repoAssociations.map(\.worktreePath)
+                        }
+                ))
                 return .merge(
                     [
                         .run { send in

--- a/Nex/Features/Graft/GraftFeature.swift
+++ b/Nex/Features/Graft/GraftFeature.swift
@@ -141,7 +141,7 @@ struct GraftFeature {
                     ))
                     return .run { send in
                         do {
-                            let session = try await graftService.start(association)
+                            let session = try await graftService.start(association, nil)
                             await send(.startSucceeded(session))
                         } catch {
                             await send(.startFailed(
@@ -297,7 +297,7 @@ struct GraftFeature {
                         return
                     }
                     do {
-                        let session = try await graftService.start(prompt.newAssociation)
+                        let session = try await graftService.start(prompt.newAssociation, nil)
                         await send(.startSucceeded(session))
                     } catch {
                         // Stop succeeded; start failed. BOTH sides

--- a/Nex/Services/GraftService.swift
+++ b/Nex/Services/GraftService.swift
@@ -12,6 +12,10 @@ enum GraftSessionStatus: Equatable {
 struct GraftSession: Equatable, Identifiable {
     var id: UUID
     var worktreePath: String
+    /// Destination checkout root the worktree mirrors into. The
+    /// parent repo's main checkout by default; with an explicit
+    /// `--into` target it can be another linked worktree of the
+    /// same repository (a hub).
     var parentRepoRoot: String
     var branch: String
     var status: GraftSessionStatus
@@ -70,11 +74,18 @@ enum GraftError: Error, Equatable {
     /// LINKED worktree back to its parent; running it on the parent
     /// itself would be a self-reference with no useful mirroring.
     case notAWorktree(path: String)
+    /// Refuses an explicit `--into` destination that isn't usable:
+    /// not a git checkout, a checkout of a different repository than
+    /// the source worktree, or the source checkout itself.
+    case invalidGraftTarget(path: String, reason: String)
     case unknown(String)
 }
 
 struct GraftService {
-    var start: @Sendable (_ association: RepoAssociation) async throws -> GraftSession
+    /// `intoPath` optionally overrides the destination: any other
+    /// checkout of the same repository (typically a linked worktree
+    /// acting as a hub). `nil` = the parent repo's main checkout.
+    var start: @Sendable (_ association: RepoAssociation, _ intoPath: String?) async throws -> GraftSession
     var stop: @Sendable (_ associationID: UUID) async throws -> Void
     var activeSessions: @Sendable () async -> [GraftSession]
     var updates: @Sendable () -> AsyncStream<GraftSessionEvent>
@@ -135,22 +146,50 @@ final class GraftServiceImpl: Sendable {
 
     // MARK: - Start
 
-    func start(_ association: RepoAssociation) async throws -> GraftSession {
+    func start(_ association: RepoAssociation, into intoPath: String? = nil) async throws -> GraftSession {
         let worktreePath = association.worktreePath
         guard let info = await gitService.resolveRepoRoot(worktreePath) else {
             throw GraftError.missingWorktree(worktreePath: worktreePath)
         }
-        let parentRepoRoot = canonicalize(info.parentRepoRoot)
+        let mainCheckoutRoot = canonicalize(info.parentRepoRoot)
         let worktreeRoot = canonicalize(info.worktreeRoot)
 
-        // Refuse to graft the parent repo onto itself. Graft only
-        // makes sense for a linked worktree mirroring back to its
-        // parent — running it on the parent's main checkout would
-        // mean we'd stash the user's edits, checkout themselves,
-        // sync themselves, and rewind themselves, which is just an
-        // expensive no-op (or worse, a stash conflict).
-        guard worktreeRoot != parentRepoRoot else {
-            throw GraftError.notAWorktree(path: worktreePath)
+        // Resolve the destination checkout. Default: the parent
+        // repo's main checkout (derived from the git common dir).
+        // An explicit `--into` target lets any OTHER checkout of the
+        // SAME repository act as the destination — typically a linked
+        // worktree serving as a hub that runs the dev servers.
+        let parentRepoRoot: String
+        if let intoPath {
+            guard let targetInfo = await gitService.resolveRepoRoot(intoPath) else {
+                throw GraftError.invalidGraftTarget(
+                    path: intoPath, reason: "not a git checkout"
+                )
+            }
+            let targetRoot = canonicalize(targetInfo.worktreeRoot)
+            guard canonicalize(targetInfo.parentRepoRoot) == mainCheckoutRoot else {
+                throw GraftError.invalidGraftTarget(
+                    path: intoPath,
+                    reason: "belongs to a different repository than the source worktree"
+                )
+            }
+            guard targetRoot != worktreeRoot else {
+                throw GraftError.invalidGraftTarget(
+                    path: intoPath, reason: "destination is the source worktree itself"
+                )
+            }
+            parentRepoRoot = targetRoot
+        } else {
+            // Refuse to graft the parent repo onto itself. Graft only
+            // makes sense for a linked worktree mirroring back to its
+            // parent — running it on the parent's main checkout would
+            // mean we'd stash the user's edits, checkout themselves,
+            // sync themselves, and rewind themselves, which is just an
+            // expensive no-op (or worse, a stash conflict).
+            guard worktreeRoot != mainCheckoutRoot else {
+                throw GraftError.notAWorktree(path: worktreePath)
+            }
+            parentRepoRoot = mainCheckoutRoot
         }
 
         // Reject if the parent root is already being grafted into —
@@ -784,10 +823,36 @@ final class GraftServiceImpl: Sendable {
         let worktreePreGraftSha: String?
     }
 
+    /// The destination checkout's git metadata directory. For a main
+    /// checkout `<root>/.git` IS a directory; for a linked worktree
+    /// destination it's a FILE containing `gitdir: <path>` pointing at
+    /// `<common>/.git/worktrees/<name>` — follow the pointer so the
+    /// breadcrumb lands in a writable, per-checkout location either
+    /// way (writing "into" a `.git` file would fail with ENOTDIR).
+    private func gitDirPath(for checkoutRoot: String) -> String {
+        let dotGit = (checkoutRoot as NSString).appendingPathComponent(".git")
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: dotGit, isDirectory: &isDir),
+              !isDir.boolValue else {
+            return dotGit
+        }
+        guard let contents = try? String(contentsOfFile: dotGit, encoding: .utf8),
+              let line = contents
+              .split(separator: "\n")
+              .first(where: { $0.hasPrefix("gitdir:") }) else {
+            return dotGit
+        }
+        let raw = line.dropFirst("gitdir:".count)
+            .trimmingCharacters(in: .whitespaces)
+        let resolved = raw.hasPrefix("/")
+            ? raw
+            : (checkoutRoot as NSString).appendingPathComponent(raw)
+        return (resolved as NSString).standardizingPath
+    }
+
     private func breadcrumbPath(at parentRepoRoot: String) -> String {
-        let gitDir = (parentRepoRoot as NSString)
-            .appendingPathComponent(".git")
-        return (gitDir as NSString).appendingPathComponent(Self.breadcrumbName)
+        (gitDirPath(for: parentRepoRoot) as NSString)
+            .appendingPathComponent(Self.breadcrumbName)
     }
 
     private func writeBreadcrumb(at parentRepoRoot: String, breadcrumb: Breadcrumb) throws {
@@ -845,7 +910,7 @@ extension GraftService: DependencyKey {
     ) -> GraftService {
         let impl = GraftServiceImpl(gitService: gitService, watcher: watcher)
         return GraftService(
-            start: { try await impl.start($0) },
+            start: { try await impl.start($0, into: $1) },
             stop: { try await impl.stop($0) },
             activeSessions: { await impl.activeSessions() },
             updates: { impl.updates() },

--- a/Nex/Services/SocketServer.swift
+++ b/Nex/Services/SocketServer.swift
@@ -166,8 +166,10 @@ enum SocketMessage: Equatable {
     /// `nex graft start` — begin worktree-to-root mirroring. `paneID`
     /// comes from `NEX_PANE_ID` and scopes resolution to the caller's
     /// workspace when neither `workspace` nor `repo` is supplied.
+    /// `into` (`--into <path>`) overrides the destination checkout —
+    /// another worktree of the same repo instead of the main checkout.
     /// Request/response — see `replyCommandAllowlist`.
-    case graftStart(workspace: String?, repo: String?, paneID: UUID?)
+    case graftStart(workspace: String?, repo: String?, paneID: UUID?, into: String?)
     /// `nex graft stop` — stop active sessions in scope.
     case graftStop(workspace: String?, repo: String?, paneID: UUID?)
     /// `nex graft status` — list active sessions across all workspaces.
@@ -862,6 +864,9 @@ final class SocketServer: Sendable {
         var scrollback: Bool?
         /// `graft-start` / `graft-stop` — repo name or path scope.
         var repo: String?
+        /// `graft-start` — explicit destination checkout path
+        /// (`--into`). Absent = the parent repo's main checkout.
+        var into: String?
         /// `web-open` / `web-url` etc. — destination URL or
         /// (for capture) the visible-text/screenshot/meta mode.
         var url: String?
@@ -989,6 +994,7 @@ final class SocketServer: Sendable {
             case targetPath = "target_path"
             case lines, scrollback
             case repo
+            case into
             case url, mode, hard
             case tab
             case makeActive = "make_active"
@@ -1187,7 +1193,8 @@ final class SocketServer: Sendable {
             let workspace = (wire.workspace?.isEmpty == true) ? nil : wire.workspace
             let repo = (wire.repo?.isEmpty == true) ? nil : wire.repo
             let paneID = wire.paneID.flatMap { UUID(uuidString: $0) }
-            return (.graftStart(workspace: workspace, repo: repo, paneID: paneID), wire)
+            let into = (wire.into?.isEmpty == true) ? nil : wire.into
+            return (.graftStart(workspace: workspace, repo: repo, paneID: paneID, into: into), wire)
         }
 
         if wire.command == "graft-stop" {

--- a/NexTests/AppReducerTests.swift
+++ b/NexTests/AppReducerTests.swift
@@ -561,7 +561,7 @@ struct AppReducerTests {
         )
         let stopRecorder = StopRecorder()
         store.dependencies.graftService = GraftService(
-            start: { _ in
+            start: { _, _ in
                 GraftSession(
                     id: UUID(), worktreePath: "", parentRepoRoot: "",
                     branch: "", status: .starting, stashRef: nil, lastSync: nil

--- a/NexTests/GraftCLIReplyTests.swift
+++ b/NexTests/GraftCLIReplyTests.swift
@@ -32,21 +32,23 @@ struct GraftCLIReplyTests {
         sessions: IdentifiedArrayOf<GraftSession> = [],
         activeSessions: @escaping @Sendable () async -> [GraftSession] = { [] },
         graftStartResult: @escaping @Sendable (RepoAssociation) async throws -> GraftSession,
-        graftStopResult: @escaping @Sendable (UUID) async throws -> Void = { _ in }
+        graftStartInto: LockedString? = nil,
+        graftStopResult: @escaping @Sendable (UUID) async throws -> Void = { _ in },
+        associations: [RepoAssociation]? = nil
     ) -> TestStoreOf<AppReducer> {
         var workspace = WorkspaceFeature.State(id: Self.wsID, name: "alpha")
         let pane = Pane(id: Self.paneID)
         workspace.panes = IdentifiedArrayOf(uniqueElements: [pane])
         workspace.layout = .leaf(Self.paneID)
         workspace.focusedPaneID = Self.paneID
-        workspace.repoAssociations = [
+        workspace.repoAssociations = IdentifiedArrayOf(uniqueElements: associations ?? [
             RepoAssociation(
                 id: Self.assocID,
                 repoID: Self.repoID,
                 worktreePath: "/tmp/wt",
                 branchName: "feature/x"
             )
-        ]
+        ])
 
         var appState = AppReducer.State()
         appState.workspaces = [workspace]
@@ -61,7 +63,10 @@ struct GraftCLIReplyTests {
             $0.surfaceManager = SurfaceManager()
             $0.continuousClock = ImmediateClock()
             $0.graftService = GraftService(
-                start: graftStartResult,
+                start: { assoc, into in
+                    if let into { graftStartInto?.set(into) }
+                    return try await graftStartResult(assoc)
+                },
                 stop: graftStopResult,
                 activeSessions: activeSessions,
                 updates: { AsyncStream { _ in } },
@@ -95,7 +100,7 @@ struct GraftCLIReplyTests {
         )
         let sink = CaptureSink()
         await store.send(.socketMessage(
-            .graftStart(workspace: nil, repo: nil, paneID: Self.paneID),
+            .graftStart(workspace: nil, repo: nil, paneID: Self.paneID, into: nil),
             reply: makeCaptureHandle(sink)
         ))
         await store.finish()
@@ -114,7 +119,7 @@ struct GraftCLIReplyTests {
         let store = makeStore(graftStartResult: { _ in session })
         let sink = CaptureSink()
         await store.send(.socketMessage(
-            .graftStart(workspace: nil, repo: nil, paneID: nil),
+            .graftStart(workspace: nil, repo: nil, paneID: nil, into: nil),
             reply: makeCaptureHandle(sink)
         ))
 
@@ -133,7 +138,7 @@ struct GraftCLIReplyTests {
 
         let sink = CaptureSink()
         await store.send(.socketMessage(
-            .graftStart(workspace: nil, repo: "my-repo", paneID: nil),
+            .graftStart(workspace: nil, repo: "my-repo", paneID: nil, into: nil),
             reply: makeCaptureHandle(sink)
         ))
         await store.finish()
@@ -147,12 +152,68 @@ struct GraftCLIReplyTests {
         let store = makeStore(graftStartResult: { _ in session })
         let sink = CaptureSink()
         await store.send(.socketMessage(
-            .graftStart(workspace: "nope", repo: nil, paneID: nil),
+            .graftStart(workspace: "nope", repo: nil, paneID: nil, into: nil),
             reply: makeCaptureHandle(sink)
         ))
 
         #expect(sink.payloads[0]["ok"] as? Bool == false)
         #expect((sink.payloads[0]["error"] as? String)?.contains("workspace not found") == true)
+    }
+
+    @Test func graftStartForwardsIntoDestinationToService() async {
+        let session = Self.makeSession()
+        let into = LockedString()
+        let store = makeStore(
+            graftStartResult: { _ in session },
+            graftStartInto: into
+        )
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .graftStart(workspace: nil, repo: nil, paneID: Self.paneID, into: "/tmp/hub"),
+            reply: makeCaptureHandle(sink)
+        ))
+        await store.finish()
+
+        #expect(sink.payloads[0]["ok"] as? Bool == true)
+        #expect(into.value == "/tmp/hub")
+    }
+
+    @Test func graftStartIntoWithMultipleAssociationsFails() async {
+        // `--into` names ONE destination; with several associations in
+        // scope they'd all race to claim it. Must be a hard error, and
+        // the service must never be called.
+        let session = Self.makeSession()
+        let startCalls = LockedString()
+        let store = makeStore(
+            graftStartResult: { assoc in
+                startCalls.set(assoc.id.uuidString)
+                return session
+            },
+            associations: [
+                RepoAssociation(
+                    id: Self.assocID,
+                    repoID: Self.repoID,
+                    worktreePath: "/tmp/wt",
+                    branchName: "feature/x"
+                ),
+                RepoAssociation(
+                    id: UUID(),
+                    repoID: Self.repoID,
+                    worktreePath: "/tmp/wt2",
+                    branchName: "feature/y"
+                )
+            ]
+        )
+        let sink = CaptureSink()
+        await store.send(.socketMessage(
+            .graftStart(workspace: nil, repo: "my-repo", paneID: nil, into: "/tmp/hub"),
+            reply: makeCaptureHandle(sink)
+        ))
+        await store.finish()
+
+        #expect(sink.payloads[0]["ok"] as? Bool == false)
+        #expect((sink.payloads[0]["error"] as? String)?.contains("--into") == true)
+        #expect(startCalls.value.isEmpty)
     }
 
     // MARK: - graft-stop

--- a/NexTests/GraftFeatureTests.swift
+++ b/NexTests/GraftFeatureTests.swift
@@ -34,7 +34,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in session },
+                start: { _, _ in session },
                 stop: { _ in },
                 activeSessions: { [] },
                 updates: { AsyncStream { _ in } },
@@ -71,7 +71,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in .init(id: Self.assocID, worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
+                start: { _, _ in .init(id: Self.assocID, worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
                 stop: { _ in },
                 activeSessions: { [] },
                 updates: { AsyncStream { _ in } },
@@ -103,7 +103,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
+                start: { _, _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
                 stop: { _ in },
                 activeSessions: { [] },
                 updates: { AsyncStream { _ in } },
@@ -143,7 +143,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in
+                start: { _, _ in
                     throw GraftError.alreadyActive(parentRepoRoot: "/tmp/repo")
                 },
                 stop: { _ in },
@@ -213,7 +213,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { assoc in
+                start: { assoc, _ in
                     startCalls.increment()
                     ordering.append("start:\(assoc.id.uuidString)")
                     return newSession
@@ -271,7 +271,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
+                start: { _, _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
                 stop: { _ in },
                 activeSessions: { [] },
                 updates: { AsyncStream { _ in } },
@@ -298,7 +298,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
+                start: { _, _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
                 stop: { _ in },
                 activeSessions: { [] },
                 updates: { AsyncStream { _ in } },
@@ -332,7 +332,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
+                start: { _, _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
                 stop: { _ in stopCalls.increment() },
                 activeSessions: { [] },
                 updates: { AsyncStream { _ in } },
@@ -360,7 +360,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
+                start: { _, _ in .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil) },
                 stop: { _ in stopCalls.increment() },
                 activeSessions: { [] },
                 updates: { AsyncStream { _ in } },
@@ -392,7 +392,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { assoc in
+                start: { assoc, _ in
                     ordering.append("start:\(assoc.id.uuidString)")
                     return restarted
                 },
@@ -434,7 +434,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in
+                start: { _, _ in
                     startCalls.increment()
                     return .init(id: UUID(), worktreePath: "", parentRepoRoot: "", branch: "", status: .starting, stashRef: nil, lastSync: nil)
                 },
@@ -485,7 +485,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in
+                start: { _, _ in
                     throw GraftError.alreadyActive(parentRepoRoot: "/tmp/repo")
                 },
                 stop: { _ in },
@@ -526,7 +526,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in
+                start: { _, _ in
                     throw GraftError.alreadyActive(parentRepoRoot: "/tmp/repo")
                 },
                 stop: { _ in },
@@ -561,7 +561,7 @@ struct GraftFeatureTests {
             GraftFeature()
         } withDependencies: {
             $0.graftService = GraftService(
-                start: { _ in
+                start: { _, _ in
                     throw GraftError.alreadyActive(parentRepoRoot: "/tmp/repo")
                 },
                 stop: { _ in },

--- a/NexTests/GraftServiceTests.swift
+++ b/NexTests/GraftServiceTests.swift
@@ -185,6 +185,98 @@ struct GraftServiceTests {
         }
     }
 
+    @Test func startIntoSiblingWorktreeSyncsThereAndStopRestores() async throws {
+        // `--into <path>`: a linked worktree of the same repo acts as
+        // the destination (hub) instead of the main checkout.
+        let env = try makeRepoEnv()
+        defer { env.cleanup() }
+        let hub = try addSiblingWorktree(parent: env.parent, name: "hub")
+        defer { try? FileManager.default.removeItem(atPath: hub) }
+        let watcher = RecursiveFSWatcher(backend: .test)
+        let impl = GraftServiceImpl(gitService: .live, watcher: watcher)
+
+        let hubInitialSHA = try shell("git", ["rev-parse", "HEAD"], at: hub)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let session = try await impl.start(env.association, into: hub)
+        #expect(session.parentRepoRoot.hasSuffix((hub as NSString).lastPathComponent))
+
+        // Breadcrumb lives in the hub worktree's own git dir (behind
+        // the `.git` FILE pointer), not the main checkout's `.git/`.
+        let hubGitDir = try shell(
+            "git", ["rev-parse", "--absolute-git-dir"], at: hub
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        let hubBreadcrumb = (hubGitDir as NSString)
+            .appendingPathComponent(GraftServiceImpl.breadcrumbName)
+        #expect(FileManager.default.fileExists(atPath: hubBreadcrumb))
+        let mainBreadcrumb = (env.parent as NSString)
+            .appendingPathComponent(".git/\(GraftServiceImpl.breadcrumbName)")
+        #expect(!FileManager.default.fileExists(atPath: mainBreadcrumb))
+
+        // A change in the source worktree lands in the hub, NOT in
+        // the main checkout.
+        let newFile = (env.worktree as NSString).appendingPathComponent("synced.txt")
+        try "hello hub".write(toFile: newFile, atomically: true, encoding: .utf8)
+        watcher.inject([newFile], into: env.worktree)
+        let hubFile = (hub as NSString).appendingPathComponent("synced.txt")
+        try await pollUntil(timeout: .seconds(5)) {
+            FileManager.default.fileExists(atPath: hubFile)
+        }
+        let mainFile = (env.parent as NSString).appendingPathComponent("synced.txt")
+        #expect(!FileManager.default.fileExists(atPath: mainFile))
+
+        try await impl.stop(env.association.id)
+
+        // Hub restored to its pre-graft state; breadcrumb gone.
+        let hubSHAAfter = try shell("git", ["rev-parse", "HEAD"], at: hub)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(hubSHAAfter == hubInitialSHA)
+        #expect(!FileManager.default.fileExists(atPath: hubFile))
+        #expect(!FileManager.default.fileExists(atPath: hubBreadcrumb))
+        // Source worktree untouched; the user's edit survives.
+        #expect(FileManager.default.fileExists(atPath: newFile))
+    }
+
+    @Test func startIntoRejectsCheckoutOfDifferentRepo() async throws {
+        let env = try makeRepoEnv()
+        defer { env.cleanup() }
+        let other = try makeRepoEnv()
+        defer { other.cleanup() }
+        let impl = GraftServiceImpl(
+            gitService: .live,
+            watcher: RecursiveFSWatcher(backend: .test)
+        )
+        do {
+            _ = try await impl.start(env.association, into: other.parent)
+            Issue.record("expected GraftError.invalidGraftTarget")
+        } catch let error as GraftError {
+            if case .invalidGraftTarget = error {
+                // ok
+            } else {
+                Issue.record("unexpected error: \(error)")
+            }
+        }
+    }
+
+    @Test func startIntoRejectsSourceWorktreeItself() async throws {
+        let env = try makeRepoEnv()
+        defer { env.cleanup() }
+        let impl = GraftServiceImpl(
+            gitService: .live,
+            watcher: RecursiveFSWatcher(backend: .test)
+        )
+        do {
+            _ = try await impl.start(env.association, into: env.worktree)
+            Issue.record("expected GraftError.invalidGraftTarget")
+        } catch let error as GraftError {
+            if case .invalidGraftTarget = error {
+                // ok
+            } else {
+                Issue.record("unexpected error: \(error)")
+            }
+        }
+    }
+
     @Test func stopAfterDirtyStartPopsStashAndRemovesBreadcrumb() async throws {
         let env = try makeRepoEnv()
         defer { env.cleanup() }

--- a/NexTests/SocketParsingTests.swift
+++ b/NexTests/SocketParsingTests.swift
@@ -912,7 +912,7 @@ struct SocketParsingTests {
         {"command":"graft-start","workspace":"Dev","repo":"my-repo","pane_id":"\(Self.paneIDString)"}
         """)
         let result = SocketServer.parseWireMessage(data)
-        #expect(result?.0 == .graftStart(workspace: "Dev", repo: "my-repo", paneID: Self.paneUUID))
+        #expect(result?.0 == .graftStart(workspace: "Dev", repo: "my-repo", paneID: Self.paneUUID, into: nil))
     }
 
     @Test func parseGraftStartBare() {
@@ -920,15 +920,23 @@ struct SocketParsingTests {
         {"command":"graft-start"}
         """)
         let result = SocketServer.parseWireMessage(data)
-        #expect(result?.0 == .graftStart(workspace: nil, repo: nil, paneID: nil))
+        #expect(result?.0 == .graftStart(workspace: nil, repo: nil, paneID: nil, into: nil))
     }
 
     @Test func parseGraftStartEmptyStringsNormalised() {
         let data = jsonData("""
-        {"command":"graft-start","workspace":"","repo":""}
+        {"command":"graft-start","workspace":"","repo":"","into":""}
         """)
         let result = SocketServer.parseWireMessage(data)
-        #expect(result?.0 == .graftStart(workspace: nil, repo: nil, paneID: nil))
+        #expect(result?.0 == .graftStart(workspace: nil, repo: nil, paneID: nil, into: nil))
+    }
+
+    @Test func parseGraftStartWithIntoDestination() {
+        let data = jsonData("""
+        {"command":"graft-start","repo":"my-repo","into":"/tmp/hub"}
+        """)
+        let result = SocketServer.parseWireMessage(data)
+        #expect(result?.0 == .graftStart(workspace: nil, repo: "my-repo", paneID: nil, into: "/tmp/hub"))
     }
 
     @Test func parseGraftStop() {

--- a/README.md
+++ b/README.md
@@ -177,10 +177,13 @@ When creating a workspace you can attach one or more registered repos and option
 Toggle graft on a repo association from the inspector to mirror the worktree's working-tree changes back into the parent checkout in real time. Useful when you want to leave your IDE pointed at the main checkout while an agent works in a worktree. State, including checkpoint SHA and pre-graft branch, is captured so toggling off restores the parent to where it was. Orphaned breadcrumbs from interrupted sessions are detected on launch and surfaced as a recovery banner.
 
 ```bash
-nex graft start   # attach the current pane's worktree to its parent repo
-nex graft status  # human-readable, or --json for tooling
+nex graft start                # attach the current pane's worktree to its parent repo
+nex graft start --into <path>  # graft into another worktree of the same repo instead of the main checkout
+nex graft status               # human-readable, or --json for tooling
 nex graft stop
 ```
+
+`--into` lets any other checkout of the same repository act as the destination — e.g. a hub worktree that runs the dev servers — instead of the repo's main checkout. It requires a single association in scope (narrow with `--repo`).
 
 ### Live git status
 
@@ -232,7 +235,7 @@ nex layout cycle | select <name>
 nex open  [--here] <path>     # routes by file type: .md→markdown preview, .html/.htm/.pdf/.svg + images→web pane
 nex md    [--here] <path>     # always opens a markdown preview pane (--here reuses the calling pane)
 nex diff  [<path>]            # opens a diff pane for the current repo
-nex graft start | stop | status [--json]
+nex graft start | stop | status [--json]   # start also takes --into <path> to target another worktree
 ```
 
 ### Diagnostics

--- a/Tools/nex-cli/nex.swift
+++ b/Tools/nex-cli/nex.swift
@@ -228,7 +228,7 @@ func printUsage() {
       nex open [--here] <filepath>   # routes by file type: .md→markdown, .html/.pdf/images→web pane
       nex md [--here] <filepath>     # always opens a markdown preview pane
       nex diff [<path>]
-      nex graft start [--workspace <name-or-uuid>] [--repo <name-or-path>]
+      nex graft start [--workspace <name-or-uuid>] [--repo <name-or-path>] [--into <path>]
       nex graft stop [--workspace <name-or-uuid>] [--repo <name-or-path>]
       nex graft status [--json]
       nex web open [--private] <url>
@@ -4456,7 +4456,7 @@ func handleGraft(_ args: inout ArraySlice<String>) {
     case "-h", "--help", "help":
         fputs("""
         Usage:
-          nex graft start [--workspace <name-or-uuid>] [--repo <name-or-path>]
+          nex graft start [--workspace <name-or-uuid>] [--repo <name-or-path>] [--into <path>]
           nex graft stop  [--workspace <name-or-uuid>] [--repo <name-or-path>]
           nex graft status [--json]
 
@@ -4464,6 +4464,11 @@ func handleGraft(_ args: inout ArraySlice<String>) {
         (requires NEX_PANE_ID). Use --repo to target a single
         association; use --workspace to scope across every association
         in another workspace.
+
+        --into <path> grafts into that checkout instead of the repo's
+        main checkout — any other worktree of the same repository can
+        be the destination (e.g. a hub worktree running dev servers).
+        Requires a single association in scope.
         \n
         """, stderr)
     default:
@@ -4476,10 +4481,22 @@ func handleGraft(_ args: inout ArraySlice<String>) {
 private func handleGraftCommand(command: String, args: inout ArraySlice<String>) {
     let workspace = parseFlag("--workspace", from: &args)
     let repo = parseFlag("--repo", from: &args)
+    let into = command == "graft-start" ? parseFlag("--into", from: &args) : nil
 
     var payload: [String: Any] = ["command": command]
     if let workspace { payload["workspace"] = workspace }
     if let repo { payload["repo"] = repo }
+    if let into {
+        // Absolutize CLI-side: the app process has a different cwd,
+        // so a relative destination path must be resolved against the
+        // caller's cwd before it rides the wire.
+        let expanded = (into as NSString).expandingTildeInPath
+        let absolute = expanded.hasPrefix("/")
+            ? expanded
+            : (FileManager.default.currentDirectoryPath as NSString)
+            .appendingPathComponent(expanded)
+        payload["into"] = (absolute as NSString).standardizingPath
+    }
     if workspace == nil, repo == nil,
        let paneID = ProcessInfo.processInfo.environment["NEX_PANE_ID"] {
         payload["pane_id"] = paneID


### PR DESCRIPTION
## Why

Graft's destination is derived from `git rev-parse --git-common-dir`, which always resolves to the repo's **main checkout**. A linked worktree can therefore never be the destination — but that's exactly what a hub workflow needs (a hub worktree runs the dev servers; station worktrees graft their changes onto it for live verification).

## What

- **`nex graft start --into <path>`** — use any other checkout of the same repository as the destination instead of the main checkout. The CLI absolutizes the path against the caller's cwd before it rides the wire. Requires a single association in scope (with several, they'd all race to claim the same destination — hard error suggesting `--repo`).
- **`GraftService.start`** gains an optional destination override, validated up front via a new `GraftError.invalidGraftTarget`: target must be a git checkout, must belong to the same repository as the source worktree (compared by canonicalized common-dir root), and must not be the source itself. Default path (no `--into`) is byte-for-byte the old behaviour, including the `notAWorktree` self-graft guard.
- **Breadcrumb placement fix** — for a worktree destination, `<root>/.git` is a *file*, and writing `<root>/.git/nex-graft-active` fails with ENOTDIR. `breadcrumbPath` now follows the `gitdir:` pointer so the breadcrumb lands in `<common>/.git/worktrees/<name>/` for worktree destinations (main-checkout placement unchanged).
- **Orphan recovery** — the launch-time breadcrumb scan now also covers association worktree paths, so a breadcrumb left in a worktree destination after a crash is detected and recoverable like before.

The sync mechanics (`write-tree` → `read-tree --reset -u`), stash handling, and stop/restore sequence are untouched — they were already destination-agnostic.

## Tests

- `GraftServiceTests`: new integration tests against real temp repos — graft into a sibling worktree (sync lands in hub, not main; breadcrumb in the hub's git dir; stop restores the hub and leaves source edits intact), rejection of a different repo's checkout, rejection of the source worktree as its own destination.
- `GraftCLIReplyTests`: `into` forwarded to the service; multi-association `--into` rejected without calling the service.
- `SocketParsingTests`: `into` parse + empty-string normalisation.

`xcodebuild build` green; all graft/parsing/reducer suites green. Full-suite run shows pre-existing persistence round-trip flakes that also fail on a clean `main` under parallel load (see #267) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)